### PR TITLE
fix(database): 用户活跃统计 - 修复 PostgreSQL 冲突更新列歧义

### DIFF
--- a/backend/internal/repository/analytics.go
+++ b/backend/internal/repository/analytics.go
@@ -41,29 +41,29 @@ func (r *Repository) RecordUserActivity(userID string, event string, count int, 
 	switch event {
 	case "login":
 		activity.LoginCount = count
-		updates["login_count"] = gorm.Expr("login_count + ?", count)
+		updates["login_count"] = gorm.Expr("user_daily_activities.login_count + ?", count)
 	case "task":
 		activity.TaskCount = count
-		updates["task_count"] = gorm.Expr("task_count + ?", count)
+		updates["task_count"] = gorm.Expr("user_daily_activities.task_count + ?", count)
 	case "agent_message":
 		activity.AgentMessageCount = count
-		updates["agent_message_count"] = gorm.Expr("agent_message_count + ?", count)
+		updates["agent_message_count"] = gorm.Expr("user_daily_activities.agent_message_count + ?", count)
 	case "canvas":
 		activity.CanvasActive = true
 		updates["canvas_active"] = true
 	case "asset":
 		activity.AssetCount = count
-		updates["asset_count"] = gorm.Expr("asset_count + ?", count)
+		updates["asset_count"] = gorm.Expr("user_daily_activities.asset_count + ?", count)
 	case "resource":
 		activity.ResourceCount = count
-		updates["resource_count"] = gorm.Expr("resource_count + ?", count)
+		updates["resource_count"] = gorm.Expr("user_daily_activities.resource_count + ?", count)
 	default:
 		return nil
 	}
 	if event != "login" {
 		activity.FirstActiveAt = &now
 		activity.LastActiveAt = &now
-		updates["first_active_at"] = gorm.Expr("COALESCE(first_active_at, ?)", now)
+		updates["first_active_at"] = gorm.Expr("COALESCE(user_daily_activities.first_active_at, ?)", now)
 		updates["last_active_at"] = now
 	}
 	return r.db.Clauses(clause.OnConflict{

--- a/backend/internal/repository/analytics_test.go
+++ b/backend/internal/repository/analytics_test.go
@@ -1,0 +1,73 @@
+package repository
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+type sqlCaptureLogger struct {
+	statements []string
+}
+
+func (l *sqlCaptureLogger) LogMode(logger.LogLevel) logger.Interface { return l }
+func (*sqlCaptureLogger) Info(context.Context, string, ...any)       {}
+func (*sqlCaptureLogger) Warn(context.Context, string, ...any)       {}
+func (*sqlCaptureLogger) Error(context.Context, string, ...any)      {}
+
+func (l *sqlCaptureLogger) Trace(_ context.Context, _ time.Time, query func() (string, int64), _ error) {
+	statement, _ := query()
+	l.statements = append(l.statements, statement)
+}
+
+func TestRecordUserActivityQualifiesPostgresConflictColumns(t *testing.T) {
+	capture := &sqlCaptureLogger{}
+	db, err := gorm.Open(postgres.New(postgres.Config{
+		DSN:                  "host=localhost user=test dbname=test sslmode=disable",
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{
+		DisableAutomaticPing:   true,
+		DryRun:                 true,
+		Logger:                 capture,
+		SkipDefaultTransaction: true,
+	})
+	if err != nil {
+		t.Fatalf("open dry-run postgres database: %v", err)
+	}
+
+	repo := New(db)
+	cases := []struct {
+		event  string
+		column string
+	}{
+		{event: "login", column: "login_count"},
+		{event: "task", column: "task_count"},
+		{event: "agent_message", column: "agent_message_count"},
+		{event: "asset", column: "asset_count"},
+		{event: "resource", column: "resource_count"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.event, func(t *testing.T) {
+			capture.statements = nil
+			if err := repo.RecordUserActivity("user-1", tc.event, 1, time.Unix(1_700_000_000, 0)); err != nil {
+				t.Fatalf("record activity: %v", err)
+			}
+			if len(capture.statements) == 0 {
+				t.Fatal("expected generated SQL")
+			}
+			statement := capture.statements[len(capture.statements)-1]
+			if !strings.Contains(statement, "user_daily_activities."+tc.column) {
+				t.Fatalf("conflict update column is not target-qualified: %s", statement)
+			}
+			if tc.event != "login" && !strings.Contains(statement, "COALESCE(user_daily_activities.first_active_at") {
+				t.Fatalf("first active column is not target-qualified: %s", statement)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #4

## 改动摘要

- 为用户活动 upsert 的计数列显式加上 user_daily_activities 目标表限定。
- 同步限定 COALESCE 中的 first_active_at，覆盖非登录活动的首次活跃时间更新。
- 增加 PostgreSQL GORM DryRun 回归测试，覆盖登录、任务、Agent 消息、素材和资源计数。

## 根因与影响

PostgreSQL 在 ON CONFLICT DO UPDATE 中同时暴露目标表和待插入行。原有 login_count + ? 等未限定表达式存在列引用歧义，会返回 SQLSTATE 42702。

业务请求本身可能继续成功，但用户活跃统计写入会丢失，并在后端和数据库日志中持续产生错误。相同写法影响所有递增计数，以及 first_active_at 的 COALESCE 表达式。

## 风险

- 不修改数据库结构、API 或用户可见行为。
- 变更仅限定现有更新表达式的目标表列。
- 已用 SQLite 内存数据库验证相同限定语法可正常执行，保留项目的 SQLite 兼容性。

## 验证

- 通过：go test ./internal/repository -run TestRecordUserActivityQualifiesPostgresConflictColumns -count=1
- 通过：cmd/server、internal/handler、internal/repository 包测试。
- PostgreSQL 17 实例回归：连续两次登录均返回 200，login_count 从 2 增至 4，SQLSTATE 42702 日志为 0。
- SQLite 内存 SQL 回归：冲突更新后 login_count 从 1 增至 2。
- 全量 go test ./... 中 internal/service 的既有 SQLite 测试受本机 CGO_ENABLED=0 / 缺少 gcc 限制，加载 go-sqlite3 stub 时失败；与本次修改无关。

## 截图

本次为后端 SQL 修复，无用户界面变化，不需要截图。
