### PR TITLE
fix(canvas): Agent 会话 - 展示后端具体失败原因

### DIFF
--- a/web/src/components/canvas/canvas-assistant-panel.tsx
+++ b/web/src/components/canvas/canvas-assistant-panel.tsx
@@ -8,7 +8,7 @@ import { modelOptionName, normalizeModelOptionValue, resolveModelChannel, resolv
 import { canvasThemes } from "@/lib/canvas-theme";
 import { nanoid } from "nanoid";
 import { requestToolResponse, type ResponseFunctionTool, type ResponseInputMessage, type ResponseToolCall } from "@/services/api/image";
-import { createAgentSession, queryAgentSession } from "@/services/api/task-center";
+import { agentSessionFailureMessage, createAgentSession, queryAgentSession } from "@/services/api/task-center";
 import { imageToDataUrl } from "@/services/image-storage";
 import { useAssetStore } from "@/stores/use-asset-store";
 import { useThemeStore } from "@/stores/use-theme-store";
@@ -1004,7 +1004,7 @@ async function createCinematicSessionOps(projectId: string, prompt: string, snap
     let detail = created;
     for (let attempt = 0; attempt < 120; attempt += 1) {
         if (detail.session.status === "completed") break;
-        if (detail.session.status === "failed") throw new Error("后端影视 Agent 会话失败");
+        if (detail.session.status === "failed") throw new Error(agentSessionFailureMessage(detail));
         await delay(2000);
         detail = await queryAgentSession(created.session.id);
     }

--- a/web/src/pages/canvas/use-canvas-document-workflow.ts
+++ b/web/src/pages/canvas/use-canvas-document-workflow.ts
@@ -7,7 +7,7 @@ import { parseDocumentCharacterBreakdown, partitionCharacterBreakdowns, upsertCh
 import { createDocumentChapter } from "@/lib/canvas/canvas-document";
 import { createCanvasNode } from "@/lib/canvas/canvas-project-domain";
 import { backendProviderConfig, buildGenerationConfig, runBackendCanvasGenerationTask } from "@/lib/canvas/canvas-project-generation";
-import { createAgentSession, queryAgentSession } from "@/services/api/task-center";
+import { agentSessionFailureMessage, createAgentSession, queryAgentSession } from "@/services/api/task-center";
 import { resolveModelRequestConfig, useConfigStore, useEffectiveConfig } from "@/stores/use-config-store";
 import { CanvasNodeType, type CanvasConnection, type CanvasDocumentChapter, type CanvasNodeData, type CanvasNodeMetadata, type CanvasRichDocument, type Position, type ViewportTransform } from "@/types/canvas";
 
@@ -167,7 +167,7 @@ export function useCanvasDocumentWorkflow({
             let detail = created;
             for (let attempt = 0; attempt < 120; attempt += 1) {
                 if (detail.session.status === "completed") break;
-                if (detail.session.status === "failed") throw new Error("后端影视 Agent 会话失败");
+                if (detail.session.status === "failed") throw new Error(agentSessionFailureMessage(detail));
                 await new Promise<void>((resolve) => window.setTimeout(resolve, 2000));
                 detail = await queryAgentSession(created.session.id);
             }

--- a/web/src/services/api/task-center.ts
+++ b/web/src/services/api/task-center.ts
@@ -141,6 +141,18 @@ export function queryAgentSession(id: string) {
     return request<AgentSessionDetail>(api.get(`/query_session/${encodeURIComponent(id)}`));
 }
 
+export function agentSessionFailureMessage(detail: AgentSessionDetail, fallback = "后端影视 Agent 会话失败") {
+    for (let index = detail.tasks.length - 1; index >= 0; index -= 1) {
+        const task = detail.tasks[index];
+        if ((task.status === "failed" || task.status === "cancelled") && task.error?.trim()) return generationErrorMessage(task.error.trim());
+    }
+    for (let index = detail.messages.length - 1; index >= 0; index -= 1) {
+        const message = detail.messages[index];
+        if (message.role === "assistant" && message.content.trim()) return generationErrorMessage(message.content.trim());
+    }
+    return fallback;
+}
+
 export function downloadSessionResults(id: string) {
     return request<TaskResult[]>(api.get(`/download_results/${encodeURIComponent(id)}`));
 }


### PR DESCRIPTION
## 概要

影视 Agent 会话失败时，显示后端已经返回的具体失败原因，不再统一替换为“后端影视 Agent 会话失败”。

## 根因

后端会在失败会话的 assistant 消息中保存任务错误，但画布助手和小说拆解两个轮询入口只检查 `session.status`，随后抛出硬编码文案，导致 524 费用风险、内容审核等重要提示被吞掉。

## 改动

- 增加统一的会话失败消息解析函数；
- 优先使用失败/取消任务的 `error` 字段；
- 会话摘要没有任务错误时，回退到后端保存的最后一条 assistant 消息；
- 继续复用内容审核错误的统一用户文案；
- 只有完全没有详情时才保留原通用兜底；
- 画布在线 Agent 与小说拆解入口共用相同行为。

## 安全边界

改动只显示当前用户会话接口已经返回的消息，不新增后端字段，也不展示 API Key、认证头或堆栈。

## 验证

- `npm run build`

Fixes #9
