### PR TITLE
fix(api): 系统渠道 - 允许注册和调用局域网 API 地址

### DIFF
--- a/backend/internal/service/outbound.go
+++ b/backend/internal/service/outbound.go
@@ -80,7 +80,7 @@ func resolveOutboundHost(ctx context.Context, host string) ([]net.IP, error) {
 		return nil, BadAuthRequest("外部服务域名无效")
 	}
 	if !allowPrivateUpstreams() && (host == "localhost" || strings.HasSuffix(host, ".localhost")) {
-		return nil, BadAuthRequest("不允许访问本机或内网地址")
+		return nil, BadAuthRequest("不允许访问本机地址")
 	}
 	addresses, err := net.DefaultResolver.LookupIP(ctx, "ip", host)
 	if err != nil {
@@ -90,9 +90,10 @@ func resolveOutboundHost(ctx context.Context, host string) ([]net.IP, error) {
 		return nil, BadAuthRequest("外部服务域名没有可用地址")
 	}
 	if !allowPrivateUpstreams() {
+		// 局域网地址用于连接自部署模型；默认仍阻止回环和链路本地等高风险目标。
 		for _, ip := range addresses {
 			if blockedOutboundIP(ip) {
-				return nil, BadAuthRequest("不允许访问本机、内网或链路本地地址")
+				return nil, BadAuthRequest("不允许访问本机或链路本地地址")
 			}
 		}
 	}
@@ -100,7 +101,7 @@ func resolveOutboundHost(ctx context.Context, host string) ([]net.IP, error) {
 }
 
 func blockedOutboundIP(ip net.IP) bool {
-	return ip == nil || ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() || ip.IsMulticast()
+	return ip == nil || ip.IsLoopback() || ip.IsLinkLocalMulticast() || ip.IsLinkLocalUnicast() || ip.IsUnspecified() || ip.IsMulticast()
 }
 
 func allowPrivateUpstreams() bool {

--- a/backend/internal/service/outbound_test.go
+++ b/backend/internal/service/outbound_test.go
@@ -2,12 +2,19 @@ package service
 
 import "testing"
 
-func TestValidateOutboundURLRejectsPrivateHosts(t *testing.T) {
+func TestValidateOutboundURLRejectsLocalAndLinkLocalHosts(t *testing.T) {
 	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "false")
 	for _, rawURL := range []string{"http://127.0.0.1:8080", "http://localhost:8080", "http://169.254.169.254/latest/meta-data"} {
 		if _, err := ValidateOutboundURL(rawURL); err == nil {
 			t.Fatalf("ValidateOutboundURL(%q) should fail", rawURL)
 		}
+	}
+}
+
+func TestValidateOutboundURLAllowsPrivateNetworkHosts(t *testing.T) {
+	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "false")
+	if _, err := ValidateOutboundURL("http://192.168.1.10:8080"); err != nil {
+		t.Fatalf("ValidateOutboundURL() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## 变更内容

- 允许系统渠道注册和调用局域网私有 API 地址
- 继续拦截回环、localhost、链路本地、未指定和组播地址
- 补充私网地址放行及高风险地址拒绝的回归测试

## 验证

- 按项目 AGENTS.md 要求，未运行测试、语法检查或构建

Closes #5