### PR TITLE
fix(canvas): 项目删除 - 让主页显示确认弹窗

### DIFF
--- a/web/src/layouts/user-layout.tsx
+++ b/web/src/layouts/user-layout.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { CanvasDeleteProjectsDialog } from "@/components/canvas/canvas-delete-projects-dialog";
 import { AppTopNav } from "@/components/layout/app-top-nav";
 
 export default function UserLayout({ children }: { children: ReactNode }) {
@@ -7,6 +8,7 @@ export default function UserLayout({ children }: { children: ReactNode }) {
         <div className="app-user-workspace flex h-dvh flex-col overflow-hidden text-foreground">
             <AppTopNav />
             <div className="relative min-h-0 flex-1 overflow-hidden">{children}</div>
+            <CanvasDeleteProjectsDialog />
         </div>
     );
 }

--- a/web/src/pages/canvas/index.tsx
+++ b/web/src/pages/canvas/index.tsx
@@ -8,7 +8,6 @@ import { CollectionGrid, ListToolbar, PageHeader, PaginationBar, WorkspacePage }
 import { readZip } from "@/lib/zip";
 import { setMediaBlob } from "@/services/file-storage";
 import { setImageBlob } from "@/services/image-storage";
-import { CanvasDeleteProjectsDialog } from "@/components/canvas/canvas-delete-projects-dialog";
 import { CanvasProjectCard } from "@/components/canvas/canvas-project-card";
 import type { CanvasExportFile } from "@/types/canvas-export";
 import { useCanvasStore } from "@/stores/canvas/use-canvas-store";
@@ -140,7 +139,6 @@ export default function CanvasPage() {
                 <PaginationBar current={page} pageSize={pageSize} total={filteredProjects.length} pageSizeOptions={[12, 24, 48]} onChange={(nextPage, nextPageSize) => { setPage(nextPageSize !== pageSize ? 1 : nextPage); setPageSize(nextPageSize); }} />
 
                 <input ref={inputRef} type="file" accept="application/zip,.zip" className="hidden" onChange={(event) => void importCanvas(event.target.files?.[0])} />
-                <CanvasDeleteProjectsDialog />
         </WorkspacePage>
     );
 }


### PR DESCRIPTION
## 变更内容

- 将 `CanvasDeleteProjectsDialog` 统一挂载到所有用户页面共用的 `UserLayout`。
- 移除 `/canvas` 项目库页面中的重复挂载。
- 主页和“我的画布”现在共享同一套删除确认流程。

## 根因

`CanvasProjectCard` 的删除菜单只写入 `deleteProjectIds` 跨页面状态。此前确认弹窗只挂载在 `/canvas` 页面，因此主页点击删除后没有组件消费该状态，既不会显示确认框，也不会发出删除请求。

## 用户影响

主页“最近项目”点击删除后会正常显示“删除画布？”确认弹窗；只有用户确认后才执行现有删除逻辑。

## 验证

- `git diff --check`
- VPS 生产 Docker web 镜像构建通过，其中 `tsc --noEmit && vite build` 成功。
- 构建仅报告仓库既有的大 chunk 体积警告，无编译错误。
- 确认 `CanvasDeleteProjectsDialog` 在用户布局中只挂载一次。

Closes #15
