### PR TITLE
fix(platform): Codex 插件 - 补全仓库 marketplace 安装入口

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "infinite-canvas-local",
+  "interface": {
+    "displayName": "Infinite Canvas Local"
+  },
+  "plugins": [
+    {
+      "name": "infinite-canvas",
+      "source": {
+        "source": "local",
+        "path": "./plugins/infinite-canvas"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/canvas-agent/README.md
+++ b/canvas-agent/README.md
@@ -42,7 +42,7 @@ Canvas Agent 默认只监听 `127.0.0.1`。网页第一次带正确 token 连接
 
 ### Codex app 插件
 
-仓库内提供了 Codex app 插件：`plugins/infinite-canvas`。在 Codex app 中添加本仓库的 marketplace 后，可以安装 `Infinite Canvas` 插件；插件会注册同一个 `infinite-canvas` MCP，并带上画布操作说明。
+仓库内提供了 Codex app 插件：`plugins/infinite-canvas`。该插件尚未上架公共插件目录，直接搜索不会显示；在 Codex app 中添加本仓库的 marketplace 后即可安装。插件会注册同一个 `infinite-canvas` MCP，并带上画布操作说明。
 
 添加本地 marketplace 时建议使用仓库绝对路径，避免 Codex 从其他工作目录解析失败：
 

--- a/plugins/infinite-canvas/README.md
+++ b/plugins/infinite-canvas/README.md
@@ -4,64 +4,42 @@
 
 ## 安装
 
+> Infinite Canvas 尚未上架 Codex 公共插件目录，直接搜索不会显示。请从本仓库自带的 marketplace 安装。
+
 ### AI 自动安装
 
 把下面这段发给 Codex：
 
 ```text
 请从 https://github.com/ddcat-ai/open-ai-canvas.git 安装 Infinite Canvas Codex 插件。
-请 clone 仓库到 ~/plugins/open-ai-canvas，确认 plugins/infinite-canvas/.codex-plugin/plugin.json 存在，
-把 plugins/open-ai-canvas 加入 personal marketplace，先运行 codex plugin marketplace add ~，
-再运行 codex plugin add infinite-canvas@personal。
+请 clone 仓库到 ~/plugins/open-ai-canvas，确认 .agents/plugins/marketplace.json 和
+plugins/infinite-canvas/.codex-plugin/plugin.json 都存在。然后运行
+codex plugin marketplace add ~/plugins/open-ai-canvas，
+再运行 codex plugin add infinite-canvas@infinite-canvas-local。
 安装后请校验插件，并告诉我是否需要开启一个新对话来加载新技能和 MCP 工具。
 ```
 
 ### 手动安装
 
-推荐把仓库 clone 到 Codex personal marketplace 默认会引用的位置：
+如果本机还没有仓库，先 clone：
 
 ```bash
 mkdir -p ~/plugins
 git clone https://github.com/ddcat-ai/open-ai-canvas.git ~/plugins/open-ai-canvas
 ```
 
-确保 `~/.agents/plugins/marketplace.json` 中有 Infinite Canvas 条目，注意 `path` 指向仓库里的插件子目录：
-
-```json
-{
-  "name": "personal",
-  "interface": {
-    "displayName": "Personal"
-  },
-  "plugins": [
-    {
-      "name": "infinite-canvas",
-      "source": {
-        "source": "local",
-        "path": "./plugins/open-ai-canvas/plugins/infinite-canvas"
-      },
-      "policy": {
-        "installation": "AVAILABLE",
-        "authentication": "ON_INSTALL"
-      },
-      "category": "Productivity"
-    }
-  ]
-}
-```
-
-然后注册 personal marketplace 并安装插件：
+注册仓库 marketplace 并安装插件；如果使用已有仓库，请把路径替换为仓库的绝对路径：
 
 ```bash
-codex plugin marketplace add ~
-codex plugin add infinite-canvas@personal
+codex plugin marketplace add ~/plugins/open-ai-canvas
+codex plugin add infinite-canvas@infinite-canvas-local
 ```
 
 安装后建议开启一个新的 Codex 对话，让新的 skill 和 MCP 工具完整加载。
 
 ### 本仓库开发调试
 
-如果你就在 Infinite Canvas 仓库中调试插件，可以直接添加仓库自带 marketplace。建议使用仓库绝对路径，避免 Codex 从其他工作目录解析失败：
+如果你就在 Infinite Canvas 仓库中调试插件，可以直接添加当前仓库。建议使用仓库绝对路径，避免 Codex 从其他工作目录解析失败：
 
 ```bash
 cd /path/to/infinite-canvas

--- a/web/src/components/canvas/canvas-local-agent-panel.tsx
+++ b/web/src/components/canvas/canvas-local-agent-panel.tsx
@@ -17,7 +17,7 @@ const MAX_ATTACHMENTS = 6;
 const MAX_ATTACHMENT_PAYLOAD_BYTES = 28 * 1024 * 1024;
 const DEFAULT_AGENT_URL = "http://127.0.0.1:17371";
 const AGENT_CONNECT_STEPS = [
-    { title: "安装 Codex 插件", text: "在 Codex app 安装 Infinite Canvas 插件后，首次使用插件会自动启动本地 Agent。" },
+    { title: "从仓库安装插件", text: "插件暂未上架公共目录，请按项目 README 添加仓库 marketplace；安装后新建 Codex 对话。" },
     { title: "打开画布连接", text: "回到这里点击连接，网页会自动读取本机 Agent 配置。" },
     { title: "手动启动备用", text: "如果自动发现失败，请按插件说明启动本地 Agent 后再回到这里连接。" },
 ];
@@ -641,7 +641,7 @@ function AgentConnectView({ theme, url, token, enabled, connected, activity, con
                 <div>
                     <div className="text-base font-semibold leading-6">连接本地 Agent</div>
                     <div className="mt-1 text-xs leading-5" style={{ color: theme.node.muted }}>
-                        安装 Codex 插件后，画布会优先自动连接本机 Agent。
+                        安装仓库自带的 Codex 插件后，画布会优先自动连接本机 Agent。
                     </div>
                 </div>
                 <div className="space-y-2">


### PR DESCRIPTION
## 改动摘要

- 新增仓库级 `.agents/plugins/marketplace.json`，让仓库根目录可被 Codex 直接注册为 marketplace
- 修正 Infinite Canvas 插件安装说明，移除无效的 personal marketplace 手工配置流程
- 在插件文档、Canvas Agent 文档和网页连接页中明确：插件尚未上架公共目录，需要从仓库安装

Closes #19

## 原因与影响

插件包已经存在于 `plugins/infinite-canvas`，但仓库缺少 marketplace 清单；同时文档与网页只提示“安装插件”，导致用户在公共插件目录搜索后无法继续。修复后，clone 仓库并运行两条 Codex CLI 命令即可安装，不影响现有 Agent 协议或画布数据。

## 风险与兼容性

- 不修改 MCP 协议、后端接口或持久化数据
- 已存在的个人 marketplace 安装仍可继续使用
- 仅调整安装入口、文档和连接页提示文案

## 验证

- `validate_plugin.py plugins/infinite-canvas` 通过
- marketplace JSON 可解析，插件目录与 manifest 路径存在
- 使用 Codex CLI 成功执行 `plugin marketplace add`，插件以 `infinite-canvas@infinite-canvas-local` 出现在列表中；随后已移除临时 marketplace
- `git diff --check` 通过
- 按仓库约定未执行前端构建

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义