### PR TITLE
fix(media): xAI 视频 - 使用官方生成请求字段

### DIFF
--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -993,6 +993,10 @@ func validateGenerationInterface(mode string, interfaceType string) error {
 }
 
 func grokVideoBody(input canvasGenerationInput) (map[string]interface{}, error) {
+	if input.Config.InterfaceType == "xai-video" {
+		return xaiVideoBody(input)
+	}
+
 	seconds := defaultString(input.Config.VideoSeconds, "6")
 	duration, err := strconv.Atoi(seconds)
 	if err != nil || duration <= 0 {
@@ -1019,6 +1023,29 @@ func grokVideoBody(input canvasGenerationInput) (map[string]interface{}, error) 
 		body["image"] = images[0]
 		body["images"] = images
 	}
+	return body, nil
+}
+
+// xAI 生成接口与 legacy /videos 使用不同字段，保持独立可避免兼容字段触发上游 422。
+func xaiVideoBody(input canvasGenerationInput) (map[string]interface{}, error) {
+	body := map[string]interface{}{
+		"model":        input.Config.Model,
+		"prompt":       strings.TrimSpace(input.Prompt),
+		"duration":     normalizeXAIVideoDuration(input.Config.VideoSeconds),
+		"aspect_ratio": normalizeXAIVideoAspectRatio(input.Config.Size),
+		"resolution":   normalizeXAIVideoResolution(input.Config.VQuality),
+	}
+	if !shouldSendNewAPIVideoImages(input) || len(input.ReferenceImages) == 0 {
+		return body, nil
+	}
+	if len(input.ReferenceImages) > 1 {
+		return nil, fmt.Errorf("xAI 图生视频只支持 1 张起始图，当前连接了 %d 张", len(input.ReferenceImages))
+	}
+	imageURL, err := openAIImageInputURL(input.ReferenceImages[0])
+	if err != nil {
+		return nil, err
+	}
+	body["image"] = map[string]interface{}{"url": imageURL}
 	return body, nil
 }
 
@@ -1785,6 +1812,74 @@ func normalizeVideoResolution(value string) string {
 		return value
 	}
 	return value + "p"
+}
+
+func normalizeXAIVideoDuration(value string) int {
+	duration, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || duration <= 0 {
+		return 6
+	}
+	if duration > 15 {
+		return 15
+	}
+	return duration
+}
+
+func normalizeXAIVideoResolution(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "480", "480p", "low":
+		return "480p"
+	case "1080", "1080p":
+		return "1080p"
+	default:
+		return "720p"
+	}
+}
+
+func normalizeXAIVideoAspectRatio(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	allowed := map[string]bool{
+		"1:1": true, "16:9": true, "9:16": true, "4:3": true,
+		"3:4": true, "3:2": true, "2:3": true,
+	}
+	if allowed[value] {
+		return value
+	}
+	parts := strings.Split(value, "x")
+	if len(parts) != 2 {
+		return "16:9"
+	}
+	width, widthErr := strconv.Atoi(strings.TrimSpace(parts[0]))
+	height, heightErr := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return "16:9"
+	}
+	ratio := float64(width) / float64(height)
+	candidates := []struct {
+		name  string
+		ratio float64
+	}{
+		{name: "1:1", ratio: 1},
+		{name: "16:9", ratio: 16.0 / 9},
+		{name: "9:16", ratio: 9.0 / 16},
+		{name: "4:3", ratio: 4.0 / 3},
+		{name: "3:4", ratio: 3.0 / 4},
+		{name: "3:2", ratio: 3.0 / 2},
+		{name: "2:3", ratio: 2.0 / 3},
+	}
+	bestName := "16:9"
+	bestDifference := 2.0
+	for _, candidate := range candidates {
+		difference := ratio - candidate.ratio
+		if difference < 0 {
+			difference = -difference
+		}
+		if difference < bestDifference {
+			bestName = candidate.name
+			bestDifference = difference
+		}
+	}
+	return bestName
 }
 
 func normalizeSeedanceDuration(value string) int {

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -387,6 +387,14 @@ func TestRunVideoTaskUsesXAIVideoGenerationEndpoint(t *testing.T) {
 			if body["model"] != "grok-imagine-video-1.5" || body["prompt"] != "make it move" {
 				t.Errorf("request body = %#v", body)
 			}
+			if body["duration"] != float64(10) || body["aspect_ratio"] != "1:1" || body["resolution"] != "720p" {
+				t.Errorf("xAI settings = %#v", body)
+			}
+			for _, legacyField := range []string{"seconds", "size", "images"} {
+				if _, exists := body[legacyField]; exists {
+					t.Errorf("request body includes legacy field %q: %#v", legacyField, body)
+				}
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_, _ = w.Write([]byte(`{"request_id":"video-1"}`))
 		case "GET /v1/videos/video-1":
@@ -412,6 +420,8 @@ func TestRunVideoTaskUsesXAIVideoGenerationEndpoint(t *testing.T) {
 			Model:         "grok-imagine-video-1.5",
 			InterfaceType: "xai-video",
 			VideoSeconds:  "10",
+			Size:          "1:1",
+			VQuality:      "720",
 		},
 	})
 	if err != nil {
@@ -424,6 +434,50 @@ func TestRunVideoTaskUsesXAIVideoGenerationEndpoint(t *testing.T) {
 	want := "POST /v1/videos/generations,GET /v1/videos/video-1,GET /files/video.mp4"
 	if got := strings.Join(paths, ","); got != want {
 		t.Fatalf("paths = %q, want %q", got, want)
+	}
+}
+
+func TestXAIVideoBodyUsesOfficialImageShapeAndNormalizesSettings(t *testing.T) {
+	body, err := grokVideoBody(canvasGenerationInput{
+		Prompt: "make it move",
+		Config: providerConfig{
+			Model:         "grok-imagine-video-1.5",
+			InterfaceType: "xai-video",
+			VideoSeconds:  "20",
+			Size:          "1024x1792",
+			VQuality:      "1080",
+		},
+		ReferenceImages: []providerMedia{{ID: "image-1", DataURL: testReferenceImageDataURL}},
+		Metadata:        map[string]interface{}{"videoEditOperation": "image_to_video"},
+	})
+	if err != nil {
+		t.Fatalf("grokVideoBody() error = %v", err)
+	}
+	if body["duration"] != 15 || body["aspect_ratio"] != "9:16" || body["resolution"] != "1080p" {
+		t.Fatalf("xAI settings = %#v", body)
+	}
+	image, ok := body["image"].(map[string]interface{})
+	if !ok || image["url"] != testReferenceImageDataURL {
+		t.Fatalf("image = %#v", body["image"])
+	}
+	for _, legacyField := range []string{"seconds", "size", "images"} {
+		if _, exists := body[legacyField]; exists {
+			t.Fatalf("body includes legacy field %q: %#v", legacyField, body)
+		}
+	}
+}
+
+func TestXAIVideoBodyRejectsMultipleStartImages(t *testing.T) {
+	_, err := grokVideoBody(canvasGenerationInput{
+		Config: providerConfig{Model: "grok-imagine-video-1.5", InterfaceType: "xai-video"},
+		ReferenceImages: []providerMedia{
+			{ID: "image-1", DataURL: testReferenceImageDataURL},
+			{ID: "image-2", DataURL: testReferenceImageDataURL},
+		},
+		Metadata: map[string]interface{}{"videoEditOperation": "image_to_video"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "只支持 1 张起始图") {
+		t.Fatalf("grokVideoBody() error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## 改动摘要

- 为 `xai-video` 单独构建 xAI 官方视频生成请求体；
- 使用 `duration`、`aspect_ratio`、`resolution`，不再向该接口发送 `seconds`、`size`、`images`；
- 支持把画布中的比例或像素尺寸映射为 xAI 支持的宽高比，并把时长限制在 1–15 秒；
- 图生视频改为 `image.url` 对象结构，连接多张起始图时返回明确错误；
- 保留现有 Grok / NewAPI `/videos` legacy 适配行为；
- 增加端点请求字段、图生视频结构和多图校验的回归用例。

## 根因

#8 已补充 `/v1/videos/generations`、`request_id`、`done` 与 `video.url`，但创建任务仍调用通用 `grokVideoBody`，发送 legacy 字段：

```json
{
  "duration": 6,
  "seconds": "6",
  "size": "1280x720"
}
```

xAI 视频生成接口要求 `duration`、`aspect_ratio` 与 `resolution`。此外，图生视频的 `image` 必须是包含 `url` 的对象，因此正确渠道、密钥和模型仍会在创建阶段返回 422。

## 实际调用验证

使用同一 Sub2API Base URL、同一密钥与同一 `grok-imagine-video-1.5` 模型进行了真实调用：

- 重放修复前请求体：返回 `422 Unprocessable Entity`；
- 使用官方字段发起 1 秒、1:1、480p 请求：返回 200 和 `request_id`；
- 后续轮询返回 `done`，并提供视频内容地址。

未在 Issue、提交、PR 或日志中写入 API Key。

## 验证

- `gofmt` 已应用到修改文件；
- `git diff --check` 通过；
- 按仓库 `AGENTS.md` 约定，未运行 Go 测试或构建；新增回归用例随本 PR 提交。

## 风险与兼容性

- 仅 `InterfaceType == "xai-video"` 使用新请求体；
- 旧 Grok 模型自动识别及 `/videos` JSON 请求保持不变；
- 不修改数据库、前端存储结构、轮询路径或生成结果下载逻辑。

Fixes #21
