### PR TITLE
fix(canvas): 本地 Codex 会话 - 修复新会话首次发送失败

### DIFF
--- a/canvas-agent/package.json
+++ b/canvas-agent/package.json
@@ -13,6 +13,7 @@
   ],
   "scripts": {
     "dev": "tsx src/index.ts",
+    "test": "tsx --test test/*.test.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "prepack": "npm run build"

--- a/canvas-agent/src/agents.ts
+++ b/canvas-agent/src/agents.ts
@@ -6,12 +6,13 @@ import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 
 import { AGENT_PROMPT, VERSION } from "./config.js";
+import { assertCodexThreadWorkspace, codexThreadInWorkspace, resolveCodexThread } from "./codex-thread.js";
 import type { AgentAttachment, AgentEmit } from "./types.js";
 
 type Json = Record<string, unknown>;
 type AgentEvent = Json & { type: string; usage?: unknown };
 type PendingRequest = { resolve: (value: unknown) => void; reject: (error: Error) => void };
-type CodexRunOptions = { threadId?: string; cwd?: string };
+type CodexRunOptions = { threadId?: string; cwd?: string; onThreadId?: (threadId: string) => void };
 type AgentHistoryMessage = { id: string; role: "user" | "assistant" | "tool" | "error"; title?: string; text: string; detail?: unknown; streamId?: string };
 
 let codexQueue: Promise<unknown> = Promise.resolve();
@@ -36,6 +37,7 @@ async function runCodexTurnNow(prompt: string, emit: AgentEmit, attachments: Age
         files = await writeAttachmentFiles(attachments);
         codexApp ||= await CodexAppClient.start(emit);
         const threadId = await ensureCodexThread(codexApp, options);
+        if (threadId !== options.threadId) options.onThreadId?.(threadId);
         await codexApp.startTurn(threadId, prompt, files);
     } catch (error) {
         emit("agent_error", { message: errorMessage(error) });
@@ -55,7 +57,7 @@ export async function resumeCodexThread(emit: AgentEmit, threadId: string, cwd?:
     codexApp ||= await CodexAppClient.start(emit);
     await loadCodexThread(emit, threadId, cwd, false);
     const thread = await codexApp.resumeThread(threadId, cwd);
-    assertThreadWorkspace(thread, cwd);
+    assertCodexThreadWorkspace(thread, cwd);
     codexThreadId = String(field(thread, "id") || threadId);
     return { thread, messages: threadMessages(thread) };
 }
@@ -70,7 +72,7 @@ export async function listCodexThreads(emit: AgentEmit, options: { cwd: string; 
         cwd: options.cwd,
         ...(options.searchTerm ? { searchTerm: options.searchTerm } : {}),
     });
-    const data = Array.isArray(field(result, "data")) ? (field(result, "data") as unknown[]).map(summarizeCodexThread).filter((thread) => threadInWorkspace(thread, options.cwd)) : [];
+    const data = Array.isArray(field(result, "data")) ? (field(result, "data") as unknown[]).map(summarizeCodexThread).filter((thread) => codexThreadInWorkspace(thread, options.cwd)) : [];
     return { data, nextCursor: field(result, "nextCursor") || null, backwardsCursor: field(result, "backwardsCursor") || null };
 }
 
@@ -97,18 +99,7 @@ export function runClaudeTurn(prompt: string, emit: AgentEmit) {
 }
 
 async function ensureCodexThread(app: CodexAppClient, options: CodexRunOptions) {
-    if (options.threadId) {
-        const result = await app.readThread(options.threadId, false);
-        assertThreadWorkspace(field(result, "thread") || {}, options.cwd);
-        const thread = await app.resumeThread(options.threadId, options.cwd);
-        assertThreadWorkspace(thread, options.cwd);
-        codexThreadId = String(field(thread, "id") || options.threadId);
-        return codexThreadId;
-    }
-    if (!codexThreadId) {
-        const thread = await app.startThread(options.cwd);
-        codexThreadId = String(field(thread, "id") || "");
-    }
+    codexThreadId = await resolveCodexThread(app, options, codexThreadId);
     return codexThreadId;
 }
 
@@ -301,18 +292,8 @@ async function loadCodexThread(emit: AgentEmit, threadId: string, cwd: string | 
     codexApp ||= await CodexAppClient.start(emit);
     const result = await codexApp.readThread(threadId, includeTurns);
     const thread = field(result, "thread") || {};
-    assertThreadWorkspace(thread, cwd);
+    assertCodexThreadWorkspace(thread, cwd);
     return thread;
-}
-
-function assertThreadWorkspace(thread: unknown, cwd?: string) {
-    if (!cwd || threadInWorkspace(thread, cwd)) return;
-    throw new Error("该 Codex 会话不属于当前画布工作空间");
-}
-
-function threadInWorkspace(thread: unknown, cwd: string) {
-    const threadCwd = String(field(thread, "cwd") || "");
-    return Boolean(threadCwd && path.resolve(threadCwd) === path.resolve(cwd));
 }
 
 function normalizeItem(item: unknown) {

--- a/canvas-agent/src/codex-thread.ts
+++ b/canvas-agent/src/codex-thread.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+
+type Json = Record<string, unknown>;
+
+export type CodexThreadClient = {
+    startThread: (cwd?: string) => Promise<unknown>;
+    resumeThread: (threadId: string, cwd?: string) => Promise<unknown>;
+    readThread: (threadId: string, includeTurns?: boolean) => Promise<unknown>;
+};
+
+export type CodexThreadOptions = { threadId?: string; cwd?: string };
+
+export async function resolveCodexThread(client: CodexThreadClient, options: CodexThreadOptions, currentThreadId = "") {
+    const requestedThreadId = String(options.threadId || "");
+    if (requestedThreadId) {
+        // thread/start 会先返回尚未落盘的 ID；同一进程内应直接开始首轮，不能立即恢复它。
+        if (requestedThreadId === currentThreadId) return requestedThreadId;
+        try {
+            const result = await client.readThread(requestedThreadId, false);
+            assertCodexThreadWorkspace(field(result, "thread") || {}, options.cwd);
+            const thread = await client.resumeThread(requestedThreadId, options.cwd);
+            assertCodexThreadWorkspace(thread, options.cwd);
+            return String(field(thread, "id") || requestedThreadId);
+        } catch (error) {
+            // Agent 可能在新会话首轮前重启；这种空会话没有用户内容，可以安全替换。
+            if (!isUnmaterializedCodexThreadError(error)) throw error;
+            return await startCodexThread(client, options.cwd);
+        }
+    }
+    if (currentThreadId) return currentThreadId;
+    return await startCodexThread(client, options.cwd);
+}
+
+export function assertCodexThreadWorkspace(thread: unknown, cwd?: string) {
+    if (!cwd || codexThreadInWorkspace(thread, cwd)) return;
+    throw new Error("该 Codex 会话不属于当前画布工作空间");
+}
+
+export function codexThreadInWorkspace(thread: unknown, cwd: string) {
+    const threadCwd = String(field(thread, "cwd") || "");
+    return Boolean(threadCwd && path.resolve(threadCwd) === path.resolve(cwd));
+}
+
+async function startCodexThread(client: CodexThreadClient, cwd?: string) {
+    const thread = await client.startThread(cwd);
+    const threadId = String(field(thread, "id") || "");
+    if (!threadId) throw new Error("Codex app-server 没有返回 thread id");
+    return threadId;
+}
+
+function isUnmaterializedCodexThreadError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    return /no rollout found for thread id|not materialized yet/i.test(message);
+}
+
+function field(value: unknown, key: string) {
+    return value && typeof value === "object" ? (value as Json)[key] : undefined;
+}

--- a/canvas-agent/src/http-server.ts
+++ b/canvas-agent/src/http-server.ts
@@ -85,7 +85,11 @@ export function startHttpServer() {
             await verifyCodexThreadWorkspace(emit, threadId, workspace.workspacePath);
             updateCanvasWorkspace(config, workspace.canvasId, { activeThreadId: threadId });
         }
-        void runCodexTurn(withAgentPrompt(String(req.body?.prompt || "")), emit, attachments, { threadId, cwd: workspace.workspacePath });
+        void runCodexTurn(withAgentPrompt(String(req.body?.prompt || "")), emit, attachments, {
+            threadId,
+            cwd: workspace.workspacePath,
+            onThreadId: (nextThreadId) => updateCanvasWorkspace(config, workspace.canvasId, { activeThreadId: nextThreadId }),
+        });
         res.json({ ok: true, threadId });
     }));
     app.post("/agent/claude/turn", (req, res) => {

--- a/canvas-agent/test/codex-thread.test.ts
+++ b/canvas-agent/test/codex-thread.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveCodexThread, type CodexThreadClient } from "../src/codex-thread.js";
+
+const cwd = "C:\\canvas-workspace";
+
+test("当前进程刚创建的会话直接开始首轮", async () => {
+    const client = fakeClient();
+
+    const threadId = await resolveCodexThread(client.value, { threadId: "thread-new", cwd }, "thread-new");
+
+    assert.equal(threadId, "thread-new");
+    assert.deepEqual(client.calls, []);
+});
+
+test("已有会话仍校验工作空间并恢复", async () => {
+    const client = fakeClient({
+        readThread: async () => ({ thread: { id: "thread-old", cwd } }),
+        resumeThread: async () => ({ id: "thread-old", cwd }),
+    });
+
+    const threadId = await resolveCodexThread(client.value, { threadId: "thread-old", cwd });
+
+    assert.equal(threadId, "thread-old");
+    assert.deepEqual(client.calls, ["read:thread-old", "resume:thread-old"]);
+});
+
+test("未落盘的空会话自动替换", async () => {
+    const client = fakeClient({
+        readThread: async () => ({ thread: { id: "thread-stale", cwd } }),
+        resumeThread: async () => {
+            throw new Error("no rollout found for thread id thread-stale");
+        },
+        startThread: async () => ({ id: "thread-replacement", cwd }),
+    });
+
+    const threadId = await resolveCodexThread(client.value, { threadId: "thread-stale", cwd });
+
+    assert.equal(threadId, "thread-replacement");
+    assert.deepEqual(client.calls, ["read:thread-stale", "resume:thread-stale", "start"]);
+});
+
+test("读取阶段发现未 materialize 的空会话也会替换", async () => {
+    const client = fakeClient({
+        readThread: async () => {
+            throw new Error("thread thread-stale is not materialized yet");
+        },
+        startThread: async () => ({ id: "thread-replacement", cwd }),
+    });
+
+    const threadId = await resolveCodexThread(client.value, { threadId: "thread-stale", cwd });
+
+    assert.equal(threadId, "thread-replacement");
+    assert.deepEqual(client.calls, ["read:thread-stale", "start"]);
+});
+
+test("非空会话错误不会被静默替换", async () => {
+    const client = fakeClient({
+        readThread: async () => {
+            throw new Error("permission denied");
+        },
+    });
+
+    await assert.rejects(() => resolveCodexThread(client.value, { threadId: "thread-old", cwd }), /permission denied/);
+    assert.deepEqual(client.calls, ["read:thread-old"]);
+});
+
+function fakeClient(overrides: Partial<CodexThreadClient> = {}) {
+    const calls: string[] = [];
+    const value: CodexThreadClient = {
+        readThread: async (threadId) => {
+            calls.push(`read:${threadId}`);
+            return await (overrides.readThread?.(threadId, false) || Promise.resolve({ thread: { id: threadId, cwd } }));
+        },
+        resumeThread: async (threadId, workspace) => {
+            calls.push(`resume:${threadId}`);
+            return await (overrides.resumeThread?.(threadId, workspace) || Promise.resolve({ id: threadId, cwd: workspace }));
+        },
+        startThread: async (workspace) => {
+            calls.push("start");
+            return await (overrides.startThread?.(workspace) || Promise.resolve({ id: "thread-started", cwd: workspace }));
+        },
+    };
+    return { calls, value };
+}


### PR DESCRIPTION
## 改动摘要

- 抽出可独立验证的 Codex 会话解析逻辑。
- 当前 Agent 进程刚通过 `thread/start` 创建的会话直接进入 `turn/start`，不再对尚未落盘的零轮次会话执行恢复。
- 遇到配置遗留的 `no rollout found` / `not materialized yet` 空会话时，自动创建替代会话并更新当前画布的 `activeThreadId`。
- 有效历史会话仍会读取、校验工作空间并恢复；权限、工作空间或其他错误继续原样失败，不会被静默降级。
- 为新建直用、有效恢复、两种未落盘错误和非相关错误补充回归测试。

## 根因

`startCodexThread` 已经保存了 `thread/start` 返回的 thread id，但首次发送又把该 ID 交给 `ensureCodexThread`。原逻辑只要收到 `options.threadId` 就无条件执行 `thread/read` 和 `thread/resume`；Codex 在第一条用户消息前尚未生成 rollout，因此恢复失败。

Agent 如果恰好在第一条消息前重启，未 materialize 的 ID 还会残留在画布配置中，使后续发送持续命中同一错误。

## 用户影响

- 新画布或“新对话”的第一条本地 Codex 指令可以正常开始。
- 升级前已残留的空会话无需用户手动清理，下一次发送会自动恢复为可用的新会话。
- 画布节点、连线和有效的历史 Codex 会话不受影响。

## 风险控制

自动替换仅匹配 Codex 明确返回的未落盘会话错误；其他恢复异常仍会展示给用户。历史会话的工作空间校验逻辑保持不变。

## 验证

- `git diff --cached --check` 通过。
- 已补充 5 个回归测试场景。
- 按仓库 `AGENTS.md` 约束，未执行测试、语法检查或构建。

Closes #23
