### PR TITLE
fix(canvas): 图片预览 - 支持全视口缩放与拖拽查看细节

### DIFF
--- a/web/src/pages/canvas/canvas-project-status-dialogs.tsx
+++ b/web/src/pages/canvas/canvas-project-status-dialogs.tsx
@@ -1,4 +1,4 @@
-import { Button, Modal } from "antd";
+import { Button, Image, Modal } from "antd";
 
 import { TaskDetailItem, taskStatusText } from "./canvas-project-feedback";
 import type { GenerationTask, TaskLog } from "@/services/api/task-center";
@@ -47,10 +47,25 @@ export function CanvasProjectStatusDialogs({ theme, task, taskLogs, taskLoading,
                 <div className="py-8 text-center text-base font-medium">暂未实现</div>
             </Modal>
 
-            <Modal title={previewNode?.type === CanvasNodeType.Video ? "视频预览" : "图片预览"} open={Boolean(previewNode?.metadata?.content)} centered onCancel={onClosePreview} footer={null} width="min(1200px, calc(100vw - 32px))" styles={{ body: { padding: 0, display: "flex", justifyContent: "center", alignItems: "center", maxHeight: "84vh", overflow: "hidden", background: "#090909" } }}>
+            <Modal title="视频预览" open={Boolean(previewNode?.metadata?.content && previewNode.type === CanvasNodeType.Video)} centered onCancel={onClosePreview} footer={null} width="min(1200px, calc(100vw - 32px))" styles={{ body: { padding: 0, display: "flex", justifyContent: "center", alignItems: "center", maxHeight: "84vh", overflow: "hidden", background: "#090909" } }}>
                 {previewNode?.metadata?.content && previewNode.type === CanvasNodeType.Video ? <video src={previewNode.metadata.content} controls className="max-h-[84vh] max-w-full bg-black object-contain" /> : null}
-                {previewNode?.metadata?.content && previewNode.type === CanvasNodeType.Image ? <img src={previewNode.metadata.content} alt={previewNode.title || "图片"} className="max-h-[84vh] max-w-full object-contain" /> : null}
             </Modal>
+
+            {previewNode?.metadata?.content && previewNode.type === CanvasNodeType.Image ? (
+                <Image
+                    src={previewNode.metadata.content}
+                    alt={previewNode.title || "图片"}
+                    style={{ display: "none" }}
+                    preview={{
+                        open: true,
+                        movable: true,
+                        minScale: 0.5,
+                        maxScale: 12,
+                        scaleStep: 0.25,
+                        onOpenChange: (open) => !open && onClosePreview(),
+                    }}
+                />
+            ) : null}
 
             <Modal
                 title="清空画布？"


### PR DESCRIPTION
## 变更内容

- 将画布图片“查看大图”和“进入全景预览”改为全视口预览
- 支持工具栏与滚轮缩放、双击放大、拖拽查看及触摸捏合
- 解除原有 `1200px / 84vh` 弹窗尺寸限制
- 保持视频预览行为不变

## 验证

- 已核对 Ant Design 6.5.1 图片预览接口
- 已执行 `git diff --check`
- 按项目约束，未运行测试、类型检查或构建

Fixes #40