### PR TITLE
Fix/网站 Agent 增加 Responses Prompt Cache 会话亲和

### DIFF
--- a/web/src/components/canvas/canvas-assistant-panel.tsx
+++ b/web/src/components/canvas/canvas-assistant-panel.tsx
@@ -23,6 +23,7 @@ import { NODE_DEFAULT_SIZE } from "@/constant/canvas";
 import { CanvasNodeType, type CanvasAssistantMessage, type CanvasAssistantPendingBackendSession, type CanvasAssistantReference, type CanvasAssistantSession, type CanvasNodeData } from "@/types/canvas";
 import { useCanvasAgentStore } from "@/stores/canvas/use-canvas-agent-store";
 import { previewCanvasAgentOps, summarizeCanvasAgentOps, type CanvasAgentOp, type CanvasAgentOperationImpact, type CanvasAgentSnapshot } from "@/lib/canvas/canvas-agent-ops";
+import { canvasAgentPromptCacheKey } from "@/lib/openai-prompt-cache";
 
 export const CANVAS_AGENT_PANEL_MOTION_MS = 500;
 const PANEL_MOTION_SECONDS = CANVAS_AGENT_PANEL_MOTION_MS / 1000;
@@ -412,7 +413,7 @@ export function CanvasAssistantPanel({ nodes, selectedNodeIds, snapshot, project
             const result = await requestToolResponse({ ...requestConfig, systemPrompt: "" }, messages, ONLINE_AGENT_TOOLS, "required", (text) => {
                 streamed = text;
                 if (text.trim()) upsertMessage(sessionId, { id: assistantId, role: "assistant", text });
-            });
+            }, { promptCacheKey: canvasAgentPromptCacheKey(sessionId) });
             addOnlineLog("模型工具回复", result);
             if (result.toolCalls.length) {
                 const writableCalls = result.toolCalls.filter(isWritableToolCall);
@@ -468,7 +469,7 @@ export function CanvasAssistantPanel({ nodes, selectedNodeIds, snapshot, project
         const next = await requestToolResponse({ ...requestConfig, systemPrompt: "" }, nextMessages, ONLINE_AGENT_TOOLS, "auto", (text) => {
             streamed = text;
             if (text.trim()) upsertMessage(sessionId, { id: assistantId, role: "assistant", text });
-        });
+        }, { promptCacheKey: canvasAgentPromptCacheKey(sessionId) });
         addOnlineLog(`Agent Tool Loop ${step + 1} 回复`, next);
         if (next.toolCalls.length) {
             const writableCalls = next.toolCalls.filter(isWritableToolCall);

--- a/web/src/lib/openai-prompt-cache.ts
+++ b/web/src/lib/openai-prompt-cache.ts
@@ -1,0 +1,17 @@
+export const OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH = 64;
+
+export function clampOpenAIPromptCacheKey(value?: string) {
+    const key = value?.trim();
+    if (!key) return undefined;
+    return Array.from(key).slice(0, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH).join("");
+}
+
+export function canvasAgentPromptCacheKey(sessionId: string) {
+    const value = sessionId.trim();
+    return value ? clampOpenAIPromptCacheKey(`canvas-agent:${value}`) : undefined;
+}
+
+export function withOpenAIPromptCacheKey<T extends Record<string, unknown>>(body: T, value?: string): T & { prompt_cache_key?: string } {
+    const key = clampOpenAIPromptCacheKey(value);
+    return key ? { ...body, prompt_cache_key: key } : body;
+}

--- a/web/src/services/api/image.ts
+++ b/web/src/services/api/image.ts
@@ -7,6 +7,7 @@ import { buildImageReferencePromptText } from "@/lib/image-reference-prompt";
 import { channelRequest } from "@/services/api/custom-channel-relay";
 import { imageToDataUrl } from "@/services/image-storage";
 import type { ReferenceImage } from "@/types/image";
+import { withOpenAIPromptCacheKey } from "@/lib/openai-prompt-cache";
 
 export type AiTextMessage = {
     role: "system" | "user" | "assistant";
@@ -100,7 +101,7 @@ type GeminiPayload = {
     promptFeedback?: { blockReason?: string };
 };
 type GeminiStreamState = { buffer: string; text: string; toolCalls: ResponseToolCall[]; error?: string };
-type RequestOptions = { signal?: AbortSignal };
+type RequestOptions = { signal?: AbortSignal; promptCacheKey?: string };
 
 const QUALITY_BASE: Record<string, number> = {
     low: 1024,
@@ -945,13 +946,21 @@ export async function requestToolResponse(config: AiConfig, messages: ResponseIn
                 parallel_tool_calls: false,
             }, onDelta, options);
         }
-        return await requestStreamingResponse(requestConfig, {
-            model: requestConfig.model,
-            input: toResponseInput(withSystemMessage(requestConfig, messages)),
-            tools: tools.map(toResponseTool),
-            tool_choice: toolChoice,
-            parallel_tool_calls: false,
-        }, onDelta, options);
+        return await requestStreamingResponse(
+            requestConfig,
+            withOpenAIPromptCacheKey(
+                {
+                    model: requestConfig.model,
+                    input: toResponseInput(withSystemMessage(requestConfig, messages)),
+                    tools: tools.map(toResponseTool),
+                    tool_choice: toolChoice,
+                    parallel_tool_calls: false,
+                },
+                options?.promptCacheKey,
+            ),
+            onDelta,
+            options,
+        );
     } catch (error) {
         throw new Error(readAxiosError(error, "请求失败"));
     }

--- a/web/test/agent-prompt-cache.test.ts
+++ b/web/test/agent-prompt-cache.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+
+import { canvasAgentPromptCacheKey, clampOpenAIPromptCacheKey, OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH, withOpenAIPromptCacheKey } from "../src/lib/openai-prompt-cache";
+
+describe("Agent prompt cache", () => {
+    test("同一会话生成稳定且隔离的缓存键", () => {
+        expect(canvasAgentPromptCacheKey("session-a")).toBe("canvas-agent:session-a");
+        expect(canvasAgentPromptCacheKey("session-a")).toBe(canvasAgentPromptCacheKey("session-a"));
+        expect(canvasAgentPromptCacheKey("session-a")).not.toBe(canvasAgentPromptCacheKey("session-b"));
+        expect(canvasAgentPromptCacheKey(" ")).toBeUndefined();
+    });
+
+    test("缓存键按 OpenAI 上限截断", () => {
+        const key = clampOpenAIPromptCacheKey(`canvas-agent:${"x".repeat(100)}`);
+        expect(Array.from(key || "")).toHaveLength(OPENAI_PROMPT_CACHE_KEY_MAX_LENGTH);
+    });
+
+    test("Responses 请求体携带缓存键", () => {
+        const body = withOpenAIPromptCacheKey({ model: "test-model", input: [] }, " canvas-agent:session-a ");
+        expect(body.prompt_cache_key).toBe("canvas-agent:session-a");
+    });
+
+    test("空缓存键不会写入 Responses 请求体", () => {
+        const body = withOpenAIPromptCacheKey({ model: "test-model", input: [] }, " ");
+        expect(body).not.toHaveProperty("prompt_cache_key");
+    });
+});


### PR DESCRIPTION
## 改动摘要

- 为网站 Agent 的 OpenAI Responses 请求增加稳定的会话级 `prompt_cache_key`。
- 同一 Agent 会话的首请求与工具续跑复用相同缓存键，不同会话相互隔离。
- 按 OpenAI 限制将缓存键截断到最多 64 个 Unicode 字符。
- 仅修改 Responses 请求体，不影响 Chat Completions、Gemini、图片、视频或后端中继。
- 增加缓存键稳定性、隔离性、长度限制及请求体注入测试。

## 问题原因

网站 Agent 的工具循环会在每一步重新发送完整的 `input + tools`，但此前没有提供 `prompt_cache_key`，也没有其他会话亲和信息。部分 OpenAI 兼容上游因此无法把同一会话的重复前缀稳定路由到相同 Prompt Cache，导致 cached token 持续为 0。

本次修复使用持久化的 Agent session ID 生成 `canvas-agent:<sessionId>`，并只在 `requestToolResponse` 的 OpenAI Responses 分支写入请求体。

## 实测结果

修复前的一组 8 次网站 Agent 请求共计 201,619 input token，cached token 全部为 0。

修复后使用同一模型和上游连续验证，3 次 `/v1/responses` 请求分别命中约：

- 5.8K cached token
- 5.8K cached token
- 18.2K cached token

说明上游已经能够复用网站 Agent 的稳定请求前缀。

## 验证

- `bun test web/test/agent-prompt-cache.test.ts`：4 passed，0 failed
- `npx prettier --check src/lib/openai-prompt-cache.ts test/agent-prompt-cache.test.ts`：通过
- `git diff --check`：通过
- `docker build -t open-ai-canvas-web:pr73 .`：通过
  - `tsc --noEmit`：通过
  - Vite production build：通过

## 风险与兼容性

- 缓存键来自随机会话 ID，不包含用户提示词、API Key 或画布内容。
- 空会话 ID 不发送缓存字段。
- 没有启用 `prompt_cache_retention`，避免给兼容渠道增加额外字段要求。
- 没有引入 `previous_response_id`，不依赖上游 Responses 状态存储。

Closes #73
