### PR TITLE
fix(canvas): 创作任务 - 页面切换保留后台执行并支持及时停止

### DIFF
--- a/web/src/pages/create/index.tsx
+++ b/web/src/pages/create/index.tsx
@@ -114,7 +114,7 @@ export default function CreatePage() {
         });
         return () => {
             cancelled = true;
-            abortRef.current?.abort();
+            // 页面卸载只停止当前页面的状态更新，后台任务由任务中心继续执行，返回页面后再恢复状态。
         };
     }, []);
 

--- a/web/src/services/api/task-center.ts
+++ b/web/src/services/api/task-center.ts
@@ -195,8 +195,8 @@ export function listGenerationTasks(limit = 30, options?: { projectId?: string; 
     return request<GenerationTask[]>(api.get("/tasks", { params: { limit, projectId: options?.projectId, activeOnly: options?.activeOnly || undefined } }));
 }
 
-export function queryGenerationTask(id: string) {
-    return request<GenerationTask>(api.get(`/tasks/${encodeURIComponent(id)}`));
+export function queryGenerationTask(id: string, options?: { signal?: AbortSignal }) {
+    return request<GenerationTask>(api.get(`/tasks/${encodeURIComponent(id)}`, { signal: options?.signal }));
 }
 
 export function retryGenerationTask(id: string) {
@@ -225,7 +225,7 @@ export async function waitForGenerationTask(id: string, options?: { signal?: Abo
             if (options?.signal?.aborted) throw new DOMException("Aborted", "AbortError");
             let task: GenerationTask;
             try {
-                task = await queryGenerationTask(id);
+                task = await queryGenerationTask(id, { signal: options?.signal });
                 lastTask = task;
                 lastQueryError = undefined;
                 options?.onTaskUpdate?.(task);


### PR DESCRIPTION
## 变更说明

- 修复创作页面卸载时误调用 AbortController，避免切换页面或刷新导致后台任务被取消。
- 返回创作页后继续通过任务中心同步任务状态和生成结果。
- 任务轮询请求绑定 AbortSignal，用户主动点击停止时可以及时中断查询并取消任务。

## 验证

- 手动提交视频任务后刷新页面，确认没有再次 POST /api/tasks。
- 刷新后原任务继续运行并完成。
- 未运行自动化测试、构建或语法检查，遵循仓库 AGENTS.md 约束。

Closes #135即