### PR TITLE
feat(tasks): recover text creation after reconnect

### DIFF
--- a/backend/internal/database/schema.go
+++ b/backend/internal/database/schema.go
@@ -57,6 +57,7 @@ func Models() []any {
 		&model.Session{},
 		&model.Message{},
 		&model.TaskLog{},
+		&model.TaskTextChunk{},
 		&model.SessionFile{},
 		&model.Result{},
 	}
@@ -79,5 +80,8 @@ func MigrateSchema(db *gorm.DB) error {
 	if err := db.Exec("DROP INDEX IF EXISTS idx_users_email").Error; err != nil {
 		return err
 	}
-	return db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_nonempty ON users(lower(email)) WHERE email <> ''").Error
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_users_email_nonempty ON users(lower(email)) WHERE email <> ''").Error; err != nil {
+		return err
+	}
+	return db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_tasks_user_submission_nonempty ON tasks(user_id, submission_id) WHERE submission_id <> ''").Error
 }

--- a/backend/internal/handler/routes.go
+++ b/backend/internal/handler/routes.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"time"
@@ -51,6 +53,57 @@ func RegisterTaskRoutes(r *gin.RouterGroup, svc *service.Service) {
 			return
 		}
 		ok(c, tasks)
+	})
+	r.POST("/tasks/recover", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		var req struct {
+			SubmissionIDs []string `json:"submissionIds"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			fail(c, http.StatusBadRequest, err)
+			return
+		}
+		tasks, err := svc.TasksForSubmissions(user.ID, req.SubmissionIDs)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, tasks)
+	})
+	r.GET("/tasks/:id/text-chunks", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		after, err := taskTextAfterCursor(c)
+		if err != nil {
+			fail(c, http.StatusBadRequest, err)
+			return
+		}
+		stream, err := svc.TaskTextStream(user.ID, c.Param("id"), after)
+		if err != nil {
+			fail(c, http.StatusNotFound, err)
+			return
+		}
+		ok(c, stream)
+	})
+	r.GET("/tasks/:id/text-events", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		after, err := taskTextAfterCursor(c)
+		if err != nil {
+			fail(c, http.StatusBadRequest, err)
+			return
+		}
+		streamTaskTextEvents(c, svc, user.ID, c.Param("id"), after)
 	})
 	r.GET("/tasks/:id", func(c *gin.Context) {
 		user, err := currentUser(c, svc)
@@ -117,6 +170,74 @@ func RegisterTaskRoutes(r *gin.RouterGroup, svc *service.Service) {
 		}
 		ok(c, logs)
 	})
+}
+
+func taskTextAfterCursor(c *gin.Context) (int64, error) {
+	raw := c.Query("after")
+	if raw == "" {
+		raw = c.GetHeader("Last-Event-ID")
+	}
+	if raw == "" {
+		return 0, nil
+	}
+	after, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || after < 0 {
+		return 0, fmt.Errorf("after 必须是非负整数")
+	}
+	return after, nil
+}
+
+func streamTaskTextEvents(c *gin.Context, svc *service.Service, userID string, taskID string, after int64) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache, no-transform")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+	if _, err := fmt.Fprint(c.Writer, ": connected\n\n"); err != nil {
+		return
+	}
+	c.Writer.Flush()
+	ticker := time.NewTicker(750 * time.Millisecond)
+	defer ticker.Stop()
+	lastStatus := ""
+	for {
+		stream, err := svc.TaskTextStream(userID, taskID, after)
+		if err != nil {
+			writeTaskTextSSE(c, "error", 0, map[string]string{"message": "任务文本流不可用"})
+			return
+		}
+		for _, chunk := range stream.Chunks {
+			writeTaskTextSSE(c, "delta", chunk.Sequence, map[string]interface{}{"attempt": stream.Attempt, "sequence": chunk.Sequence, "delta": chunk.Delta})
+			after = chunk.Sequence
+		}
+		statusKey := fmt.Sprintf("%s:%d:%s", stream.Task.Status, stream.Task.Progress, stream.Task.Stage)
+		if statusKey != lastStatus {
+			writeTaskTextSSE(c, "status", 0, map[string]interface{}{"attempt": stream.Attempt, "task": stream.Task})
+			lastStatus = statusKey
+		}
+		if stream.Task.Status == "succeeded" || stream.Task.Status == "failed" || stream.Task.Status == "cancelled" {
+			writeTaskTextSSE(c, "terminal", 0, map[string]interface{}{"attempt": stream.Attempt, "task": stream.Task})
+			return
+		}
+		c.Writer.Flush()
+		select {
+		case <-c.Request.Context().Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func writeTaskTextSSE(c *gin.Context, event string, id int64, value interface{}) {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return
+	}
+	if id > 0 {
+		_, _ = fmt.Fprintf(c.Writer, "id: %d\n", id)
+	}
+	_, _ = fmt.Fprintf(c.Writer, "event: %s\ndata: %s\n\n", event, data)
+	c.Writer.Flush()
 }
 
 func RegisterSessionRoutes(r *gin.RouterGroup, svc *service.Service) {

--- a/backend/internal/model/models.go
+++ b/backend/internal/model/models.go
@@ -736,6 +736,7 @@ type UserAnnouncementRead struct {
 type Task struct {
 	ID                string     `json:"id" gorm:"primaryKey;size:36"`
 	UserID            string     `json:"userId" gorm:"index;size:36;index:idx_tasks_user_created,priority:1"`
+	SubmissionID      string     `json:"submissionId,omitempty" gorm:"size:96"`
 	SessionID         string     `json:"sessionId" gorm:"index;size:36"`
 	ProjectID         string     `json:"projectId" gorm:"index;size:80"`
 	Type              string     `json:"type" gorm:"index;size:64"`
@@ -792,6 +793,17 @@ type TaskLog struct {
 	Message   string    `json:"message"`
 	Payload   string    `json:"payload" gorm:"type:text"`
 	CreatedAt time.Time `json:"createdAt"`
+}
+
+// TaskTextChunk stores a recoverable text-generation delta outside task logs.
+type TaskTextChunk struct {
+	ID        string    `json:"id" gorm:"primaryKey;size:36"`
+	UserID    string    `json:"userId" gorm:"index;size:36"`
+	TaskID    string    `json:"taskId" gorm:"index;size:36;uniqueIndex:idx_task_text_chunk_sequence,priority:1"`
+	Attempt   int       `json:"attempt" gorm:"uniqueIndex:idx_task_text_chunk_sequence,priority:2"`
+	Sequence  int64     `json:"sequence" gorm:"uniqueIndex:idx_task_text_chunk_sequence,priority:3"`
+	Delta     string    `json:"delta" gorm:"type:text"`
+	CreatedAt time.Time `json:"createdAt" gorm:"index"`
 }
 
 type SessionFile struct {

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -270,6 +270,23 @@ func (r *Repository) TaskForUser(userID string, id string) (*model.Task, error) 
 	return &task, nil
 }
 
+func (r *Repository) TaskForSubmission(userID string, submissionID string) (*model.Task, error) {
+	var task model.Task
+	if err := r.db.First(&task, "user_id = ? AND submission_id = ?", userID, submissionID).Error; err != nil {
+		return nil, err
+	}
+	return &task, nil
+}
+
+func (r *Repository) TasksForSubmissions(userID string, submissionIDs []string) ([]model.Task, error) {
+	if len(submissionIDs) == 0 {
+		return []model.Task{}, nil
+	}
+	var tasks []model.Task
+	err := r.db.Where("user_id = ? AND submission_id IN ?", userID, submissionIDs).Order("created_at asc").Find(&tasks).Error
+	return tasks, err
+}
+
 func (r *Repository) ActiveTaskCountForUser(userID string) (int64, error) {
 	var count int64
 	err := r.db.Model(&model.Task{}).Where("user_id = ? AND status IN ?", userID, []model.TaskStatus{model.TaskStatusQueued, model.TaskStatusRunning}).Count(&count).Error
@@ -420,7 +437,7 @@ func (r *Repository) Tasks(userID string, limit int, projectID string, activeOnl
 	if limit <= 0 || limit > 100 {
 		limit = 50
 	}
-	query := r.db.Select("id", "session_id", "project_id", "type", "status", "stage", "progress", "prompt", "operation", "provider", "model", "input_json", "result_json", "billing_order_id", "attempts", "started_at", "completed_at", "created_at", "updated_at").
+	query := r.db.Select("id", "submission_id", "session_id", "project_id", "type", "status", "stage", "progress", "prompt", "operation", "provider", "model", "input_json", "result_json", "billing_order_id", "attempts", "started_at", "completed_at", "created_at", "updated_at").
 		Where("user_id = ?", userID)
 	if strings.TrimSpace(projectID) != "" {
 		query = query.Where("project_id = ?", strings.TrimSpace(projectID))
@@ -481,6 +498,25 @@ func (r *Repository) TaskLogs(userID string, taskID string) ([]model.TaskLog, er
 	var logs []model.TaskLog
 	err := r.db.Order("created_at asc").Find(&logs, "user_id = ? AND task_id = ?", userID, taskID).Error
 	return logs, err
+}
+
+func (r *Repository) TaskTextChunks(userID string, taskID string, attempt int, afterSequence int64) ([]model.TaskTextChunk, error) {
+	var chunks []model.TaskTextChunk
+	query := r.db.Where("user_id = ? AND task_id = ? AND attempt = ?", userID, taskID, attempt).Order("sequence asc")
+	if afterSequence > 0 {
+		query = query.Where("sequence > ?", afterSequence)
+	}
+	return chunks, query.Find(&chunks).Error
+}
+
+func (r *Repository) LastTaskTextChunkSequence(taskID string, attempt int) (int64, error) {
+	var sequence int64
+	err := r.db.Model(&model.TaskTextChunk{}).Where("task_id = ? AND attempt = ?", taskID, attempt).Select("COALESCE(MAX(sequence), 0)").Scan(&sequence).Error
+	return sequence, err
+}
+
+func (r *Repository) CreateTaskTextChunk(chunk *model.TaskTextChunk) error {
+	return r.db.Create(chunk).Error
 }
 
 func (r *Repository) SystemChannels(includeDisabled bool) ([]model.ModelChannel, error) {

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/base64"
@@ -60,6 +61,7 @@ type providerConfig struct {
 const providerHTTPTimeout = 5 * time.Minute
 const videoPollTimeout = 30 * time.Minute
 const maxProviderResponseBytes int64 = 64 << 20
+const maxTextStreamResponseBytes int64 = 8 << 20
 
 type providerMedia struct {
 	ID         string `json:"id"`
@@ -144,58 +146,19 @@ func (e providerHTTPError) Error() string {
 }
 
 func (s *Service) processCanvasGenerationTask(ctx context.Context, userID string, taskType string, fallbackPrompt string, rawInput string) (map[string]interface{}, error) {
-	var input canvasGenerationInput
-	if err := json.Unmarshal([]byte(rawInput), &input); err != nil {
-		return nil, fmt.Errorf("任务输入解析失败：%w", err)
-	}
-	if strings.TrimSpace(input.Prompt) == "" {
-		input.Prompt = fallbackPrompt
-	}
-	promptTemplateOperation := metadataString(input.Metadata, "promptTemplateOperation")
-	if promptTemplateOperation != "" {
-		values := metadataStringValues(input.Metadata["promptTemplateVariables"])
-		compiled, compileErr := s.compilePrompt(userID, promptTemplateOperation, values)
-		if compileErr != nil {
-			return nil, fmt.Errorf("编译用户提示词失败：%w", compileErr)
-		}
-		input.Prompt = compiled.Content
-	}
-	if strings.TrimSpace(input.Prompt) == "" {
-		return nil, errors.New("prompt is required")
-	}
-	if input.Mode == "" && strings.HasPrefix(taskType, "video_") {
-		input.Mode = "video"
-	}
-	config, err := s.resolveProviderConfig(input.Config)
+	input, err := s.canvasGenerationInput(ctx, userID, taskType, fallbackPrompt, rawInput)
 	if err != nil {
 		return nil, err
-	}
-	input.Config = config
-	if input.Config.APIFormat == "gemini" && input.Config.InterfaceType != string(model.ChannelInterfaceGeminiVeo) {
-		return nil, errors.New("后端任务队列暂不支持 Gemini 调用格式，请使用 OpenAI 兼容渠道")
-	}
-	if strings.TrimSpace(input.Config.BaseURL) == "" || strings.TrimSpace(input.Config.APIKey) == "" || strings.TrimSpace(input.Config.Model) == "" {
-		return nil, errors.New("后端生成任务缺少 Base URL、API Key 或模型名")
-	}
-	if err := validateGenerationInterface(input.Mode, input.Config.InterfaceType); err != nil {
-		return nil, err
-	}
-	if isVolcengineJiMengProtocol(input.Config.InterfaceType) && strings.TrimSpace(input.Config.SecretKey) == "" {
-		return nil, errors.New("即梦官方 API 缺少 Secret Key")
-	}
-	if resumedProviderRequestID(ctx) == "" {
-		requirePublicURL := input.Config.InterfaceType == "newapi-channel-1" || input.Config.InterfaceType == "newapi-channel-2" || input.Config.InterfaceType == string(model.ChannelInterfaceVolcengineArkVideo)
-		if err := s.hydrateGenerationMedia(userID, &input, requirePublicURL); err != nil {
-			return nil, err
-		}
 	}
 	switch input.Mode {
 	case "image":
 		return runImageTask(ctx, input)
 	case "text":
 		result, taskErr := runTextTask(ctx, input)
-		if taskErr == nil && promptTemplateOperation != "" {
-			taskErr = validatePromptTemplateResult(promptTemplateOperation, result)
+		if taskErr == nil {
+			if operation := metadataString(input.Metadata, "promptTemplateOperation"); operation != "" {
+				taskErr = validatePromptTemplateResult(operation, result)
+			}
 		}
 		return result, taskErr
 	case "video":
@@ -205,6 +168,101 @@ func (s *Service) processCanvasGenerationTask(ctx context.Context, userID string
 	default:
 		return nil, fmt.Errorf("不支持的生成模式：%s", input.Mode)
 	}
+}
+
+func (s *Service) canvasGenerationInput(ctx context.Context, userID string, taskType string, fallbackPrompt string, rawInput string) (canvasGenerationInput, error) {
+	var input canvasGenerationInput
+	if err := json.Unmarshal([]byte(rawInput), &input); err != nil {
+		return canvasGenerationInput{}, fmt.Errorf("任务输入解析失败：%w", err)
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		input.Prompt = fallbackPrompt
+	}
+	if operation := metadataString(input.Metadata, "promptTemplateOperation"); operation != "" {
+		values := metadataStringValues(input.Metadata["promptTemplateVariables"])
+		compiled, err := s.compilePrompt(userID, operation, values)
+		if err != nil {
+			return canvasGenerationInput{}, fmt.Errorf("编译用户提示词失败：%w", err)
+		}
+		input.Prompt = compiled.Content
+	}
+	if strings.TrimSpace(input.Prompt) == "" {
+		return canvasGenerationInput{}, errors.New("prompt is required")
+	}
+	if input.Mode == "" && strings.HasPrefix(taskType, "video_") {
+		input.Mode = "video"
+	}
+	config, err := s.resolveProviderConfig(input.Config)
+	if err != nil {
+		return canvasGenerationInput{}, err
+	}
+	input.Config = config
+	if input.Config.APIFormat == "gemini" && input.Config.InterfaceType != string(model.ChannelInterfaceGeminiVeo) {
+		return canvasGenerationInput{}, errors.New("后端任务队列暂不支持 Gemini 调用格式，请使用 OpenAI 兼容渠道")
+	}
+	if strings.TrimSpace(input.Config.BaseURL) == "" || strings.TrimSpace(input.Config.APIKey) == "" || strings.TrimSpace(input.Config.Model) == "" {
+		return canvasGenerationInput{}, errors.New("后端生成任务缺少 Base URL、API Key 或模型名")
+	}
+	if err := validateGenerationInterface(input.Mode, input.Config.InterfaceType); err != nil {
+		return canvasGenerationInput{}, err
+	}
+	if isVolcengineJiMengProtocol(input.Config.InterfaceType) && strings.TrimSpace(input.Config.SecretKey) == "" {
+		return canvasGenerationInput{}, errors.New("即梦官方 API 缺少 Secret Key")
+	}
+	if resumedProviderRequestID(ctx) == "" {
+		requirePublicURL := input.Config.InterfaceType == "newapi-channel-1" || input.Config.InterfaceType == "newapi-channel-2" || input.Config.InterfaceType == string(model.ChannelInterfaceVolcengineArkVideo)
+		if err := s.hydrateGenerationMedia(userID, &input, requirePublicURL); err != nil {
+			return canvasGenerationInput{}, err
+		}
+	}
+	return input, nil
+}
+
+func (s *Service) processCanvasTextGenerationTask(ctx context.Context, task model.Task) (map[string]interface{}, error) {
+	input, err := s.canvasGenerationInput(ctx, task.UserID, task.Type, task.Prompt, task.InputJSON)
+	if err != nil {
+		return nil, err
+	}
+	writer, err := s.newTaskTextWriter(task)
+	if err != nil {
+		return nil, err
+	}
+	flushStop := make(chan struct{})
+	flushDone := make(chan struct{})
+	go func() {
+		ticker := time.NewTicker(taskTextChunkFlushInterval)
+		defer ticker.Stop()
+		defer close(flushDone)
+		for {
+			select {
+			case <-ticker.C:
+				if err := writer.Flush(); err != nil {
+					return
+				}
+			case <-flushStop:
+				return
+			}
+		}
+	}()
+	result, runErr := runTextTaskStream(ctx, input, writer.Write)
+	close(flushStop)
+	<-flushDone
+	flushErr := writer.Flush()
+	if runErr != nil {
+		return nil, runErr
+	}
+	if writerErr := writer.Failure(); writerErr != nil {
+		return nil, writerErr
+	}
+	if flushErr != nil {
+		return nil, flushErr
+	}
+	if operation := metadataString(input.Metadata, "promptTemplateOperation"); operation != "" {
+		if err := validatePromptTemplateResult(operation, result); err != nil {
+			return result, err
+		}
+	}
+	return result, nil
 }
 
 func metadataStringValues(value any) map[string]string {
@@ -537,6 +595,171 @@ func runTextTask(ctx context.Context, input canvasGenerationInput) (map[string]i
 		return runResponsesTextTask(ctx, input)
 	}
 	return runLegacyTextTask(ctx, input)
+}
+
+type textDeltaHandler func(string) error
+
+func runTextTaskStream(ctx context.Context, input canvasGenerationInput, onDelta textDeltaHandler) (map[string]interface{}, error) {
+	if onDelta == nil {
+		return runTextTask(ctx, input)
+	}
+	switch input.Config.InterfaceType {
+	case "chat-completion":
+		return runChatCompletionsTextTaskStream(ctx, input, onDelta)
+	case "openai-response":
+		return runResponsesTextTaskStream(ctx, input, onDelta)
+	}
+	return runLegacyTextTaskStream(ctx, input, onDelta)
+}
+
+func runLegacyTextTaskStream(ctx context.Context, input canvasGenerationInput, onDelta textDeltaHandler) (map[string]interface{}, error) {
+	emitted := false
+	forward := func(delta string) error {
+		emitted = true
+		return onDelta(delta)
+	}
+	result, err := runResponsesTextTaskStream(ctx, input, forward)
+	if err == nil || emitted || !shouldFallbackTextToChat(err) {
+		return result, err
+	}
+	return runChatCompletionsTextTaskStream(ctx, input, onDelta)
+}
+
+func runResponsesTextTaskStream(ctx context.Context, input canvasGenerationInput, onDelta textDeltaHandler) (map[string]interface{}, error) {
+	responseInput, err := textResponseInput(input)
+	if err != nil {
+		return nil, err
+	}
+	return streamTextTaskRequest(ctx, input.Config, "/responses", map[string]interface{}{"model": input.Config.Model, "input": responseInput}, extractResponseText, extractResponsesStreamDelta, onDelta)
+}
+
+func runChatCompletionsTextTaskStream(ctx context.Context, input canvasGenerationInput, onDelta textDeltaHandler) (map[string]interface{}, error) {
+	messages := []map[string]interface{}{}
+	if systemPrompt := strings.TrimSpace(input.Config.SystemPrompt); systemPrompt != "" {
+		messages = append(messages, map[string]interface{}{"role": "system", "content": systemPrompt})
+	}
+	userContent, err := textChatContent(input)
+	if err != nil {
+		return nil, err
+	}
+	messages = append(messages, map[string]interface{}{"role": "user", "content": userContent})
+	return streamTextTaskRequest(ctx, input.Config, "/chat/completions", map[string]interface{}{"model": input.Config.Model, "messages": messages}, extractChatCompletionText, extractChatCompletionStreamDelta, onDelta)
+}
+
+func streamTextTaskRequest(ctx context.Context, config providerConfig, path string, body map[string]interface{}, extractText func(map[string]interface{}) string, extractDelta func(string, map[string]interface{}) string, onDelta textDeltaHandler) (map[string]interface{}, error) {
+	body["stream"] = true
+	var text strings.Builder
+	appendDelta := func(delta string) error {
+		if delta == "" {
+			return nil
+		}
+		if err := onDelta(delta); err != nil {
+			return err
+		}
+		text.WriteString(delta)
+		return nil
+	}
+	handleEvent := func(event string, data string) error {
+		if strings.TrimSpace(data) == "[DONE]" {
+			return nil
+		}
+		var payload map[string]interface{}
+		if err := json.Unmarshal([]byte(data), &payload); err != nil {
+			return fmt.Errorf("文本流事件格式无效：%w", err)
+		}
+		if message := providerStreamError(payload); message != "" {
+			return errors.New(message)
+		}
+		return appendDelta(extractDelta(event, payload))
+	}
+	handleJSON := func(data []byte) error {
+		var payload map[string]interface{}
+		if err := json.Unmarshal(data, &payload); err != nil {
+			return fmt.Errorf("文本接口返回非 JSON 内容：%w", err)
+		}
+		if message := providerStreamError(payload); message != "" {
+			return errors.New(message)
+		}
+		if content := extractText(payload); content != "" {
+			return appendDelta(content)
+		}
+		return errors.New("文本接口没有返回内容")
+	}
+	if _, err := postTextEventStream(ctx, config, path, body, handleEvent, handleJSON); err != nil {
+		return nil, err
+	}
+	if text.Len() == 0 {
+		return nil, errors.New("文本接口没有返回内容")
+	}
+	return map[string]interface{}{"mode": "text", "text": text.String()}, nil
+}
+
+func providerStreamError(payload map[string]interface{}) string {
+	if errorValue, ok := payload["error"].(map[string]interface{}); ok {
+		if message := stringField(errorValue, "message"); message != "" {
+			return message
+		}
+	}
+	if message := stringField(payload, "message"); message != "" && (strings.Contains(strings.ToLower(stringField(payload, "type")), "error") || payload["code"] != nil) {
+		return message
+	}
+	if code, ok := payload["code"].(float64); ok && code != 0 {
+		return defaultString(stringField(payload, "msg"), "请求失败")
+	}
+	return ""
+}
+
+func extractResponsesStreamDelta(event string, payload map[string]interface{}) string {
+	eventType := strings.ToLower(strings.TrimSpace(defaultString(event, stringField(payload, "type"))))
+	if strings.Contains(eventType, "output_text.delta") || strings.Contains(eventType, "text.delta") || eventType == "" {
+		return stringField(payload, "delta")
+	}
+	return ""
+}
+
+func extractChatCompletionStreamDelta(_ string, payload map[string]interface{}) string {
+	if data, ok := payload["data"].(map[string]interface{}); ok {
+		payload = data
+	}
+	choices, ok := payload["choices"].([]interface{})
+	if !ok {
+		return ""
+	}
+	var chunks []string
+	for _, choice := range choices {
+		record, ok := choice.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if delta, ok := record["delta"].(map[string]interface{}); ok {
+			if text := streamContentText(delta["content"]); text != "" {
+				chunks = append(chunks, text)
+			}
+		}
+		if text := stringField(record, "text"); text != "" {
+			chunks = append(chunks, text)
+		}
+	}
+	return strings.Join(chunks, "")
+}
+
+func streamContentText(value interface{}) string {
+	switch item := value.(type) {
+	case string:
+		return item
+	case []interface{}:
+		var chunks []string
+		for _, child := range item {
+			if record, ok := child.(map[string]interface{}); ok {
+				if text := stringField(record, "text"); text != "" {
+					chunks = append(chunks, text)
+				}
+			}
+		}
+		return strings.Join(chunks, "")
+	default:
+		return ""
+	}
 }
 
 func runLegacyTextTask(ctx context.Context, input canvasGenerationInput) (map[string]interface{}, error) {
@@ -1613,6 +1836,19 @@ func postJSON(ctx context.Context, config providerConfig, path string, body inte
 	return doJSON(req, target)
 }
 
+func postTextEventStream(ctx context.Context, config providerConfig, path string, body interface{}, onEvent func(string, string) error, onJSON func([]byte) error) (bool, error) {
+	data, _ := json.Marshal(body)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL(config.BaseURL, path), bytes.NewReader(data))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Authorization", "Bearer "+config.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "text/event-stream")
+	ApplyOutboundHeaders(req, config.Headers)
+	return doTextEventStream(req, onEvent, onJSON)
+}
+
 func postForm(ctx context.Context, config providerConfig, path string, contentType string, body io.Reader, target interface{}) error {
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL(config.BaseURL, path), body)
 	if err != nil {
@@ -1692,6 +1928,134 @@ func doJSON(req *http.Request, target interface{}) error {
 		}
 	}
 	return nil
+}
+
+func doTextEventStream(req *http.Request, onEvent func(string, string) error, onJSON func([]byte) error) (bool, error) {
+	startedAt := time.Now()
+	requestTimeout := providerHTTPTimeout
+	if deadline, ok := req.Context().Deadline(); ok {
+		if remaining := time.Until(deadline); remaining > 0 {
+			requestTimeout = remaining
+		}
+	}
+	var release func()
+	var coordinator *runtimeCoordinator
+	var runtimeService *Service
+	channelID := ""
+	if metadata, ok := req.Context().Value(providerAnalyticsKey{}).(providerAnalyticsContext); ok && metadata.Service != nil {
+		runtimeService = metadata.Service
+		coordinator = metadata.Service.coordinator
+		channelID = metadata.ChannelID
+		open, err := coordinator.circuitOpen(req.Context(), channelID)
+		if err != nil {
+			return false, fmt.Errorf("读取渠道熔断状态失败：%w", err)
+		}
+		if open {
+			return false, errors.New("当前渠道连续失败，已暂时熔断，请稍后重试")
+		}
+		slotID := channelID
+		if slotID == "" {
+			slotID = "custom:" + strings.ToLower(req.URL.Host)
+		}
+		acquiredRelease, _, acquireErr := metadata.Service.AcquireChannelSlot(req.Context(), channelID, slotID, requestTimeout+time.Minute)
+		if acquireErr != nil {
+			recordProviderRequest(req, startedAt, 0, nil, acquireErr)
+			return false, acquireErr
+		}
+		release = acquiredRelease
+		defer release()
+	}
+	if _, err := ValidateOutboundURL(req.URL.String()); err != nil {
+		recordProviderRequest(req, startedAt, 0, nil, err)
+		return false, err
+	}
+	ApplyDefaultOutboundHeaders(req)
+	resp, err := OutboundHTTPClient(requestTimeout).Do(req)
+	if err != nil {
+		if runtimeService != nil {
+			_ = runtimeService.RecordChannelResult(req.Context(), channelID, !errors.Is(err, context.Canceled))
+		}
+		recordProviderRequest(req, startedAt, 0, nil, err)
+		return false, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, maxTextStreamResponseBytes+1))
+		err := providerHTTPError{StatusCode: resp.StatusCode, Status: resp.Status, Body: string(data)}
+		if runtimeService != nil {
+			_ = runtimeService.RecordChannelResult(req.Context(), channelID, resp.StatusCode >= 500)
+		}
+		recordProviderRequest(req, startedAt, resp.StatusCode, data, err)
+		return false, err
+	}
+	if !strings.Contains(strings.ToLower(resp.Header.Get("Content-Type")), "text/event-stream") {
+		data, readErr := io.ReadAll(io.LimitReader(resp.Body, maxTextStreamResponseBytes+1))
+		if readErr != nil {
+			recordProviderRequest(req, startedAt, resp.StatusCode, nil, readErr)
+			return false, readErr
+		}
+		if int64(len(data)) > maxTextStreamResponseBytes {
+			err := fmt.Errorf("文本响应超过 %s 限制", formatStorageLimit(maxTextStreamResponseBytes))
+			recordProviderRequest(req, startedAt, resp.StatusCode, nil, err)
+			return false, err
+		}
+		if err := onJSON(data); err != nil {
+			recordProviderRequest(req, startedAt, resp.StatusCode, nil, err)
+			return false, err
+		}
+		recordProviderRequest(req, startedAt, resp.StatusCode, nil, nil)
+		if runtimeService != nil {
+			_ = runtimeService.RecordChannelResult(req.Context(), channelID, false)
+		}
+		return false, nil
+	}
+
+	scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxTextStreamResponseBytes+1))
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	eventName := "message"
+	dataLines := make([]string, 0, 2)
+	dispatch := func() error {
+		if len(dataLines) == 0 {
+			return nil
+		}
+		err := onEvent(eventName, strings.Join(dataLines, "\n"))
+		eventName = "message"
+		dataLines = dataLines[:0]
+		return err
+	}
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			if err := dispatch(); err != nil {
+				recordProviderRequest(req, startedAt, resp.StatusCode, nil, err)
+				return true, err
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			continue
+		}
+		if strings.HasPrefix(line, "event:") {
+			eventName = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+			continue
+		}
+		if strings.HasPrefix(line, "data:") {
+			dataLines = append(dataLines, strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		recordProviderRequest(req, startedAt, resp.StatusCode, nil, err)
+		return true, err
+	}
+	if err := dispatch(); err != nil {
+		recordProviderRequest(req, startedAt, resp.StatusCode, nil, err)
+		return true, err
+	}
+	recordProviderRequest(req, startedAt, resp.StatusCode, nil, nil)
+	if runtimeService != nil {
+		_ = runtimeService.RecordChannelResult(req.Context(), channelID, false)
+	}
+	return true, nil
 }
 
 func doBinary(req *http.Request) ([]byte, string, error) {

--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -19,6 +19,8 @@ import (
 
 	"infinite-canvas/backend/internal/model"
 	"infinite-canvas/backend/internal/repository"
+
+	"gorm.io/gorm"
 )
 
 type Service struct {
@@ -53,14 +55,15 @@ type CreateSessionRequest struct {
 }
 
 type CreateTaskRequest struct {
-	SessionID string         `json:"sessionId"`
-	ProjectID string         `json:"projectId"`
-	Type      string         `json:"type"`
-	Operation string         `json:"operation"`
-	Prompt    string         `json:"prompt"`
-	Provider  string         `json:"provider"`
-	Model     string         `json:"model"`
-	Input     map[string]any `json:"input"`
+	SubmissionID string         `json:"submissionId"`
+	SessionID    string         `json:"sessionId"`
+	ProjectID    string         `json:"projectId"`
+	Type         string         `json:"type"`
+	Operation    string         `json:"operation"`
+	Prompt       string         `json:"prompt"`
+	Provider     string         `json:"provider"`
+	Model        string         `json:"model"`
+	Input        map[string]any `json:"input"`
 }
 
 type SessionDetail struct {
@@ -72,6 +75,7 @@ type SessionDetail struct {
 
 type TaskSummary struct {
 	ID                string              `json:"id"`
+	SubmissionID      string              `json:"submissionId,omitempty"`
 	SessionID         string              `json:"sessionId,omitempty"`
 	ProjectID         string              `json:"projectId,omitempty"`
 	Type              string              `json:"type"`
@@ -159,20 +163,20 @@ type agentStoryboardPlan struct {
 }
 
 type agentStoryboardShot struct {
-	Title        string   `json:"title"`
-	Description  string   `json:"description"`
-	Duration     int      `json:"durationSeconds"`
-	Dialogue     string   `json:"dialogue"`
-	ShotSize     string   `json:"shotSize"`
-	Emotion      string   `json:"emotion"`
-	Lighting     string   `json:"lightingAndAtmosphere"`
-	AudioEffects string   `json:"audioEffects"`
-	VisualPrompt string   `json:"visualPrompt"`
-	VideoPrompt  string   `json:"videoPrompt"`
-	Camera       string   `json:"camera"`
-	Motion       string   `json:"motion"`
-	TimeBeats    string   `json:"timeBeats"`
-	Negative     string   `json:"negativePrompt"`
+	Title         string   `json:"title"`
+	Description   string   `json:"description"`
+	Duration      int      `json:"durationSeconds"`
+	Dialogue      string   `json:"dialogue"`
+	ShotSize      string   `json:"shotSize"`
+	Emotion       string   `json:"emotion"`
+	Lighting      string   `json:"lightingAndAtmosphere"`
+	AudioEffects  string   `json:"audioEffects"`
+	VisualPrompt  string   `json:"visualPrompt"`
+	VideoPrompt   string   `json:"videoPrompt"`
+	Camera        string   `json:"camera"`
+	Motion        string   `json:"motion"`
+	TimeBeats     string   `json:"timeBeats"`
+	Negative      string   `json:"negativePrompt"`
 	AssetTags     []string `json:"assetTags"`
 	CharacterIDs  []string `json:"characterIds"`
 	Intent        string   `json:"narrativeIntent"`
@@ -309,6 +313,19 @@ func (s *Service) CreateTask(userID string, req CreateTaskRequest) (*model.Task,
 	if prompt == "" {
 		return nil, errors.New("prompt is required")
 	}
+	submissionID, err := normalizeTaskSubmissionID(req.SubmissionID)
+	if err != nil {
+		return nil, err
+	}
+	if submissionID != "" {
+		existing, findErr := s.repo.TaskForSubmission(userID, submissionID)
+		if findErr == nil {
+			return taskForOutput(*existing), nil
+		}
+		if !errors.Is(findErr, gorm.ErrRecordNotFound) {
+			return nil, findErr
+		}
+	}
 	normalizedInput, err := normalizeTaskInput(req.Input)
 	if err != nil {
 		return nil, err
@@ -331,7 +348,7 @@ func (s *Service) CreateTask(userID string, req CreateTaskRequest) (*model.Task,
 	if taskType == "" {
 		taskType = "video_image_to_video"
 	}
-	task := model.Task{ID: newID(), UserID: userID, SessionID: req.SessionID, ProjectID: req.ProjectID, Type: taskType, Status: model.TaskStatusQueued, Stage: "等待队列调度", Progress: 5, Prompt: prompt, Operation: req.Operation, Provider: req.Provider, Model: req.Model}
+	task := model.Task{ID: newID(), UserID: userID, SubmissionID: submissionID, SessionID: req.SessionID, ProjectID: req.ProjectID, Type: taskType, Status: model.TaskStatusQueued, Stage: "等待队列调度", Progress: 5, Prompt: prompt, Operation: req.Operation, Provider: req.Provider, Model: req.Model}
 	if err := s.ensureTaskProjectActive(userID, req.ProjectID); err != nil {
 		return nil, err
 	}
@@ -348,6 +365,11 @@ func (s *Service) CreateTask(userID string, req CreateTaskRequest) (*model.Task,
 		task.BillingOrderID = billingOrder.ID
 	}
 	err = s.createTaskWithinStorageQuota(&task, billingOrder, policy)
+	if err != nil && submissionID != "" {
+		if existing, findErr := s.repo.TaskForSubmission(userID, submissionID); findErr == nil {
+			return taskForOutput(*existing), nil
+		}
+	}
 	if errors.Is(err, repository.ErrActiveTaskLimit) {
 		return nil, BadAuthRequest(fmt.Sprintf("同时排队或运行的任务最多 %d 个，请等待已有任务完成", policy.Task.ActiveTaskLimit))
 	}
@@ -360,6 +382,14 @@ func (s *Service) CreateTask(userID string, req CreateTaskRequest) (*model.Task,
 	s.recordActivity(userID, "task", 1)
 	_ = s.log(userID, task.ID, "info", "任务已进入队列", "")
 	return taskForOutput(task), nil
+}
+
+func normalizeTaskSubmissionID(value string) (string, error) {
+	value = strings.TrimSpace(value)
+	if len(value) > 96 {
+		return "", BadAuthRequest("submissionId 长度不能超过 96 个字符")
+	}
+	return value, nil
 }
 
 // 所有任务输入先收敛为 JSON 对象，确保计费与密钥保护不会因 Go 结构体类型不同而被绕过。
@@ -584,6 +614,146 @@ func (s *Service) TaskLogs(userID string, id string) ([]model.TaskLog, error) {
 	return s.repo.TaskLogs(userID, id)
 }
 
+func (s *Service) TasksForSubmissions(userID string, submissionIDs []string) ([]TaskSummary, error) {
+	ids := make([]string, 0, len(submissionIDs))
+	seen := map[string]struct{}{}
+	for _, raw := range submissionIDs {
+		id, err := normalizeTaskSubmissionID(raw)
+		if err != nil {
+			return nil, err
+		}
+		if id == "" {
+			continue
+		}
+		if _, exists := seen[id]; exists {
+			continue
+		}
+		seen[id] = struct{}{}
+		ids = append(ids, id)
+	}
+	if len(ids) > 100 {
+		return nil, BadAuthRequest("一次最多恢复 100 个任务")
+	}
+	tasks, err := s.repo.TasksForSubmissions(userID, ids)
+	if err != nil {
+		return nil, err
+	}
+	orders, err := s.repo.BillingOrdersByTaskIDs(userID, taskBillingTaskIDs(tasks))
+	if err != nil {
+		return nil, err
+	}
+	return taskSummariesForOutputWithBilling(tasks, orders), nil
+}
+
+type TaskTextChunkOutput struct {
+	Sequence int64  `json:"sequence"`
+	Delta    string `json:"delta"`
+}
+
+type TaskTextStream struct {
+	Task         TaskSummary           `json:"task"`
+	Attempt      int                   `json:"attempt"`
+	Chunks       []TaskTextChunkOutput `json:"chunks"`
+	NextSequence int64                 `json:"nextSequence"`
+}
+
+func (s *Service) TaskTextStream(userID string, id string, afterSequence int64) (*TaskTextStream, error) {
+	task, err := s.repo.TaskForUser(userID, id)
+	if err != nil {
+		return nil, err
+	}
+	attempt := task.Attempts
+	chunks, err := s.repo.TaskTextChunks(userID, task.ID, attempt, afterSequence)
+	if err != nil {
+		return nil, err
+	}
+	result := TaskTextStream{Task: taskSummaryForOutput(*task), Attempt: attempt, Chunks: make([]TaskTextChunkOutput, 0, len(chunks)), NextSequence: afterSequence}
+	for _, chunk := range chunks {
+		result.Chunks = append(result.Chunks, TaskTextChunkOutput{Sequence: chunk.Sequence, Delta: chunk.Delta})
+		result.NextSequence = chunk.Sequence
+	}
+	return &result, nil
+}
+
+const (
+	taskTextChunkFlushBytes    = 768
+	taskTextChunkFlushInterval = 250 * time.Millisecond
+)
+
+type taskTextWriter struct {
+	service      *Service
+	userID       string
+	taskID       string
+	attempt      int
+	mu           sync.Mutex
+	nextSequence int64
+	pending      strings.Builder
+	lastFlush    time.Time
+	progressed   bool
+	failure      error
+}
+
+func (s *Service) newTaskTextWriter(task model.Task) (*taskTextWriter, error) {
+	nextSequence, err := s.repo.LastTaskTextChunkSequence(task.ID, task.Attempts)
+	if err != nil {
+		return nil, err
+	}
+	return &taskTextWriter{service: s, userID: task.UserID, taskID: task.ID, attempt: task.Attempts, nextSequence: nextSequence, lastFlush: time.Now()}, nil
+}
+
+func (w *taskTextWriter) Write(delta string) error {
+	if delta == "" {
+		return nil
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.failure != nil {
+		return w.failure
+	}
+	w.pending.WriteString(delta)
+	if w.pending.Len() < taskTextChunkFlushBytes && time.Since(w.lastFlush) < taskTextChunkFlushInterval {
+		return nil
+	}
+	return w.flushLocked()
+}
+
+func (w *taskTextWriter) Flush() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.flushLocked()
+}
+
+func (w *taskTextWriter) flushLocked() error {
+	if w.failure != nil {
+		return w.failure
+	}
+	if w.pending.Len() == 0 {
+		return nil
+	}
+	delta := w.pending.String()
+	w.pending.Reset()
+	nextSequence := w.nextSequence + 1
+	chunk := model.TaskTextChunk{ID: newID(), UserID: w.userID, TaskID: w.taskID, Attempt: w.attempt, Sequence: nextSequence, Delta: delta}
+	if err := w.service.repo.CreateTaskTextChunk(&chunk); err != nil {
+		w.pending.WriteString(delta)
+		w.failure = err
+		return err
+	}
+	w.nextSequence = nextSequence
+	w.lastFlush = time.Now()
+	if !w.progressed {
+		w.progressed = true
+		_ = w.service.repo.UpdateTaskProgress(w.taskID, "正在生成文本", 60)
+	}
+	return nil
+}
+
+func (w *taskTextWriter) Failure() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.failure
+}
+
 func taskSummariesForOutput(tasks []model.Task) []TaskSummary {
 	return taskSummariesForOutputWithBilling(tasks, nil)
 }
@@ -627,6 +797,7 @@ func taskSummaryForOutput(task model.Task) TaskSummary {
 	previewURL, previewKind := taskMediaPreview(task.ResultJSON, task.Type)
 	return TaskSummary{
 		ID:                task.ID,
+		SubmissionID:      task.SubmissionID,
 		SessionID:         task.SessionID,
 		ProjectID:         task.ProjectID,
 		Type:              task.Type,
@@ -1014,6 +1185,10 @@ func (s *Service) processTask(ctx context.Context, task model.Task) (map[string]
 	ctx = withProviderAnalytics(ctx, s, task)
 	if task.Type == "agent_storyboard_rows" {
 		return s.processStoryboardRowsTask(ctx, task)
+	}
+	if task.Type == "canvas_text" {
+		result, err := s.processCanvasTextGenerationTask(ctx, task)
+		return result, nil, err
 	}
 	if strings.HasPrefix(task.Type, "canvas_") || canRunProviderTask(task) {
 		result, err := s.processCanvasGenerationTask(ctx, task.UserID, task.Type, task.Prompt, task.InputJSON)
@@ -1701,10 +1876,10 @@ func shotDescription(shot agentStoryboardShot) string {
 func storyboardImagePromptValues(projectStyle string, styleGuide string, shot agentStoryboardShot) map[string]string {
 	negative := defaultString(strings.TrimSpace(shot.Negative), "禁止换脸、服装变化、手部畸形、乱码、风格突变和塑料材质")
 	return map[string]string{
-		"项目视觉": storyboardProjectVisualSummary(projectStyle, styleGuide),
-		"首帧构图": compactPromptText(shot.VisualPrompt+"；光影："+shot.Lighting, 360),
+		"项目视觉":   storyboardProjectVisualSummary(projectStyle, styleGuide),
+		"首帧构图":   compactPromptText(shot.VisualPrompt+"；光影："+shot.Lighting, 360),
 		"表演起始状态": compactPromptText(shot.Performance, 180),
-		"负面要求": compactPromptText(negative, 140),
+		"负面要求":   compactPromptText(negative, 140),
 	}
 }
 
@@ -1725,15 +1900,15 @@ func storyboardVideoPromptValues(projectStyle string, styleGuide string, shot ag
 	timeBeats := defaultString(strings.TrimSpace(shot.TimeBeats), fmt.Sprintf("0-%d秒：%s", shot.Duration, strings.TrimSpace(shot.Description)))
 	negative := defaultString(strings.TrimSpace(shot.Negative), "禁止换脸、服装变化、手部畸形、乱码、闪烁、风格突变和动作僵硬")
 	values := map[string]string{
-		"项目视觉": storyboardProjectVisualSummary(projectStyle, styleGuide),
-		"镜头意图": compactPromptText(shot.Intent+"；观众视点："+shot.ViewerPOV+"；情绪："+shot.Emotion, 150),
-		"首帧构图": compactPromptText(shot.VisualPrompt+"；光影："+shot.Lighting, 280),
+		"项目视觉":  storyboardProjectVisualSummary(projectStyle, styleGuide),
+		"镜头意图":  compactPromptText(shot.Intent+"；观众视点："+shot.ViewerPOV+"；情绪："+shot.Emotion, 150),
+		"首帧构图":  compactPromptText(shot.VisualPrompt+"；光影："+shot.Lighting, 280),
 		"表演与调度": compactPromptText(shot.Performance, 180),
-		"摄影机": compactPromptText(strings.TrimSpace(shot.ShotSize)+"；"+camera+"；主运镜："+motion, 220),
-		"时间节拍": compactPromptText(timeBeats, 240),
+		"摄影机":   compactPromptText(strings.TrimSpace(shot.ShotSize)+"；"+camera+"；主运镜："+motion, 220),
+		"时间节拍":  compactPromptText(timeBeats, 240),
 		"运动与结尾": compactPromptText(shot.VideoPrompt+"；连续性结尾："+shot.ContinuityOut, 240),
-		"声音": compactPromptText(strings.TrimSpace(shot.Dialogue)+"；音效："+strings.TrimSpace(shot.AudioEffects), 160),
-		"负面要求": compactPromptText(negative, 160),
+		"声音":    compactPromptText(strings.TrimSpace(shot.Dialogue)+"；音效："+strings.TrimSpace(shot.AudioEffects), 160),
+		"负面要求":  compactPromptText(negative, 160),
 	}
 	if len(shot.MustHave) > 0 {
 		priority := "必须完成：" + strings.Join(shot.MustHave, "；")

--- a/backend/internal/service/task_text_stream_test.go
+++ b/backend/internal/service/task_text_stream_test.go
@@ -1,0 +1,168 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"infinite-canvas/backend/internal/database"
+	"infinite-canvas/backend/internal/model"
+	"infinite-canvas/backend/internal/repository"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCreateTaskUsesSubmissionIDIdempotentlyPerUser(t *testing.T) {
+	svc, db := newTaskTextStreamTestService(t)
+	request := CreateTaskRequest{
+		SubmissionID: "submission-1",
+		Type:         "canvas_text",
+		Operation:    "text",
+		Prompt:       "写一段测试文案",
+		Input:        map[string]any{"mode": "text"},
+	}
+
+	first, err := svc.CreateTask("user-1", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := svc.CreateTask("user-1", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.ID != second.ID {
+		t.Fatalf("idempotent task IDs = %q, %q", first.ID, second.ID)
+	}
+
+	var count int64
+	if err := db.Model(&model.Task{}).Where("user_id = ? AND submission_id = ?", "user-1", request.SubmissionID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("task count = %d, want 1", count)
+	}
+
+	otherUser, err := svc.CreateTask("user-2", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if otherUser.ID == first.ID {
+		t.Fatal("submission ID was incorrectly shared across users")
+	}
+}
+
+func TestTaskTextStreamReplaysPartialDraft(t *testing.T) {
+	svc, db := newTaskTextStreamTestService(t)
+	task := model.Task{ID: "text-task-1", UserID: "user-1", Type: "canvas_text", Status: model.TaskStatusRunning, Prompt: "测试", Attempts: 1}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatal(err)
+	}
+	writer, err := svc.newTaskTextWriter(task)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Write("第一段"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Write("第二段"); err != nil {
+		t.Fatal(err)
+	}
+	if err := writer.Flush(); err != nil {
+		t.Fatal(err)
+	}
+
+	stream, err := svc.TaskTextStream("user-1", task.ID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stream.Chunks) != 1 || stream.Chunks[0].Sequence != 2 || stream.Chunks[0].Delta != "第二段" {
+		t.Fatalf("replayed chunks = %#v", stream.Chunks)
+	}
+}
+
+func TestRunTextTaskStreamHandlesResponsesAndChatCompletionsEvents(t *testing.T) {
+	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "true")
+	tests := []struct {
+		name          string
+		interfaceType string
+		path          string
+		events        string
+	}{
+		{
+			name:          "responses",
+			interfaceType: string(model.ChannelInterfaceOpenAIResponse),
+			path:          "/v1/responses",
+			events: "event: response.output_text.delta\n" +
+				"data: {\"type\":\"response.output_text.delta\",\"delta\":\"第一\"}\n\n" +
+				"event: response.output_text.delta\n" +
+				"data: {\"type\":\"response.output_text.delta\",\"delta\":\"段\"}\n\n" +
+				"data: [DONE]\n\n",
+		},
+		{
+			name:          "chat completions",
+			interfaceType: string(model.ChannelInterfaceChatCompletion),
+			path:          "/v1/chat/completions",
+			events: "data: {\"choices\":[{\"delta\":{\"content\":\"第一\"}}]}\n\n" +
+				"data: {\"choices\":[{\"delta\":{\"content\":\"段\"}}]}\n\n" +
+				"data: [DONE]\n\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				if request.URL.Path != test.path {
+					t.Errorf("path = %q, want %q", request.URL.Path, test.path)
+				}
+				var body map[string]any
+				if err := json.NewDecoder(request.Body).Decode(&body); err != nil {
+					t.Fatal(err)
+				}
+				if stream, _ := body["stream"].(bool); !stream {
+					t.Fatal("stream flag was not sent")
+				}
+				writer.Header().Set("Content-Type", "text/event-stream")
+				_, _ = writer.Write([]byte(test.events))
+			}))
+			defer server.Close()
+
+			var chunks []string
+			result, err := runTextTaskStream(context.Background(), canvasGenerationInput{
+				Mode:   "text",
+				Prompt: "写一句话",
+				Config: providerConfig{BaseURL: server.URL + "/v1", APIKey: "test-key", Model: "test-model", InterfaceType: test.interfaceType},
+			}, func(delta string) error {
+				chunks = append(chunks, delta)
+				return nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := strings.Join(chunks, ""); got != "第一段" {
+				t.Fatalf("deltas = %q", got)
+			}
+			if text, _ := result["text"].(string); text != "第一段" {
+				t.Fatalf("result = %#v", result)
+			}
+		})
+	}
+}
+
+func newTaskTextStreamTestService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file:"+newID()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := database.MigrateSchema(db); err != nil {
+		t.Fatal(err)
+	}
+	return New(repository.New(db), t.TempDir()), db
+}

--- a/web/src/pages/create/index.tsx
+++ b/web/src/pages/create/index.tsx
@@ -11,10 +11,9 @@ import { canvasResourceMentionToken } from "@/lib/canvas/canvas-resource-referen
 import { createClientId } from "@/lib/client-id";
 import { generationErrorMessage } from "@/lib/generation-error";
 import { VIDEO_RESOLUTION_OPTIONS } from "@/lib/video-generation-options";
-import { parseBackendGenerationResult, runBackendGenerationTask, runBackendGenerationTaskBatch, type BackendGenerationResult } from "@/services/api/generation-task";
-import { requestImageQuestion } from "@/services/api/image";
+import { parseBackendGenerationResult, runBackendGenerationTask, runBackendGenerationTaskBatch, submitBackendTextGenerationTask, type BackendGenerationResult } from "@/services/api/generation-task";
 import { listAddedSkills, type Skill } from "@/services/api/skills";
-import { listGenerationTasks, queryGenerationTask, type GenerationTask } from "@/services/api/task-center";
+import { cancelGenerationTask, getTaskTextChunks, listGenerationTasks, queryGenerationTask, recoverGenerationTasks, taskTextEventsUrl, type GenerationTask, type TaskTextStream } from "@/services/api/task-center";
 import { storeGeneratedVideo } from "@/services/api/video";
 import { resolveImageUrl, uploadImage, type UploadedImage } from "@/services/image-storage";
 import { modelDisplayName, modelOptionName, selectableModelsByCapability, useConfigStore, useEffectiveConfig } from "@/stores/use-config-store";
@@ -39,6 +38,9 @@ type CreationMessage = {
     references?: CreationReference[];
     settings?: CreationSettings;
     taskIds?: string[];
+    submissionId?: string;
+    textAttempt?: number;
+    textSequence?: number;
 };
 type CreationConversation = { id: string; title: string; updatedAt: string; messages: CreationMessage[] };
 
@@ -121,6 +123,8 @@ export default function CreatePage() {
     const followLatestMessageRef = useRef(true);
     const taskSyncWarningRef = useRef(false);
     const taskSyncInFlightRef = useRef(false);
+    const textSyncInFlightRef = useRef(false);
+    const textStopRequestedRef = useRef(false);
 
     const activeConversation = useMemo(() => conversations.find((item) => item.id === activeId) || conversations[0], [activeId, conversations]);
     const historyConversations = useMemo(
@@ -132,6 +136,12 @@ export default function CreatePage() {
     const isEmpty = !activeConversation?.messages.length;
     const pendingMediaKey = useMemo(() => pendingCreationMediaKey(conversations), [conversations]);
     const pendingTaskIds = useMemo(() => pendingCreationTaskIds(conversations), [conversations]);
+    const pendingTextTaskIds = useMemo(() => pendingCreationTextTaskIds(conversations), [conversations]);
+    const pendingTextSubmissionIds = useMemo(() => pendingCreationTextSubmissionIds(conversations), [conversations]);
+    const pendingTextTaskKey = pendingTextTaskIds.join("|");
+    const pendingTextSubmissionKey = pendingTextSubmissionIds.join("|");
+    const activeTextTaskId = useMemo(() => activeConversation?.messages.find((item) => item.role === "assistant" && item.mode === "text" && item.status === "streaming" && item.taskIds?.[0])?.taskIds?.[0], [activeConversation]);
+    const composerBusy = busy || Boolean(activeTextTaskId);
 
     useEffect(() => {
         let cancelled = false;
@@ -184,6 +194,67 @@ export default function CreatePage() {
             window.clearInterval(timer);
         };
     }, [hydrated, pendingMediaKey, pendingTaskIds, toast]);
+
+    useEffect(() => {
+        if (!hydrated || !pendingTextSubmissionKey) return;
+        let cancelled = false;
+        const submissionIds = pendingTextSubmissionKey.split("|").filter(Boolean);
+        void recoverGenerationTasks(submissionIds).then((tasks) => {
+            if (!cancelled) setConversations((current) => bindRecoveredTextTasks(current, tasks));
+        }).catch((error) => console.warn("文本创作任务恢复失败", error));
+        return () => {
+            cancelled = true;
+        };
+    }, [hydrated, pendingTextSubmissionKey]);
+
+    useEffect(() => {
+        if (!hydrated || !pendingTextTaskKey) return;
+        let cancelled = false;
+        const taskIds = pendingTextTaskKey.split("|").filter(Boolean);
+        const syncTextTasks = async () => {
+            if (textSyncInFlightRef.current) return;
+            textSyncInFlightRef.current = true;
+            try {
+                const streams = await Promise.all(taskIds.map((taskId) => getTaskTextChunks(taskId)));
+                if (!cancelled) setConversations((current) => reconcileTextTaskMessages(current, streams));
+            } catch (error) {
+                if (!cancelled) console.warn("文本创作任务状态同步失败", error);
+            } finally {
+                textSyncInFlightRef.current = false;
+            }
+        };
+        void syncTextTasks();
+        const timer = window.setInterval(() => void syncTextTasks(), 2000);
+        return () => {
+            cancelled = true;
+            window.clearInterval(timer);
+        };
+    }, [hydrated, pendingTextTaskKey]);
+
+    useEffect(() => {
+        if (!hydrated || !pendingTextTaskKey) return;
+        let cancelled = false;
+        const sources = pendingTextTaskKey.split("|").filter(Boolean).map((taskId) => {
+            const source = new EventSource(taskTextEventsUrl(taskId), { withCredentials: true });
+            source.addEventListener("delta", (event) => {
+                const payload = parseTextTaskEvent(event);
+                if (!payload || cancelled) return;
+                setConversations((current) => appendTextTaskDelta(current, taskId, payload.attempt, payload.sequence, payload.delta));
+            });
+            source.addEventListener("terminal", () => source.close());
+            source.onerror = () => source.close();
+            return source;
+        });
+        return () => {
+            cancelled = true;
+            sources.forEach((source) => source.close());
+        };
+    }, [hydrated, pendingTextTaskKey]);
+
+    useEffect(() => {
+        if (!hydrated) return;
+        setConversations((current) => markOrphanedTextDrafts(current));
+    }, [hydrated]);
 
     useEffect(() => {
         let cancelled = false;
@@ -267,7 +338,8 @@ export default function CreatePage() {
         const referenceMetadata = creationReferenceMetadata(references);
         followLatestMessageRef.current = true;
         const userMessage = newMessage("user", text, { mode, model: selectedModel, attachments, references, settings });
-        const assistantMessage = newMessage("assistant", "", { mode, model: selectedModel, status: mode === "text" ? "streaming" : "pending", settings });
+        const submissionId = mode === "text" ? createClientId() : "";
+        const assistantMessage = newMessage("assistant", "", { mode, model: selectedModel, status: mode === "text" ? "streaming" : "pending", settings, ...(submissionId ? { submissionId } : {}) });
         const boundTaskIds = new Set<string>();
         const boundTaskIdsByBatchIndex = new Map<number, string>();
         const bindTask = (task: GenerationTask) => {
@@ -286,18 +358,21 @@ export default function CreatePage() {
         setAttachments([]);
         setDraftReferences([]);
         setBusy(true);
+        if (mode === "text") textStopRequestedRef.current = false;
         const controller = new AbortController();
         abortRef.current = controller;
         const requestConfig = { ...config, model: selectedModel, imageModel: selectedModel, videoModel: selectedModel, textModel: selectedModel, size: ratio, videoSeconds: seconds, quality, vquality: videoQuality, count };
         try {
             if (mode === "text") {
-                const history = [...(activeConversation.messages || []), userMessage].map((item) => ({
-                    role: item.role,
-                    content: item.role === "user"
-                        ? buildTextMessageContent(item)
-                        : item.content,
-                }));
-                await requestImageQuestion(requestConfig, history, (text) => updateAssistant(assistantMessage.id, (item) => ({ ...item, content: text })), { signal: controller.signal });
+                const task = await submitBackendTextGenerationTask({
+                    submissionId,
+                    prompt: buildBackendTextPrompt([...activeConversation.messages, userMessage]),
+                    config: requestConfig,
+                    referenceImages: attachments,
+                    metadata: { source: "create-page", conversationId: activeConversation.id, messageId: assistantMessage.id, ...referenceMetadata },
+                    onTaskUpdate: bindTask,
+                });
+                if (textStopRequestedRef.current) await cancelGenerationTask(task.id);
             } else if (mode === "image") {
                 const taskCount = Math.max(1, Math.min(15, Math.floor(Number(count) || 1)));
                 const settled = await runBackendGenerationTaskBatch({
@@ -352,7 +427,7 @@ export default function CreatePage() {
                 addCreationAssetOnce(creationVideoAsset({ title: expandedPrompt.slice(0, 24), uploaded: storedVideo, metadata: { source: "create-generation", conversationId: activeConversation.id, messageId: assistantMessage.id, taskId, taskIds: Array.from(boundTaskIds), resultIndex: 0, prompt: expandedPrompt } }), { taskId, messageId: assistantMessage.id, resultIndex: 0 });
                 updateAssistant(assistantMessage.id, (item) => ({ ...item, status: "done", content: "视频已生成", resultUrls: [storedVideo.url] }));
             }
-            updateAssistant(assistantMessage.id, (item) => ({ ...item, status: "done" }));
+            if (mode !== "text") updateAssistant(assistantMessage.id, (item) => ({ ...item, status: "done" }));
         } catch (error) {
             if (controller.signal.aborted) {
                 updateAssistant(assistantMessage.id, (item) => ({ ...item, status: "cancelled", content: "已停止" }));
@@ -407,6 +482,7 @@ export default function CreatePage() {
         if (!previous?.content || busy) return;
         followLatestMessageRef.current = true;
         restoreMessageDraft(previous);
+        if (previous.mode === "text") return;
         const removedIds = new Set([item.id, previous.id]);
         updateActive((conversation) => {
             const messages = conversation.messages.filter((message) => !removedIds.has(message.id));
@@ -438,7 +514,7 @@ export default function CreatePage() {
         mode,
         prompt,
         setPrompt,
-        busy,
+        busy: composerBusy,
         attachments,
         references: mentionReferences,
         onRemoveAttachment: removeAttachment,
@@ -459,7 +535,17 @@ export default function CreatePage() {
         count,
         setCount,
         onSubmit: submit,
-        onStop: () => abortRef.current?.abort(),
+        onStop: () => {
+            if (activeTextTaskId) {
+                void cancelGenerationTask(activeTextTaskId).catch((error) => toast.error(generationErrorMessage(error)));
+                return;
+            }
+            if (mode === "text") {
+                textStopRequestedRef.current = true;
+                return;
+            }
+            abortRef.current?.abort();
+        },
     };
 
     return <>
@@ -506,7 +592,7 @@ function CreationHistoryDrawer({ open, conversations, activeId, onClose, onSelec
 function CreationMessageView({ item, modelName, onRetryFailure, onCreateVariant }: { item: CreationMessage; modelName: string; onRetryFailure: () => void; onCreateVariant: () => void }) {
     if (item.role === "user") return <CreationUserMessage item={item} />;
     const mode = item.mode || "text";
-    const stateLabel = item.status === "pending" ? "生成中" : item.status === "cancelled" ? "已停止" : "";
+    const stateLabel = item.status === "pending" || item.status === "streaming" ? "生成中" : item.status === "cancelled" ? "已停止" : "";
     return <article className="creation-assistant-message"><div className="creation-message-heading"><span className="creation-message-mark"><Sparkles /></span><span>{modeLabels[mode]}</span>{modelName ? <span className="creation-message-model">{modelName}</span> : null}{stateLabel ? <span className={`creation-message-state is-${item.status}`}>{stateLabel}</span> : null}</div>{mode === "text" ? <div className="creation-message-content">{item.content ? <ReactMarkdown>{item.content}</ReactMarkdown> : <span>正在生成…</span>}</div> : <MediaResult item={item} onRetryFailure={onRetryFailure} onCreateVariant={onCreateVariant} />}{item.error ? <div className="creation-message-error"><span>{generationErrorMessage(item.error)}</span><button type="button" onClick={onRetryFailure}><RefreshCw />重新生成</button></div> : null}</article>;
 }
 
@@ -668,11 +754,11 @@ function conversationPreviewMessage(conversation: CreationConversation) {
     return fallback;
 }
 
-function buildTextMessageContent(item: CreationMessage) {
-    const content = expandCreationPrompt(item.content, item.references || [], item.attachments || []);
-    const images = item.attachments || [];
-    if (!images.length) return content;
-    return [{ type: "text" as const, text: content }, ...images.map((image) => ({ type: "image_url" as const, image_url: { url: image.dataUrl || image.url || "" } }))];
+function buildBackendTextPrompt(messages: CreationMessage[]) {
+    return messages
+        .filter((item) => item.content.trim())
+        .map((item) => `${item.role === "assistant" ? "助手" : "用户"}：${expandCreationPrompt(item.content, item.references || [], item.attachments || [])}`)
+        .join("\n\n");
 }
 
 function removeReferenceTokens(value: string, references: CreationReference[]) {
@@ -689,6 +775,113 @@ function pendingCreationTaskIds(conversations: CreationConversation[]) {
         return message.taskIds || [];
     }));
     return Array.from(new Set(taskIds));
+}
+
+function pendingCreationTextTaskIds(conversations: CreationConversation[]) {
+    const taskIds = conversations.flatMap((conversation) => conversation.messages.flatMap((message) => {
+        if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming") return [];
+        return message.taskIds || [];
+    }));
+    return Array.from(new Set(taskIds));
+}
+
+function pendingCreationTextSubmissionIds(conversations: CreationConversation[]) {
+    return Array.from(new Set(conversations.flatMap((conversation) => conversation.messages.flatMap((message) => {
+        if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming" || !message.submissionId) return [];
+        return [message.submissionId];
+    }))));
+}
+
+function bindRecoveredTextTasks(conversations: CreationConversation[], tasks: GenerationTask[]) {
+    const bySubmissionID = new Map(tasks.filter((task) => task.submissionId).map((task) => [task.submissionId!, task]));
+    if (!bySubmissionID.size) return conversations;
+    return conversations.map((conversation) => {
+        let changed = false;
+        const messages = conversation.messages.map((message) => {
+            if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming" || !message.submissionId) return message;
+            const task = bySubmissionID.get(message.submissionId);
+            if (!task || message.taskIds?.includes(task.id)) return message;
+            changed = true;
+            return { ...message, taskIds: Array.from(new Set([...(message.taskIds || []), task.id])) };
+        });
+        return changed ? { ...conversation, messages, updatedAt: new Date().toISOString() } : conversation;
+    });
+}
+
+function appendTextTaskDelta(conversations: CreationConversation[], taskID: string, attempt: number, sequence: number, delta: string) {
+    if (!delta || !Number.isFinite(sequence)) return conversations;
+    return conversations.map((conversation) => {
+        let changed = false;
+        const messages = conversation.messages.map((message) => {
+            if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming" || !message.taskIds?.includes(taskID)) return message;
+            const previousAttempt = message.textAttempt ?? attempt;
+            if (attempt < previousAttempt) return message;
+            const reset = attempt > previousAttempt;
+            const previousSequence = reset ? 0 : message.textSequence || 0;
+            if (sequence <= previousSequence) return message;
+            changed = true;
+            return {
+                ...message,
+                content: `${reset ? "" : message.content}${delta}`,
+                textAttempt: attempt,
+                textSequence: sequence,
+            };
+        });
+        return changed ? { ...conversation, messages, updatedAt: new Date().toISOString() } : conversation;
+    });
+}
+
+function reconcileTextTaskMessages(conversations: CreationConversation[], streams: TaskTextStream[]) {
+    const byTaskID = new Map(streams.map((stream) => [stream.task.id, stream]));
+    return conversations.map((conversation) => {
+        let changed = false;
+        let updatedAt = conversation.updatedAt;
+        const messages = conversation.messages.map((message) => {
+            if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming") return message;
+            const stream = (message.taskIds || []).map((id) => byTaskID.get(id)).find(Boolean);
+            if (!stream) return message;
+            let next = message;
+            for (const chunk of stream.chunks) {
+                const merged = appendTextTaskDelta([{ ...conversation, messages: [next] }], stream.task.id, stream.attempt, chunk.sequence, chunk.delta)[0].messages[0];
+                next = merged;
+            }
+            if (stream.task.status === "succeeded") {
+                next = { ...next, status: "done", error: undefined };
+            } else if (stream.task.status === "failed") {
+                next = { ...next, status: "error", content: next.content || "未完成草稿", error: stream.task.error || "生成中断，草稿已保留" };
+            } else if (stream.task.status === "cancelled") {
+                next = { ...next, status: "cancelled", content: next.content || "已停止", error: undefined };
+            }
+            if (next !== message) {
+                changed = true;
+                updatedAt = stream.task.updatedAt || updatedAt;
+            }
+            return next;
+        });
+        return changed ? { ...conversation, messages, updatedAt } : conversation;
+    });
+}
+
+function markOrphanedTextDrafts(conversations: CreationConversation[]) {
+    return conversations.map((conversation) => {
+        let changed = false;
+        const messages = conversation.messages.map((message) => {
+            if (message.role !== "assistant" || message.mode !== "text" || message.status !== "streaming" || message.submissionId || message.taskIds?.length) return message;
+            changed = true;
+            return { ...message, status: "error" as const, content: message.content || "未完成草稿", error: "生成请求已中断，草稿已保留" };
+        });
+        return changed ? { ...conversation, messages, updatedAt: new Date().toISOString() } : conversation;
+    });
+}
+
+function parseTextTaskEvent(event: Event) {
+    try {
+        const value = JSON.parse((event as MessageEvent<string>).data) as { attempt?: unknown; sequence?: unknown; delta?: unknown };
+        if (typeof value.attempt !== "number" || typeof value.sequence !== "number" || typeof value.delta !== "string") return null;
+        return { attempt: value.attempt, sequence: value.sequence, delta: value.delta };
+    } catch {
+        return null;
+    }
 }
 
 async function enrichCreationTaskSummaries(tasks: GenerationTask[]) {

--- a/web/src/services/api/generation-task.ts
+++ b/web/src/services/api/generation-task.ts
@@ -1,7 +1,7 @@
 import { getMediaBlob } from "@/services/file-storage";
 import { getImageBlob } from "@/services/image-storage";
 import { resourceIdFromStorageKey, resourceStorageKey, uploadResourceFile } from "@/services/api/resources";
-import { createGenerationTask, waitForGenerationTask, type GenerationTask } from "@/services/api/task-center";
+import { createGenerationTask, isTaskRequestTransportUncertain, recoverGenerationTasks, waitForGenerationTask, type GenerationTask } from "@/services/api/task-center";
 import { resolveModelRequestConfig, type AiConfig } from "@/stores/use-config-store";
 import type { ReferenceImage } from "@/types/image";
 import type { ReferenceAudio, ReferenceVideo } from "@/types/media";
@@ -26,6 +26,16 @@ type BackendGenerationTaskOptions = {
     referenceAudios?: ReferenceAudio[];
     mask?: ReferenceImage;
     signal?: AbortSignal;
+    metadata?: Record<string, unknown>;
+    onTaskUpdate?: (task: GenerationTask) => void;
+};
+
+export type BackendTextGenerationTaskOptions = {
+    submissionId: string;
+    projectId?: string;
+    prompt: string;
+    config: AiConfig;
+    referenceImages?: ReferenceImage[];
     metadata?: Record<string, unknown>;
     onTaskUpdate?: (task: GenerationTask) => void;
 };
@@ -66,6 +76,46 @@ export async function runBackendGenerationTaskBatch(options: BackendGenerationTa
         ...options,
         metadata: { ...options.metadata, batchIndex, batchCount: count },
     }, prepared)));
+}
+
+// 文本创作只提交一次后台任务；页面重入后由 submissionId 重新关联，不将任务寿命绑定到当前页面。
+export async function submitBackendTextGenerationTask({
+    submissionId,
+    projectId,
+    prompt,
+    config,
+    referenceImages = [],
+    metadata,
+    onTaskUpdate,
+}: BackendTextGenerationTaskOptions) {
+    const prepared = await prepareGenerationReferences({ referenceImages });
+    try {
+        const task = await createGenerationTask({
+            submissionId,
+            ...(projectId ? { projectId } : {}),
+            type: "canvas_text",
+            operation: "text",
+            prompt,
+            model: config.model,
+            input: {
+                mode: "text",
+                prompt,
+                config: backendProviderConfig(config),
+                referenceImages: prepared.referenceImages,
+                referenceVideos: [],
+                referenceAudios: [],
+                metadata,
+            },
+        });
+        onTaskUpdate?.(task);
+        return task;
+    } catch (error) {
+        if (!isTaskRequestTransportUncertain(error)) throw error;
+        const [task] = await recoverGenerationTasks([submissionId]).catch(() => [] as GenerationTask[]);
+        if (!task) throw error;
+        onTaskUpdate?.(task);
+        return task;
+    }
 }
 
 function throwIfAborted(signal?: AbortSignal) {

--- a/web/src/services/api/task-center.ts
+++ b/web/src/services/api/task-center.ts
@@ -14,6 +14,7 @@ export type BackendEnvelope<T> = {
 
 export type GenerationTask = {
     id: string;
+    submissionId?: string;
     sessionId?: string;
     projectId?: string;
     type: string;
@@ -123,6 +124,7 @@ export type CreateSessionInput = {
 };
 
 export type CreateTaskInput = {
+    submissionId?: string;
     sessionId?: string;
     projectId?: string;
     type?: string;
@@ -131,6 +133,29 @@ export type CreateTaskInput = {
     provider?: string;
     model?: string;
     input?: Record<string, unknown>;
+};
+
+export class TaskRequestTransportError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "TaskRequestTransportError";
+    }
+}
+
+export function isTaskRequestTransportUncertain(error: unknown): error is TaskRequestTransportError {
+    return error instanceof TaskRequestTransportError;
+}
+
+export type TaskTextChunk = {
+    sequence: number;
+    delta: string;
+};
+
+export type TaskTextStream = {
+    task: GenerationTask;
+    attempt: number;
+    chunks: TaskTextChunk[];
+    nextSequence: number;
 };
 
 const api = axios.create({ baseURL: import.meta.env.VITE_CANVAS_BACKEND_URL || "/api", withCredentials: true });
@@ -183,7 +208,7 @@ export function uploadAgentFile(sessionId: string, file: File) {
 }
 
 export function createGenerationTask(input: CreateTaskInput) {
-    return request<GenerationTask>(api.post("/tasks", input)).then((task) => {
+    return createTaskRequest(input).then((task) => {
         notifyCanvasTaskCreated(task);
         // 创建任务时积分已被预占，不能等任务结束后才刷新可用余额。
         window.dispatchEvent(new CustomEvent("wallet:updated"));
@@ -191,8 +216,28 @@ export function createGenerationTask(input: CreateTaskInput) {
     });
 }
 
+async function createTaskRequest(input: CreateTaskInput) {
+    try {
+        const response = await api.post<BackendEnvelope<GenerationTask>>("/tasks", input);
+        if (response.data.code !== 0) throw new Error(response.data.msg || "请求失败");
+        return response.data.data;
+    } catch (error) {
+        if (axios.isAxiosError<BackendEnvelope<unknown>>(error)) {
+            if (!error.response) throw new TaskRequestTransportError(error.message || "任务提交连接中断");
+            throw new Error(error.response.data?.msg || error.message || "请求失败");
+        }
+        throw error;
+    }
+}
+
 export function listGenerationTasks(limit = 30, options?: { projectId?: string; activeOnly?: boolean }) {
     return request<GenerationTask[]>(api.get("/tasks", { params: { limit, projectId: options?.projectId, activeOnly: options?.activeOnly || undefined } }));
+}
+
+export function recoverGenerationTasks(submissionIds: string[]) {
+    const uniqueIds = Array.from(new Set(submissionIds.map((value) => value.trim()).filter(Boolean))).slice(0, 100);
+    if (!uniqueIds.length) return Promise.resolve([] as GenerationTask[]);
+    return request<GenerationTask[]>(api.post("/tasks/recover", { submissionIds: uniqueIds }));
 }
 
 export function queryGenerationTask(id: string, options?: { signal?: AbortSignal }) {
@@ -213,6 +258,15 @@ export function cancelGenerationTask(id: string) {
 
 export function listTaskLogs(id: string) {
     return request<TaskLog[]>(api.get(`/tasks/${encodeURIComponent(id)}/logs`));
+}
+
+export function getTaskTextChunks(id: string, after = 0) {
+    return request<TaskTextStream>(api.get(`/tasks/${encodeURIComponent(id)}/text-chunks`, { params: { after: Math.max(0, after) } }));
+}
+
+export function taskTextEventsUrl(id: string, after = 0) {
+    const baseUrl = String(api.defaults.baseURL || "/api").replace(/\/$/, "");
+    return `${baseUrl}/tasks/${encodeURIComponent(id)}/text-events?after=${Math.max(0, after)}`;
 }
 
 export async function waitForGenerationTask(id: string, options?: { signal?: AbortSignal; intervalMs?: number; timeoutMs?: number; initialTask?: GenerationTask; onTaskUpdate?: (task: GenerationTask) => void }) {


### PR DESCRIPTION
## What this PR adds

- Per-user idempotent `submissionId` for text generation submissions and task recovery.
- Persisted text deltas with authenticated replay via chunk API and SSE.
- Text-only Create-page migration: submit once, recover after navigation/reload, and retain partial drafts after failure or cancellation.

## Intentionally excluded

- Image/video task materialization, recovery, and page-unmount behavior are already covered upstream by #136 and #139.
- No Docker, deployment, or broad UI changes.

## Verification

- `go test ./internal/service -run '^$'`
- `go test ./internal/service -run TestRunTextTaskStreamHandlesResponsesAndChatCompletionsEvents -count=1`
- `go test ./internal/handler -run '^$'`
- `npm run build` in `web`

The full Go suite is not runnable in this Windows environment because its SQLite driver requires CGO; the targeted compilation and stream parser tests pass.