### PR TITLE
fix(canvas): 图片模型 - 修复 Grok 分辨率与节点 hover 抖动

### DIFF
--- a/backend/internal/service/model_capability.go
+++ b/backend/internal/service/model_capability.go
@@ -109,8 +109,8 @@ func DefaultImageCapabilityConfig(protocol string, modelName string) *ImageCapab
 	case model.ChannelInterfaceGrokImage:
 		image.References.MaxImages = 1
 		image.References.MaskSupported = false
-		image.Size = ImageSizeConfig{Parameter: "none", Values: []string{}, Default: "auto", AllowCustom: false}
-		image.Quality = ImageQualityConfig{Supported: false, Values: []string{}, Default: "auto"}
+		image.Size = ImageSizeConfig{Parameter: "aspect_ratio", Values: []string{"1:1", "9:16", "16:9", "4:3", "3:4"}, Default: "1:1", AllowCustom: false}
+		image.Quality = ImageQualityConfig{Supported: true, Values: []string{"1k", "2k"}, Default: "1k"}
 		image.TransparentBackground = VideoBooleanConfig{Supported: false, Default: false}
 		image.ResponseFormat = ParameterSupport{Supported: true}
 		image.OutputFormat = ParameterSupport{Supported: false}
@@ -423,10 +423,12 @@ func validateImageTask(profile *ImageCapabilityConfig, input canvasGenerationInp
 	if input.Mask != nil && !profile.References.MaskSupported {
 		return BadAuthRequest("当前图片模型不支持蒙版编辑")
 	}
-	if profile.Size.Parameter != "none" && !profile.Size.AllowCustom && strings.TrimSpace(input.Config.Size) != "" && !containsCapabilityString(profile.Size.Values, input.Config.Size) {
+	size := strings.TrimSpace(input.Config.Size)
+	if profile.Size.Parameter != "none" && !profile.Size.AllowCustom && size != "" && !strings.EqualFold(size, "auto") && !containsCapabilityString(profile.Size.Values, size) {
 		return BadAuthRequest("图片尺寸不在当前模型支持范围内")
 	}
-	if profile.Quality.Supported && strings.TrimSpace(input.Config.Quality) != "" && !containsCapabilityString(profile.Quality.Values, input.Config.Quality) {
+	quality := strings.TrimSpace(input.Config.Quality)
+	if profile.Quality.Supported && quality != "" && !strings.EqualFold(quality, "auto") && !containsCapabilityString(profile.Quality.Values, quality) {
 		return BadAuthRequest("图片质量不在当前模型支持范围内")
 	}
 	count, err := strconv.Atoi(strings.TrimSpace(input.Config.Count))

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -747,6 +747,22 @@ func grokImageRequestBody(input canvasGenerationInput) (grokImageRequest, string
 		return grokImageRequest{}, "", errors.New("Grok 图片协议不支持蒙版编辑，请移除蒙版后重试")
 	}
 	body := grokImageRequest{Model: input.Config.Model, Prompt: withSystemPrompt(input.Config, input.Prompt), N: 1, ResponseFormat: "url"}
+	size := input.Config.Size
+	quality := input.Config.Quality
+	if input.ImageCapability != nil {
+		if strings.TrimSpace(size) == "" || strings.EqualFold(strings.TrimSpace(size), "auto") {
+			size = input.ImageCapability.Size.Default
+		}
+		if strings.TrimSpace(quality) == "" || strings.EqualFold(strings.TrimSpace(quality), "auto") {
+			quality = input.ImageCapability.Quality.Default
+		}
+	}
+	if aspectRatio := normalizeGrokImageAspectRatio(size); aspectRatio != "" {
+		body.AspectRatio = aspectRatio
+	}
+	if resolution := normalizeGrokImageResolution(quality); resolution != "" {
+		body.Resolution = resolution
+	}
 	if len(input.ReferenceImages) == 0 {
 		return body, "/images/generations", nil
 	}
@@ -759,6 +775,26 @@ func grokImageRequestBody(input canvasGenerationInput) (grokImageRequest, string
 	}
 	body.Image = &grokImageInput{URL: imageURL}
 	return body, "/images/edits", nil
+}
+
+func normalizeGrokImageAspectRatio(value string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	switch normalized {
+	case "1:1", "9:16", "16:9", "4:3", "3:4":
+		return normalized
+	default:
+		return ""
+	}
+}
+
+func normalizeGrokImageResolution(value string) string {
+	normalized := strings.TrimSpace(strings.ToLower(value))
+	switch normalized {
+	case "1k", "2k":
+		return normalized
+	default:
+		return ""
+	}
 }
 
 func grokImageInputURL(media providerMedia) (string, error) {

--- a/backend/internal/service/provider_request_types.go
+++ b/backend/internal/service/provider_request_types.go
@@ -57,6 +57,8 @@ type grokImageRequest struct {
 	Prompt         string          `json:"prompt"`
 	Image          *grokImageInput `json:"image,omitempty"`
 	N              int             `json:"n"`
+	AspectRatio    string          `json:"aspect_ratio,omitempty"`
+	Resolution     string          `json:"resolution,omitempty"`
 	ResponseFormat string          `json:"response_format"`
 }
 

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -218,6 +218,45 @@ func TestGrokImageRequestBodyPrefersPublicURL(t *testing.T) {
 	}
 }
 
+func TestGrokImageRequestBodyMapsAspectRatioAndResolution(t *testing.T) {
+	body, path, err := grokImageRequestBody(canvasGenerationInput{
+		Config: providerConfig{Model: "grok-imagine-image", InterfaceType: "grok-image", Size: "9:16", Quality: "2k"},
+	})
+	if err != nil {
+		t.Fatalf("grokImageRequestBody() error = %v", err)
+	}
+	if path != "/images/generations" || body.AspectRatio != "9:16" || body.Resolution != "2k" {
+		t.Fatalf("path = %q, aspect_ratio = %q, resolution = %q", path, body.AspectRatio, body.Resolution)
+	}
+}
+
+func TestGrokImageRequestBodyUsesCapabilityDefaultsForAutoValues(t *testing.T) {
+	profile := DefaultImageCapabilityConfig("grok-image", "grok-imagine-image")
+	input := canvasGenerationInput{
+		Config:          providerConfig{Model: "grok-imagine-image", InterfaceType: "grok-image", Size: "auto", Quality: "auto"},
+		ImageCapability: profile,
+	}
+	if err := validateImageTask(profile, input); err != nil {
+		t.Fatalf("validateImageTask() error = %v", err)
+	}
+	body, _, err := grokImageRequestBody(input)
+	if err != nil {
+		t.Fatalf("grokImageRequestBody() error = %v", err)
+	}
+	if body.AspectRatio != "1:1" || body.Resolution != "1k" {
+		t.Fatalf("aspect_ratio = %q, resolution = %q", body.AspectRatio, body.Resolution)
+	}
+}
+
+func TestNormalizeGrokImageResolution(t *testing.T) {
+	if got := normalizeGrokImageResolution("2K"); got != "2k" {
+		t.Fatalf("normalizeGrokImageResolution(2K) = %q, want 2k", got)
+	}
+	if got := normalizeGrokImageResolution("high"); got != "" {
+		t.Fatalf("normalizeGrokImageResolution(high) = %q, want empty", got)
+	}
+}
+
 func TestNormalizePixelSizeConvertsCanvasAspectRatios(t *testing.T) {
 	tests := map[string]string{
 		"1:1":  "1024x1024",

--- a/web/src/components/canvas/canvas-node.tsx
+++ b/web/src/components/canvas/canvas-node.tsx
@@ -325,6 +325,7 @@ export const CanvasNode = React.memo(function CanvasNode({
                 translateDepth={cometTranslate}
                 disabled={cometDisabled}
                 glare={!isGeneratingNode}
+                motionTransforms={false}
                 data-state={data.metadata?.status || (isActive ? "active" : isRelated ? "related" : "idle")}
                 style={{
                     background: hasImageContent || hasVideoContent ? "transparent" : theme.node.fill,

--- a/web/src/components/image-settings-panel.tsx
+++ b/web/src/components/image-settings-panel.tsx
@@ -7,6 +7,8 @@ import { type AiConfig } from "@/stores/use-config-store";
 
 const qualityOptions = [
     { value: "auto", label: "自动" },
+    { value: "1k", label: "1K" },
+    { value: "2k", label: "2K" },
     { value: "high", label: "高" },
     { value: "medium", label: "中" },
     { value: "low", label: "低" },
@@ -78,7 +80,7 @@ export function ImageSettingsPanel({ config, onConfigChange, theme, showTitle = 
             >
                 {showTitle ? <div className="text-base font-semibold">图像设置</div> : null}
                 {profile.quality.supported ? <div className="space-y-2">
-                    <SettingTitle color={theme.node.muted}>质量</SettingTitle>
+                    <SettingTitle color={theme.node.muted}>{profile.quality.values.length > 0 && profile.quality.values.every((value) => /^\d+k$/i.test(value)) ? "分辨率" : "质量"}</SettingTitle>
                     <div className="grid grid-cols-4 gap-1.5">
                         {activeQualityOptions.map((item) => (
                             <OptionPill key={item.value} selected={quality === item.value} theme={theme} onClick={() => onConfigChange("quality", item.value)}>
@@ -181,7 +183,7 @@ export function ImageSettingsTheme({ theme, children }: { theme: CanvasTheme; ch
 }
 
 export function imageQualityLabel(value: string) {
-    return ({ auto: "自动", high: "高", medium: "中", low: "低" } as Record<string, string>)[value] || "默认";
+    return ({ auto: "自动", "1k": "1K", "2k": "2K", high: "高", medium: "中", low: "低" } as Record<string, string>)[value] || "默认";
 }
 
 export function imageSizeLabel(size: string) {

--- a/web/src/components/model-capability-editor.tsx
+++ b/web/src/components/model-capability-editor.tsx
@@ -100,6 +100,7 @@ function ImageCapabilityEditor({ value, onChange, protocol, model, disabled }: R
     const updateReferences = (patch: Partial<ImageCapabilityConfig["references"]>) => update({ references: { ...profile.references, ...patch } });
     const updateSize = (patch: Partial<ImageCapabilityConfig["size"]>) => update({ size: { ...profile.size, ...patch } });
     const updateQuality = (patch: Partial<ImageCapabilityConfig["quality"]>) => update({ quality: { ...profile.quality, ...patch } });
+    const qualityKindLabel = profile.quality.values.length > 0 && profile.quality.values.every((value) => /^\d+k$/i.test(value)) ? "分辨率" : "图片质量";
 
     return (
         <div className="space-y-3 rounded-md border border-border/70 bg-muted/10 p-3">
@@ -139,10 +140,10 @@ function ImageCapabilityEditor({ value, onChange, protocol, model, disabled }: R
             </CapabilityGroup>
 
             <CapabilityGroup title="可选生成参数">
-                <ParameterField label="图片质量" description="发送 quality 参数" supported={profile.quality.supported} disabled={disabled} onChange={(supported) => updateQuality({ supported })} />
+                <ParameterField label={qualityKindLabel} description={qualityKindLabel === "分辨率" ? "发送 resolution 参数" : "发送 quality 参数"} supported={profile.quality.supported} disabled={disabled} onChange={(supported) => updateQuality({ supported })} />
                 {profile.quality.supported ? <div className="grid gap-2 sm:grid-cols-2">
-                    <Field label="质量支持值"><Select mode="tags" className="w-full" disabled={disabled} value={profile.quality.values} tokenSeparators={[","]} onChange={(values) => updateQuality({ values, default: values.includes(profile.quality.default) ? profile.quality.default : values[0] || "auto" })} /></Field>
-                    <Field label="默认质量"><Select className="w-full" disabled={disabled} value={profile.quality.default} options={profile.quality.values.map((item) => ({ label: item, value: item }))} onChange={(defaultValue) => updateQuality({ default: defaultValue })} /></Field>
+                    <Field label={`${qualityKindLabel}支持值`}><Select mode="tags" className="w-full" disabled={disabled} value={profile.quality.values} tokenSeparators={[","]} onChange={(values) => updateQuality({ values, default: values.includes(profile.quality.default) ? profile.quality.default : values[0] || "auto" })} /></Field>
+                    <Field label={`默认${qualityKindLabel}`}><Select className="w-full" disabled={disabled} value={profile.quality.default} options={profile.quality.values.map((item) => ({ label: item, value: item }))} onChange={(defaultValue) => updateQuality({ default: defaultValue })} /></Field>
                 </div> : null}
                 <BooleanField label="透明背景" value={profile.transparentBackground} disabled={disabled} onChange={(transparentBackground) => update({ transparentBackground })} />
                 <div className="grid gap-2 sm:grid-cols-2">

--- a/web/src/components/ui/aceternity/comet-card.tsx
+++ b/web/src/components/ui/aceternity/comet-card.tsx
@@ -11,6 +11,7 @@ type CometCardProps = Omit<HTMLMotionProps<"div">, "children"> & {
     translateDepth?: number;
     disabled?: boolean;
     glare?: boolean;
+    motionTransforms?: boolean;
 };
 
 const windowBlurSubscribers = new Set<() => void>();
@@ -35,7 +36,7 @@ function resetCometCardsAfterWindowBlur() {
     windowBlurSubscribers.forEach((reset) => reset());
 }
 
-export function CometCard({ containerClassName, className, rotateDepth = 5.5, translateDepth = 5, disabled = false, glare = true, children, style, onMouseEnter, onMouseMove, onMouseLeave, onPointerCancel, ...props }: CometCardProps) {
+export function CometCard({ containerClassName, className, rotateDepth = 5.5, translateDepth = 5, disabled = false, glare = true, motionTransforms = true, children, style, onMouseEnter, onMouseMove, onMouseLeave, onPointerCancel, ...props }: CometCardProps) {
     const reducedMotion = useReducedMotion();
     const motionEnabled = !disabled && !reducedMotion;
     const [motionActive, setMotionActive] = useState(false);
@@ -51,7 +52,8 @@ export function CometCard({ containerClassName, className, rotateDepth = 5.5, tr
     const glareX = useTransform(springX, [-0.5, 0.5], [12, 88]);
     const glareY = useTransform(springY, [-0.5, 0.5], [8, 92]);
     const glareBackground = useMotionTemplate`radial-gradient(circle at ${glareX}% ${glareY}%, rgba(255,255,255,.78) 0%, rgba(255,255,255,.24) 22%, rgba(255,255,255,0) 66%)`;
-    const motionStyle: MotionStyle = motionEnabled && motionActive ? { ...(style as MotionStyle), rotateX, rotateY, x: translateX, y: translateY } : { ...(style as MotionStyle) };
+    const transformEnabled = motionEnabled && motionTransforms;
+    const motionStyle: MotionStyle = transformEnabled && motionActive ? { ...(style as MotionStyle), rotateX, rotateY, x: translateX, y: translateY } : { ...(style as MotionStyle) };
 
     const clearSettleTimer = useCallback(() => {
         if (settleTimerRef.current === null) return;
@@ -93,7 +95,7 @@ export function CometCard({ containerClassName, className, rotateDepth = 5.5, tr
                 className={cn("aceternity-comet-card relative h-full w-full", className)}
                 data-comet-active={motionEnabled && motionActive ? "true" : "false"}
                 style={motionStyle}
-                whileHover={motionEnabled && motionActive ? { scale: 1.022, z: 28 } : undefined}
+                whileHover={transformEnabled && motionActive ? { scale: 1.022, z: 28 } : undefined}
                 transition={aceternityMotion.spring.surface}
                 onMouseEnter={(event) => {
                     if (motionEnabled) {

--- a/web/src/lib/model-capabilities.ts
+++ b/web/src/lib/model-capabilities.ts
@@ -77,8 +77,8 @@ export function defaultImageCapabilityConfig(protocol?: ModelProtocol, model = "
     if (protocol === "grok-image") {
         image.references.maxImages = 1;
         image.references.maskSupported = false;
-        image.size = { parameter: "none", values: [], default: "auto", allowCustom: false };
-        image.quality = { supported: false, values: [], default: "auto" };
+        image.size = { parameter: "aspect_ratio", values: ["1:1", "9:16", "16:9", "4:3", "3:4"], default: "1:1", allowCustom: false };
+        image.quality = { supported: true, values: ["1k", "2k"], default: "1k" };
         image.transparentBackground = { supported: false, default: false };
         image.responseFormat = { supported: true };
         image.outputFormat = { supported: false };

--- a/web/src/pages/create/index.tsx
+++ b/web/src/pages/create/index.tsx
@@ -58,6 +58,8 @@ const ratioOptions = [
 ];
 const qualityOptions = [
     { value: "auto", label: "自动", description: "由模型决定" },
+    { value: "1k", label: "1K", description: "标准分辨率" },
+    { value: "2k", label: "2K", description: "高分辨率" },
     { value: "low", label: "低", description: "更快生成" },
     { value: "medium", label: "中", description: "均衡模式" },
     { value: "high", label: "高", description: "优先细节" },
@@ -778,6 +780,7 @@ function GenerationSettingsMenu(props: ComposerProps) {
     const [open, setOpen] = useState(false);
     const [customRatioOpen, setCustomRatioOpen] = useState(!ratioOptions.some((option) => option.value === props.ratio));
     const qualityLabel = qualityOptions.find((item) => item.value === props.quality)?.label || "自动";
+    const qualityTitle = props.imageProfile.quality.values.length > 0 && props.imageProfile.quality.values.every((value) => /^\d+k$/i.test(value)) ? "分辨率" : "图片质量";
     const ratios = props.mode === "video" ? props.videoProfile.ratios : props.imageProfile.size.values.length ? props.imageProfile.size.values : ratioOptions.map((item) => item.value);
     const resolutions = props.mode === "video" ? props.videoProfile.resolutions.map((value) => ({ value: value.replace(/p$/i, ""), label: videoResolutionLabel(value) })) : resolutionOptions;
     const imageSummary = [
@@ -789,7 +792,7 @@ function GenerationSettingsMenu(props: ComposerProps) {
     const panel = <div className="creation-parameter-menu">
         {props.mode === "video" || props.imageProfile.size.parameter !== "none" ? <SettingSection title="画幅" value={props.ratio}><div className="creation-parameter-content"><div className="creation-choice-grid is-ratio">{ratios.map((value) => <button key={value} type="button" aria-pressed={value === props.ratio} className={value === props.ratio ? "is-selected" : ""} onClick={() => { props.setRatio(value); setCustomRatioOpen(false); }}><span className="creation-ratio-preview"><span style={ratioPreviewStyle(value)} /></span><span>{value}</span></button>)}</div>{props.mode !== "video" && props.imageProfile.size.allowCustom && (customRatioOpen ? <label className="creation-custom-value"><span>宽 : 高</span><input value={props.ratio} onFocus={(event) => event.currentTarget.select()} onChange={(event) => props.setRatio(event.target.value)} placeholder="1920x1080 或 2:1" aria-label="自定义画幅，支持宽x高或比例" /></label> : <button type="button" className="creation-custom-trigger" onClick={() => setCustomRatioOpen(true)}><Plus />输入自定义比例</button>)}</div></SettingSection> : null}
         {props.mode === "video" ? <SettingSection title="清晰度" value={videoResolutionLabel(props.videoQuality)}><div className="creation-choice-grid is-resolution">{resolutions.map((option) => <button key={option.value} type="button" aria-pressed={option.value === props.videoQuality} className={option.value === props.videoQuality ? "is-selected" : ""} onClick={() => props.setVideoQuality(option.value)}>{option.label}</button>)}</div></SettingSection> : <>
-            {props.imageProfile.quality.supported ? <SettingSection title="图片质量" value={qualityLabel}><div className="creation-choice-grid is-quality">{qualityOptions.filter((option) => props.imageProfile.quality.values.includes(option.value)).map((option) => <button key={option.value} type="button" aria-pressed={option.value === props.quality} className={option.value === props.quality ? "is-selected" : ""} onClick={() => props.setQuality(option.value)}><span>{option.label}</span><small>{option.description}</small></button>)}</div></SettingSection> : null}
+            {props.imageProfile.quality.supported ? <SettingSection title={qualityTitle} value={qualityLabel}><div className="creation-choice-grid is-quality">{qualityOptions.filter((option) => props.imageProfile.quality.values.includes(option.value)).map((option) => <button key={option.value} type="button" aria-pressed={option.value === props.quality} className={option.value === props.quality ? "is-selected" : ""} onClick={() => props.setQuality(option.value)}><span>{option.label}</span><small>{option.description}</small></button>)}</div></SettingSection> : null}
             {props.imageProfile.maxOutputs > 1 ? <SettingSection title="生成数量" value={`${props.count} 张`}><div className="creation-parameter-content"><div className="creation-choice-grid is-count">{countOptions.filter((option) => Number(option) <= props.imageProfile.maxOutputs).map((option) => <button key={option} type="button" aria-pressed={option === props.count} className={option === props.count ? "is-selected" : ""} onClick={() => props.setCount(option)}>{option}</button>)}</div><label className="creation-custom-value"><span>自定义</span><input inputMode="numeric" pattern="[0-9]*" value={props.count} onChange={(event) => props.setCount(String(Math.max(1, Math.min(props.imageProfile.maxOutputs, Number(event.target.value) || 1))))} aria-label={`生成数量，范围 1 到 ${props.imageProfile.maxOutputs}`} /><em>张</em></label></div></SettingSection> : null}
         </>}
     </div>;

--- a/web/src/services/api/image.ts
+++ b/web/src/services/api/image.ts
@@ -124,6 +124,11 @@ function normalizeQuality(quality: string) {
     return QUALITY_BASE[normalized] ? normalized : undefined;
 }
 
+function normalizeGrokImageResolution(quality: string | undefined) {
+    const value = quality?.trim().toLowerCase();
+    return value === "1k" || value === "2k" ? value : undefined;
+}
+
 /** Map "quality + ratio" to an explicit pixel dimension like "3840x2160". */
 function resolveSize(quality: string | undefined, ratio: string): string {
     const parsedRatio = parseImageRatio(ratio);
@@ -813,6 +818,8 @@ export async function requestGeneration(config: AiConfig, prompt: string, option
         }
     }
     if (requestConfig.interfaceType === "grok-image") {
+        const requestSize = resolveImageRequestSize(imageProfile, undefined, normalizedImage.size);
+        const resolution = normalizeGrokImageResolution(normalizedImage.quality);
         try {
             const responseData = await postChannelJSON<ImageApiResponse>(
                 requestConfig,
@@ -821,6 +828,8 @@ export async function requestGeneration(config: AiConfig, prompt: string, option
                     model: requestConfig.model,
                     prompt: withSystemPrompt(requestConfig, prompt),
                     n,
+                    ...(requestSize ? { [requestSize.parameter]: requestSize.value } : {}),
+                    ...(resolution ? { resolution } : {}),
                     response_format: "url",
                 },
                 options,
@@ -896,6 +905,8 @@ export async function requestEdit(config: AiConfig, prompt: string, references: 
     if (requestConfig.interfaceType === "grok-image") {
         if (mask) throw new Error("Grok 图片协议不支持蒙版编辑，请移除蒙版后重试");
         if (references.length !== 1) throw new Error("Grok 图片编辑必须提供且仅支持 1 张参考图");
+        const requestSize = resolveImageRequestSize(imageProfile, undefined, normalizedImage.size);
+        const resolution = normalizeGrokImageResolution(normalizedImage.quality);
         try {
             const imageUrl = await grokImageInputURL(references[0]);
             const response = await postChannelJSON<ImageApiResponse>(
@@ -906,6 +917,8 @@ export async function requestEdit(config: AiConfig, prompt: string, references: 
                     prompt: withSystemPrompt(requestConfig, requestPrompt),
                     image: { url: imageUrl },
                     n,
+                    ...(requestSize ? { [requestSize.parameter]: requestSize.value } : {}),
+                    ...(resolution ? { resolution } : {}),
                     response_format: "url",
                 },
                 options,

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -5319,16 +5319,8 @@
         box-shadow: 0 18px 48px rgba(15, 23, 42, 0.1), 0 2px 6px rgba(15, 23, 42, 0.06);
     }
 
-    .canvas-node-shell.aceternity-comet-card:hover {
-        box-shadow: 0 30px 80px rgba(15, 23, 42, 0.18), 0 6px 20px rgba(15, 23, 42, 0.1);
-    }
-
     .dark .canvas-node-shell.aceternity-comet-card {
         box-shadow: 0 22px 60px rgba(0, 0, 0, 0.34), 0 2px 8px rgba(0, 0, 0, 0.3);
-    }
-
-    .dark .canvas-node-shell.aceternity-comet-card:hover {
-        box-shadow: 0 34px 90px rgba(0, 0, 0, 0.52), 0 8px 26px rgba(0, 0, 0, 0.36);
     }
 
     [data-canvas-viewport-interacting="true"] .canvas-node-shell,


### PR DESCRIPTION
## Summary
- 开放 grok-image 默认 aspect_ratio 能力与 1k/2k 分辨率选项
- 在前端直发与后端任务路径中把图片 quality 里的 1k/2k 映射为上游 resolution，并同时传递 aspect_ratio
- 禁止画布节点 CometCard 对交互外壳做 hover translate/rotate/scale，只保留静态边框、阴影和 glare 反馈，减少 hover 抖动

## Review notes
- 非 grok-image 协议的 grok-imagine-image 模型名前缀兜底保持原有不发送尺寸/质量行为，避免误给普通图片协议发送 resolution 语义
- 后端兼容旧配置里的 auto/空值，grok-image 请求体会回落到能力默认值 1:1 / 1k
- CometCard 新增 motionTransforms 开关，默认保持原行为，仅画布节点关闭几何 transform

## Validation
- gofmt: backend/internal/service/model_capability.go backend/internal/service/provider.go backend/internal/service/provider_test.go
- git diff --check
- 未运行测试/构建（遵循仓库 AGENTS.md 默认验证纪律）

Fixes #178
Fixes #182
Refs #181