### PR TITLE
fix(channels): decrypt encrypted system credentials before provider calls

### DIFF
--- a/backend/internal/service/admin.go
+++ b/backend/internal/service/admin.go
@@ -447,7 +447,25 @@ func (s *Service) PublicSystemChannels() ([]PublicModelChannel, error) {
 }
 
 func (s *Service) SystemChannel(id string) (*model.ModelChannel, error) {
-	return s.repo.SystemChannel(id)
+	channel, err := s.repo.SystemChannel(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.decryptSystemChannelSecrets(channel); err != nil {
+		return nil, err
+	}
+	return channel, nil
+}
+
+func (s *Service) adminSystemChannel(id string) (*model.ModelChannel, error) {
+	channel, err := s.repo.AdminSystemChannel(id)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.decryptSystemChannelSecrets(channel); err != nil {
+		return nil, err
+	}
+	return channel, nil
 }
 
 func (s *Service) AdminSystemChannelPage(actor *model.User, query AdminListQuery) (*AdminChannelPage, error) {
@@ -488,6 +506,9 @@ func (s *Service) CreateSystemChannel(actor *model.User, req ChannelRequest) (*P
 	if err != nil {
 		return nil, err
 	}
+	if err := s.encryptSystemChannelSecrets(&channel); err != nil {
+		return nil, err
+	}
 	if err := s.repo.Create(&channel); err != nil {
 		return nil, err
 	}
@@ -510,6 +531,9 @@ func (s *Service) UpdateSystemChannel(actor *model.User, id string, req ChannelR
 	if err != nil {
 		return nil, err
 	}
+	if err := s.decryptSystemChannelSecrets(channel); err != nil {
+		return nil, err
+	}
 	req = mergeChannelRequest(req, *channel)
 	next, err := channelFromRequest(req, *channel)
 	if err != nil {
@@ -525,6 +549,9 @@ func (s *Service) UpdateSystemChannel(actor *model.User, id string, req ChannelR
 	if req.SecretKey == "" {
 		next.SecretKey = channel.SecretKey
 	}
+	if err := s.encryptSystemChannelSecrets(&next); err != nil {
+		return nil, err
+	}
 	if err := s.repo.Save(&next); err != nil {
 		return nil, err
 	}
@@ -537,6 +564,34 @@ func (s *Service) UpdateSystemChannel(actor *model.User, id string, req ChannelR
 	}
 	public := publicChannel(next, true, items)
 	return &public, nil
+}
+
+func (s *Service) encryptSystemChannelSecrets(channel *model.ModelChannel) error {
+	apiKey, err := s.encryptSettingSecret(channel.APIKey)
+	if err != nil {
+		return err
+	}
+	secretKey, err := s.encryptSettingSecret(channel.SecretKey)
+	if err != nil {
+		return err
+	}
+	channel.APIKey = apiKey
+	channel.SecretKey = secretKey
+	return nil
+}
+
+func (s *Service) decryptSystemChannelSecrets(channel *model.ModelChannel) error {
+	apiKey, err := s.decryptSettingSecret(channel.APIKey)
+	if err != nil {
+		return err
+	}
+	secretKey, err := s.decryptSettingSecret(channel.SecretKey)
+	if err != nil {
+		return err
+	}
+	channel.APIKey = apiKey
+	channel.SecretKey = secretKey
+	return nil
 }
 
 func (s *Service) DeleteSystemChannel(actor *model.User, id string) error {

--- a/backend/internal/service/channel_models.go
+++ b/backend/internal/service/channel_models.go
@@ -88,7 +88,7 @@ func (s *Service) FetchAdminChannelModels(ctx context.Context, actor *model.User
 	if err := s.RequireAdmin(actor); err != nil {
 		return nil, err
 	}
-	channel, err := s.repo.AdminSystemChannel(channelID)
+	channel, err := s.adminSystemChannel(channelID)
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (s *Service) TestAdminChannelModel(ctx context.Context, actor *model.User, 
 	if err := s.RequireAdmin(actor); err != nil {
 		return nil, err
 	}
-	channel, err := s.repo.AdminSystemChannel(channelID)
+	channel, err := s.adminSystemChannel(channelID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -572,7 +572,7 @@ func (s *Service) resolveProviderConfig(config providerConfig) (providerConfig, 
 		}
 		return config, nil
 	}
-	channel, err := s.repo.SystemChannel(channelID)
+	channel, err := s.SystemChannel(channelID)
 	if err != nil {
 		return providerConfig{}, errors.New("系统渠道不存在或已停用")
 	}


### PR DESCRIPTION
## Summary

System-channel API and secret keys are persisted encrypted at rest. Runtime provider resolution and the authenticated system proxy were reading the encrypted record directly, so requests could forward an `enc:v1:` value as a bearer token and fail upstream with `The API key format is incorrect`.

## Changes

- Encrypt API and secret keys when system channels are created or updated.
- Decrypt system-channel secrets only after loading them for an enabled runtime request.
- Use the same decrypted view for administrator model discovery and model tests, while retaining management access for disabled channels.

## Verification

- `CGO_ENABLED=0 go build ./cmd/server`
- The existing targeted service test is currently blocked by an unrelated upstream test compile failure: `provider_stream_test.go: undefined: runTextTaskStream`.

- [x] No keys, database contents, logs, or local configuration included.