### PR TITLE
fix(volcengine): normalize Ark image minimum size

### DIFF
--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -833,7 +833,10 @@ func grokImageInputURL(media providerMedia) (string, error) {
 	return openAIImageInputURL(media)
 }
 
-const volcengineArkImageMaxPixels = 4624220
+const (
+	volcengineArkImageMinPixels = 3686400
+	volcengineArkImageMaxPixels = 4624220
+)
 
 func runVolcengineArkImageTask(ctx context.Context, input canvasGenerationInput) (map[string]interface{}, error) {
 	if input.Mask != nil {
@@ -896,12 +899,26 @@ func normalizeVolcengineArkImageSize(value string) string {
 	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
 		return size
 	}
-	if int64(width)*int64(height) <= volcengineArkImageMaxPixels {
+	pixels := int64(width) * int64(height)
+	if pixels >= volcengineArkImageMinPixels && pixels <= volcengineArkImageMaxPixels {
 		return size
 	}
-	scale := math.Sqrt(float64(volcengineArkImageMaxPixels) / (float64(width) * float64(height)))
-	width = int(math.Floor(float64(width)*scale/2)) * 2
-	height = int(math.Floor(float64(height)*scale/2)) * 2
+	targetPixels := volcengineArkImageMaxPixels
+	round := math.Floor
+	if pixels < volcengineArkImageMinPixels {
+		targetPixels = volcengineArkImageMinPixels
+		round = math.Ceil
+	}
+	scale := math.Sqrt(float64(targetPixels) / float64(pixels))
+	width = int(round(float64(width)*scale/2)) * 2
+	height = int(round(float64(height)*scale/2)) * 2
+	for width > 2 && height > 2 && int64(width)*int64(height) < volcengineArkImageMinPixels {
+		if width >= height {
+			width += 2
+		} else {
+			height += 2
+		}
+	}
 	for width > 2 && height > 2 && int64(width)*int64(height) > volcengineArkImageMaxPixels {
 		if width >= height {
 			width -= 2

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -142,8 +142,29 @@ func TestVolcengineArkImageBodyUsesJSONReferencesAndDownscalesSize(t *testing.T)
 	}
 	width, _ := strconv.Atoi(parts[0])
 	height, _ := strconv.Atoi(parts[1])
-	if width%2 != 0 || height%2 != 0 || int64(width)*int64(height) > volcengineArkImageMaxPixels {
+	if width%2 != 0 || height%2 != 0 || int64(width)*int64(height) < volcengineArkImageMinPixels || int64(width)*int64(height) > volcengineArkImageMaxPixels {
 		t.Fatalf("downscaled size = %q", size)
+	}
+}
+
+func TestVolcengineArkImageBodyUpscalesPresetBelowMinimumPixels(t *testing.T) {
+	body, err := volcengineArkImageBody(canvasGenerationInput{
+		Prompt: "vertical image",
+		Config: providerConfig{Model: "doubao-seedream-test", Size: "9:16"},
+	})
+	if err != nil {
+		t.Fatalf("volcengineArkImageBody() error = %v", err)
+	}
+	size, _ := body["size"].(string)
+	parts := strings.Split(size, "x")
+	if len(parts) != 2 {
+		t.Fatalf("size = %q", size)
+	}
+	width, _ := strconv.Atoi(parts[0])
+	height, _ := strconv.Atoi(parts[1])
+	pixels := int64(width) * int64(height)
+	if width%2 != 0 || height%2 != 0 || pixels < volcengineArkImageMinPixels || pixels > volcengineArkImageMaxPixels {
+		t.Fatalf("normalized size = %q", size)
 	}
 }
 


### PR DESCRIPTION
## 改动摘要
- 火山方舟图片任务现在会将低于上游最小像素面积的尺寸按原比例放大。
- 同时保留现有最大像素面积压缩，保证最终尺寸落在火山要求的有效范围内。
- 修复画布任务绕过前端尺寸归一化后，`9:16` 等预设被上游以 `imdsize` 拒绝的问题。

## 风险与兼容性
- 仅调整 `volcengine-ark-image` 的 Provider 尺寸归一化。
- 不改模型配置、提示词、参考图、任务状态或计费逻辑。
- 不提交密钥、数据库、日志或本机配置。

## 验证
- `go build ./cmd/server` 通过。
- 新增覆盖竖版预设自动放大与最大尺寸压缩的回归测试。
- `go test ./internal/service -run TestVolcengineArkImageBody` 目前受已有 `provider_stream_test.go` 缺失 `runTextTaskStream` 符号阻断。