### PR TITLE
fix(backend): Grok 图片生成 - 移除冲突的 size 参数

### DIFF
--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -751,8 +751,8 @@ func grokImageRequestBody(input canvasGenerationInput) (grokImageRequest, string
 		Prompt:         withSystemPrompt(input.Config, input.Prompt),
 		N:              1,
 		ResponseFormat: "url",
-		Size:           strings.TrimSpace(input.Config.Size),
-		AspectRatio:    normalizeGrokImageAspectRatio(input.Config.Size),
+		// Grok 图片协议用 aspect_ratio 表达画布比例；同时发送 size 会被上游按 OpenAI 枚举校验并拒绝。
+		AspectRatio: normalizeGrokImageAspectRatio(input.Config.Size),
 		Resolution:     normalizeGrokImageResolution(input.Config.Quality),
 	}
 	if len(input.ReferenceImages) == 0 {

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -753,7 +753,7 @@ func grokImageRequestBody(input canvasGenerationInput) (grokImageRequest, string
 		ResponseFormat: "url",
 		// Grok 图片协议用 aspect_ratio 表达画布比例；同时发送 size 会被上游按 OpenAI 枚举校验并拒绝。
 		AspectRatio: normalizeGrokImageAspectRatio(input.Config.Size),
-		Resolution:     normalizeGrokImageResolution(input.Config.Quality),
+		Resolution:  normalizeGrokImageResolution(input.Config.Quality),
 	}
 	if len(input.ReferenceImages) == 0 {
 		return body, "/images/generations", nil

--- a/backend/internal/service/provider_request_types.go
+++ b/backend/internal/service/provider_request_types.go
@@ -58,7 +58,6 @@ type grokImageRequest struct {
 	Image          *grokImageInput `json:"image,omitempty"`
 	N              int             `json:"n"`
 	ResponseFormat string          `json:"response_format"`
-	Size           string          `json:"size,omitempty"`
 	AspectRatio    string          `json:"aspect_ratio,omitempty"`
 	// Resolution 对应 xAI / grok2api 的 resolution（常见 1k / 2k）。
 	Resolution string `json:"resolution,omitempty"`

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -208,8 +208,20 @@ func TestGrokImageRequestBodyMapsAspectRatio(t *testing.T) {
 	if path != "/images/generations" {
 		t.Fatalf("path = %q", path)
 	}
-	if body.AspectRatio != "9:16" || body.Size != "9:16" || body.Resolution != "2k" {
+	if body.AspectRatio != "9:16" || body.Resolution != "2k" {
 		t.Fatalf("body = %#v", body)
+	}
+	encoded, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(encoded, &payload); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	// Grok 使用 aspect_ratio；测试锁定请求 JSON，防止非法 size 字段再次混入。
+	if _, exists := payload["size"]; exists {
+		t.Fatalf("request body must not contain size: %s", encoded)
 	}
 	if got := normalizeGrokImageAspectRatio("1280x720"); got != "16:9" {
 		t.Fatalf("normalize 1280x720 = %q", got)


### PR DESCRIPTION
## 改动摘要

- Grok 图片生成请求仅发送 `aspect_ratio`，不再同时发送会被上游拒绝的 `size`。
- 删除 Grok 请求结构中的 `size` 字段。
- 增加请求 JSON 回归检查，防止非法字段再次混入。

## 风险

- 仅影响 Grok 图片生成请求体；其他模型渠道不受影响。
- 上游必须支持现有 `aspect_ratio` 协议。

## 验证

- Docker 镜像构建成功。
- 腾讯1后端容器健康，主页与 `/api/health` 均返回 200。
- 未单独运行 Go 自动化测试：部署宿主机未安装 Go。