### PR TITLE
fix(ui): 任务中心 - 修复竖图预览溢出

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -4040,8 +4040,9 @@
     .task-record-dot.is-queued { background: var(--palette-status-loading); }
     .task-record-dot.is-failed { background: var(--palette-status-error); }
     .task-record-dot.is-idle { background: color-mix(in srgb, var(--foreground) 30%, transparent); }
-    .task-record-thumb { position: relative; display: grid; width: 84px; height: 60px; flex: 0 0 auto; place-items: center; overflow: hidden; border: 0; border-radius: var(--r-md); background: color-mix(in srgb, var(--foreground) 4%, transparent); color: color-mix(in srgb, var(--foreground) 28%, transparent); }
-    .task-record-thumb img, .task-record-thumb video { width: 100%; height: 100%; object-fit: cover; }
+    .task-record-thumb { position: relative; display: grid; width: 84px; height: 60px; flex: 0 0 auto; place-items: center; overflow: hidden; border: 0; border-radius: var(--r-md); background: color-mix(in srgb, var(--foreground) 4%, transparent); padding: 0; color: color-mix(in srgb, var(--foreground) 28%, transparent); }
+    /* 媒体脱离 Grid 固有尺寸计算，避免竖图按原始宽高比把固定缩略图撑出任务行。 */
+    .task-record-thumb img, .task-record-thumb video { position: absolute; inset: 0; display: block; width: 100%; height: 100%; object-fit: cover; }
     .task-record-meta { display: flex; min-width: 0; align-items: center; gap: 8px; margin-top: 7px; overflow: hidden; color: color-mix(in srgb, var(--foreground) 40%, transparent); font-size: var(--fs-label); white-space: nowrap; }
     .task-record-meta-canvas { display: inline-flex; min-width: 0; align-items: center; gap: 4px; overflow: hidden; text-overflow: ellipsis; }
     .task-record-meta-canvas svg { flex: 0 0 auto; opacity: .7; }


### PR DESCRIPTION
## 改动摘要

- 修复 `/tasks` 列表中竖向图片预览超出缩略图范围、覆盖相邻任务的问题。
- 将图片和视频预览移出 Grid 固有尺寸计算，固定铺满缩略图容器并继续使用 `object-fit: cover` 裁剪。
- 清除预览按钮的默认内边距，桌面端 `84×60` 与响应式 `60×44` 尺寸保持不变。

## 风险与兼容性

- 仅调整任务列表缩略图 CSS，不涉及 API、数据结构、权限、费用或部署配置。
- 图片与视频统一应用相同的裁剪边界；放大预览逻辑不受影响。
- 竖图在列表中仍会居中裁剪，行为与现有缩略图设计一致。

## 验证

- 已核对 `fix` 相对上游 `main` 仅包含本次修改。
- 未运行构建或自动化测试；本次修改为局部 CSS，遵循仓库默认验证约定。
- `https://xiangzai.cloud/tasks` 当前在本环境无法解析 DNS，尚未完成浏览器复测。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义（本次修改不涉及这些路径）