### PR TITLE
fix(canvas): 风格中心全部分类恢复卡片图片

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -4766,6 +4766,7 @@
     .style-center-grid {
         display: grid;
         grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+        grid-auto-rows: max-content;
         gap: var(--space-3);
         overscroll-behavior: contain;
     }


### PR DESCRIPTION
## 变更说明

修复风格中心“全部”分类中多行卡片被压缩，导致图片和正文不可见的问题。

## 前端

- 为 `.style-center-grid` 设置 `grid-auto-rows: max-content`
- 每行按卡片完整内容计算高度
- 超出弹窗的卡片继续使用已有纵向滚动
- 单独分类、卡片内容和图片资源不变

## 验证

- 已执行 `git diff --check`
- 未运行测试、类型检查、构建和浏览器验证
