### PR TITLE
fix(admin): 模型目录修复能力标签与表格布局

### DIFF
--- a/web/src/pages/admin/logical-models/logical-models-page.tsx
+++ b/web/src/pages/admin/logical-models/logical-models-page.tsx
@@ -261,7 +261,7 @@ export default function LogicalModelsPage() {
                 toolbarActiveFilters={keyword ? <AdminFilterChip label={`搜索：${keyword}`} onRemove={() => { setKeyword(""); setPage(1); }} /> : null}
                 toolbarActive={Boolean(keyword)}
                 onReset={() => { setKeyword(""); setPage(1); }}
-                table={{ rowKey: "id", size: "small", loading, pagination: false, columns: modelColumns, dataSource: paginatedModels, scroll: { x: 980 } }}
+                table={{ className: "admin-logical-model-table", rowKey: "id", size: "small", loading, pagination: false, columns: modelColumns, dataSource: paginatedModels, scroll: { x: 980 } }}
                 empty={<AdminTableEmpty filtered={Boolean(deferredKeyword)} title="暂无模型" />}
                 footer={<PaginationBar alwaysShow current={page} pageSize={pageSize} total={filteredModels.length} onChange={(nextPage, nextPageSize) => { setPage(nextPageSize !== pageSize ? 1 : nextPage); setPageSize(nextPageSize); }} />}
             />

--- a/web/src/pages/admin/logical-models/model-routing-capabilities.tsx
+++ b/web/src/pages/admin/logical-models/model-routing-capabilities.tsx
@@ -439,11 +439,11 @@ export function CapabilitySummary({ spec }: { spec: CapabilitySpec }) {
     return (
         <div className="flex min-w-0 max-w-full flex-wrap gap-1">
             {labels.slice(0, 4).map((label) => (
-                <Tag key={label} className="max-w-full whitespace-normal break-all text-left leading-5">
+                <Tag key={label} className="admin-capability-summary-tag max-w-full whitespace-normal break-all text-left leading-5">
                     {label}
                 </Tag>
             ))}
-            {labels.length > 4 ? <Tag className="shrink-0">+{labels.length - 4}</Tag> : null}
+            {labels.length > 4 ? <Tag className="admin-capability-summary-tag shrink-0">+{labels.length - 4}</Tag> : null}
         </div>
     );
 }

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -7891,6 +7891,21 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
     border-inline-start: 0;
 }
 
+.admin-shell .admin-logical-model-table .ant-table-tbody > tr > td {
+    height: auto;
+    vertical-align: top;
+}
+
+.admin-shell .admin-logical-model-table .admin-capability-summary-tag {
+    max-width: 100%;
+    margin-inline-end: 0;
+    overflow-wrap: anywhere;
+    border: 1px solid color-mix(in srgb, var(--foreground) 14%, transparent) !important;
+    background: color-mix(in srgb, var(--foreground) 6%, var(--admin-layer-1)) !important;
+    color: color-mix(in srgb, var(--foreground) 72%, transparent) !important;
+    white-space: normal;
+}
+
 .admin-shell .admin-table-clickable-row {
     cursor: pointer;
 }


### PR DESCRIPTION
## 变更说明

修复后台「模型目录」中能力摘要出现黑底黑字、长文本撑坏布局的问题。

## 前端

- 为能力标签补充可读的背景、边框和文字颜色
- 长能力参数允许断行，避免表格被异常撑宽
- 模型目录表格行高按内容自动计算，不再固定压缩
- 样式限定在前台模型表格，不影响其他后台表格

## 验证

- 已执行 `git diff --cached --check`
- 未运行测试、类型检查、构建和浏览器验证
