### PR TITLE
feat(admin): 模型目录 - 增加前台模型删除功能

### DIFF
--- a/backend/internal/handler/logical_models.go
+++ b/backend/internal/handler/logical_models.go
@@ -58,6 +58,18 @@ func RegisterLogicalModelRoutes(r *gin.RouterGroup, svc *service.Service) {
 	r.PATCH("/admin/logical-models/:id", func(c *gin.Context) {
 		saveAdminLogicalModel(c, svc, c.Param("id"))
 	})
+	r.DELETE("/admin/logical-models/:id", func(c *gin.Context) {
+		actor, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		if err := svc.DeleteAdminLogicalModel(actor, c.Param("id")); err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"ok": true})
+	})
 	r.POST("/admin/logical-models/:id/simulate", func(c *gin.Context) {
 		actor, err := currentUser(c, svc)
 		if err != nil {

--- a/backend/internal/repository/logical_models.go
+++ b/backend/internal/repository/logical_models.go
@@ -16,6 +16,8 @@ type LogicalModelGraph struct {
 	ChannelModels []model.ChannelModel
 }
 
+var ErrLogicalModelInUse = errors.New("logical model is in use")
+
 func (r *Repository) LogicalModels(includeDisabled bool) ([]model.LogicalModel, error) {
 	var items []model.LogicalModel
 	query := r.db.Order("sort_order asc, created_at asc")
@@ -397,6 +399,41 @@ func (r *Repository) SaveLogicalModelBundle(item *model.LogicalModel, revision *
 		}
 		item.ActiveRevisionID = revision.ID
 		item.RevisionSequence = revision.Version
+		return nil
+	})
+}
+
+func (r *Repository) DeleteLogicalModel(id string, now time.Time) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// 先停用并锁定目录主体，避免删除期间仍被新的数据库查询选中。
+		result := tx.Model(&model.LogicalModel{}).
+			Where("id = ?", id).
+			Updates(map[string]any{"enabled": false, "updated_at": now})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
+
+		var activeTasks int64
+		if err := tx.Model(&model.Task{}).
+			Where("logical_model_id = ? AND status IN ?", id, []model.TaskStatus{model.TaskStatusQueued, model.TaskStatusRunning}).
+			Count(&activeTasks).Error; err != nil {
+			return err
+		}
+		if activeTasks > 0 {
+			return ErrLogicalModelInUse
+		}
+
+		// revision 与 route 是不可变的任务快照；删除目录主体时保留它们供历史记录追溯。
+		deleted := tx.Where("id = ?", id).Delete(&model.LogicalModel{})
+		if deleted.Error != nil {
+			return deleted.Error
+		}
+		if deleted.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
 		return nil
 	})
 }

--- a/backend/internal/repository/logical_models_test.go
+++ b/backend/internal/repository/logical_models_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -46,5 +47,64 @@ func TestSaveLogicalModelBundleAllocatesMonotonicRevisionSequence(t *testing.T) 
 	}
 	if updated.RevisionSequence != 2 || updated.ActiveRevisionID != "REVISION_2" {
 		t.Fatalf("updated model state = %#v", updated)
+	}
+}
+
+func TestDeleteLogicalModelPreservesPublishedHistory(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:logical-model-delete-history?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.LogicalModel{}, &model.LogicalModelRevision{}, &model.LogicalModelRoute{}, &model.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	repo := New(db)
+
+	item := &model.LogicalModel{ID: "LMODEL_DELETE", Code: "delete-demo", Name: "Delete Demo", Capability: "text", Enabled: true, PricePolicy: "unified", BillingMode: "fixed_request", CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	revision := &model.LogicalModelRevision{ID: "REVISION_DELETE", LogicalModelID: item.ID, CapabilitySpecJSON: `{"version":1,"capability":"text"}`, DefaultOptionsJSON: `{}`, CreatedAt: time.Now()}
+	routes := []model.LogicalModelRoute{{ID: "ROUTE_DELETE", ChannelModelID: "CMODEL_DELETE", Enabled: true, Weight: 1, CreatedAt: time.Now(), UpdatedAt: time.Now()}}
+	if err := repo.SaveLogicalModelBundle(item, revision, routes, true); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.DeleteLogicalModel(item.ID, time.Now()); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.First(&model.LogicalModel{}, "id = ?", item.ID).Error; !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Fatalf("logical model lookup error = %v, want record not found", err)
+	}
+	for label, target := range map[string]any{"revision": &model.LogicalModelRevision{}, "route": &model.LogicalModelRoute{}} {
+		if err := db.First(target).Error; err != nil {
+			t.Fatalf("%s history was not preserved: %v", label, err)
+		}
+	}
+}
+
+func TestDeleteLogicalModelRejectsActiveTask(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:logical-model-delete-active-task?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.LogicalModel{}, &model.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	repo := New(db)
+	item := model.LogicalModel{ID: "LMODEL_ACTIVE", Code: "active-demo", Name: "Active Demo", Enabled: true, CreatedAt: time.Now(), UpdatedAt: time.Now()}
+	if err := db.Create(&item).Error; err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Create(&model.Task{ID: "TASK_ACTIVE", LogicalModelID: item.ID, Status: model.TaskStatusRunning, CreatedAt: time.Now(), UpdatedAt: time.Now()}).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.DeleteLogicalModel(item.ID, time.Now()); !errors.Is(err, ErrLogicalModelInUse) {
+		t.Fatalf("DeleteLogicalModel() error = %v, want ErrLogicalModelInUse", err)
+	}
+	var preserved model.LogicalModel
+	if err := db.First(&preserved, "id = ?", item.ID).Error; err != nil {
+		t.Fatalf("active logical model was removed: %v", err)
+	}
+	if !preserved.Enabled {
+		t.Fatal("active logical model disable was not rolled back")
 	}
 }

--- a/backend/internal/service/logical_models.go
+++ b/backend/internal/service/logical_models.go
@@ -408,6 +408,31 @@ func (s *Service) SaveAdminLogicalModel(actor *model.User, id string, req Logica
 	return s.buildAdminLogicalModel(*item, graph, systemChannelByID)
 }
 
+func (s *Service) DeleteAdminLogicalModel(actor *model.User, id string) error {
+	if err := s.RequireAdmin(actor); err != nil {
+		return err
+	}
+	item, err := s.repo.LogicalModel(strings.TrimSpace(id))
+	if logicalModelNotFound(err) {
+		return BadAuthRequest("前台模型不存在或已删除")
+	}
+	if err != nil {
+		return err
+	}
+	if err := s.repo.DeleteLogicalModel(item.ID, time.Now()); err != nil {
+		if errors.Is(err, repository.ErrLogicalModelInUse) {
+			return BadAuthRequest("前台模型仍被排队中或进行中任务使用，请等待任务结束后再删除")
+		}
+		if logicalModelNotFound(err) {
+			return BadAuthRequest("前台模型不存在或已删除")
+		}
+		return err
+	}
+	s.invalidateRouteCatalog()
+	_ = s.appendAdminAudit(actor, "logical_model.delete", "logical_model", item.ID, "删除前台模型目录主体", map[string]any{"code": item.Code, "name": item.Name})
+	return nil
+}
+
 func (s *Service) logicalModelBundle(actor *model.User, id string, req LogicalModelRequest) (*model.LogicalModel, *model.LogicalModelRevision, []model.LogicalModelRoute, bool, error) {
 	code := strings.ToLower(strings.TrimSpace(req.Code))
 	name := strings.TrimSpace(req.Name)

--- a/web/src/pages/admin/logical-models/logical-models-page.tsx
+++ b/web/src/pages/admin/logical-models/logical-models-page.tsx
@@ -1,7 +1,7 @@
 import { Alert, App, Button, Drawer, Form, Input, InputNumber, Modal, Segmented, Select, Switch, Table, Tag } from "antd";
 import type { FormInstance } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { FlaskConical, GitBranch, Layers3, Pencil, Plus, Search } from "lucide-react";
+import { FlaskConical, GitBranch, Layers3, Pencil, Plus, Search, Trash2 } from "lucide-react";
 import { useDeferredValue, useEffect, useMemo, useState, type ReactNode } from "react";
 
 import { PaginationBar } from "@/components/layout/workspace-page";
@@ -14,6 +14,7 @@ import { listAdminChannels } from "@/services/api/auth";
 import { listAdminChannelModels, type ChannelModel } from "@/services/api/wallet";
 import {
     createAdminLogicalModel,
+    deleteAdminLogicalModel,
     listAdminLogicalModels,
     simulateAdminLogicalModel,
     updateAdminLogicalModel,
@@ -71,6 +72,7 @@ export default function LogicalModelsPage() {
     const [channelEnabled, setChannelEnabled] = useState<Record<string, boolean>>({});
     const [editingModel, setEditingModel] = useState<AdminLogicalModel | null | undefined>();
     const [saving, setSaving] = useState(false);
+    const [deletingModelId, setDeletingModelId] = useState<string>();
     const [simulatingModel, setSimulatingModel] = useState<AdminLogicalModel>();
     const [simulationIntent, setSimulationIntent] = useState<ModelRequestIntent>();
     const [simulationResult, setSimulationResult] = useState<RouteSimulationResult>();
@@ -180,6 +182,21 @@ export default function LogicalModelsPage() {
         }
     };
 
+    const removeModel = async (item: AdminLogicalModel) => {
+        setDeletingModelId(item.id);
+        try {
+            await deleteAdminLogicalModel(item.id);
+            setModels((current) => current.filter((model) => model.id !== item.id));
+            if (paginatedModels.length === 1 && page > 1) setPage(page - 1);
+            message.success("前台模型已删除");
+        } catch (error) {
+            message.error(error instanceof Error ? error.message : "删除前台模型失败");
+            throw error;
+        } finally {
+            setDeletingModelId(undefined);
+        }
+    };
+
     const openSimulation = (item: AdminLogicalModel) => {
         setSimulationIntent({
             capability: item.capability,
@@ -238,9 +255,23 @@ export default function LogicalModelsPage() {
             render: (_, item) => (
                 <AdminRowActions
                     primary={{ label: "编辑", icon: <Pencil className="size-3.5" />, onClick: () => openModel(item) }}
+                    visibleActionCount={1}
                     actions={[
                         { key: "simulate", label: "模拟供应线路匹配", icon: <FlaskConical className="size-3.5" />, onClick: () => openSimulation(item) },
                         { key: "toggle", label: item.enabled ? "停用" : "启用", onClick: () => void toggleModel(item) },
+                        {
+                            key: "delete",
+                            label: "删除模型",
+                            icon: <Trash2 className="size-3.5" />,
+                            danger: true,
+                            disabled: deletingModelId === item.id,
+                            confirm: {
+                                title: `删除前台模型“${item.name}”？`,
+                                description: "删除后模型将从目录中移除，不能在页面恢复；历史任务和版本记录会保留。排队中或进行中的任务仍在使用时无法删除。",
+                                okText: "确认删除",
+                            },
+                            onClick: () => removeModel(item),
+                        },
                     ]}
                 />
             ),

--- a/web/src/services/api/logical-models.ts
+++ b/web/src/services/api/logical-models.ts
@@ -103,6 +103,10 @@ export function updateAdminLogicalModel(id: string, input: LogicalModelMutation)
     return request<{ model: AdminLogicalModel }>(apiClient.patch(`/admin/logical-models/${encodeURIComponent(id)}`, input));
 }
 
+export function deleteAdminLogicalModel(id: string) {
+    return request<{ ok: boolean }>(apiClient.delete(`/admin/logical-models/${encodeURIComponent(id)}`));
+}
+
 export function simulateAdminLogicalModel(id: string, intent: ModelRequestIntent) {
     return request<RouteSimulationResult>(apiClient.post(`/admin/logical-models/${encodeURIComponent(id)}/simulate`, intent));
 }


### PR DESCRIPTION
## 改动摘要

- 在 /admin/models 模型目录的“更多”操作中新增“删除模型”入口，并提供危险操作二次确认、成功与失败反馈。
- 新增管理员删除前台逻辑模型 API，校验管理员权限，并在删除后刷新路由目录缓存、记录管理员审计事件。
- 当模型仍被排队中或运行中的任务引用时拒绝删除，避免破坏活跃任务。
- 删除目录主体后保留历史 revision 与供应线路快照，供既有任务和历史记录追溯。
- 补充仓储层测试用例，覆盖正常删除保留历史快照、活跃任务阻止删除两种场景。

## 风险与兼容性

- 不涉及数据库表结构变更或数据迁移。
- 删除操作仅限管理员，接口不会依赖前端隐藏按钮进行鉴权。
- 删除后模型会立即从前台和后台目录消失，且不能在页面恢复；历史任务及版本快照继续保留。
- 已使用过但当前没有活跃任务的模型可以删除，失败或取消任务后再次重试时需重新选择仍可用的模型。

## 验证

- 已执行 git diff --check，未发现空白错误。
- 已补充后端测试代码，但按照仓库 AGENTS.md 的默认规则，本次未运行测试、类型检查或构建。
- 当前环境未安装 gofmt；Go 代码已按现有文件格式手工检查。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义