### PR TITLE
fix(tasks): 禁止取消已开始的生成任务

### DIFF
--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -691,16 +691,18 @@ func (s *Service) RetryTask(userID string, id string) (*model.Task, error) {
 	return taskForOutput(*task), nil
 }
 
-func (s *Service) CancelTask(ctx context.Context, userID string, id string) (*model.Task, error) {
+func (s *Service) CancelTask(_ context.Context, userID string, id string) (*model.Task, error) {
 	task, err := s.repo.TaskForUser(userID, id)
 	if err != nil {
 		return nil, err
+	}
+	if task.Status == model.TaskStatusRunning {
+		return nil, errors.New("任务已开始生成，无法取消")
 	}
 	if task.Status == model.TaskStatusSucceeded {
 		return nil, errors.New("completed task cannot be cancelled")
 	}
 	now := time.Now()
-	cancelledRunningTask := false
 	if task.Status == model.TaskStatusQueued {
 		cancelled, err := s.repo.CancelTaskIfStatus(userID, task.ID, model.TaskStatusQueued, now)
 		if err != nil {
@@ -722,45 +724,13 @@ func (s *Service) CancelTask(ctx context.Context, userID string, id string) (*mo
 		}
 	}
 	if task.Status == model.TaskStatusRunning {
-		cancelled, err := s.repo.CancelTaskIfStatus(userID, task.ID, model.TaskStatusRunning, now)
-		if err != nil {
-			return nil, err
-		}
-		if !cancelled {
-			latest, latestErr := s.repo.TaskForUser(userID, id)
-			if latestErr != nil {
-				return nil, latestErr
-			}
-			if latest.Status == model.TaskStatusSucceeded {
-				return nil, errors.New("completed task cannot be cancelled")
-			}
-			task = latest
-		} else {
-			cancelledRunningTask = true
-			s.cancelActiveTask(task.ID)
-			if err := s.MarkBillingUncertain(task.BillingOrderID, "运行中的上游请求被用户取消，费用状态待核对"); err != nil {
-				return nil, err
-			}
-			task, err = s.repo.TaskForUser(userID, id)
-			if err != nil {
-				return nil, err
-			}
-		}
+		return nil, errors.New("任务已开始生成，无法取消")
 	}
 	if task.Status != model.TaskStatusCancelled {
 		return nil, errors.New("task cannot be cancelled in its current state")
 	}
 	if task.SessionID != "" {
 		_ = s.markSessionFailed(*task, "会话任务已取消。")
-	}
-	if cancelledRunningTask {
-		if err := s.requestProviderCancellation(ctx, task); err != nil {
-			return nil, err
-		}
-		task, err = s.repo.TaskForUser(userID, id)
-		if err != nil {
-			return nil, err
-		}
 	}
 	if err := s.finalizeTaskTextReplay(task.ID, model.TaskStatusCancelled); err != nil {
 		_ = s.log(userID, task.ID, "error", "文本回放草稿归并失败", err.Error())

--- a/backend/internal/service/task_cancellation_test.go
+++ b/backend/internal/service/task_cancellation_test.go
@@ -1,0 +1,47 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"infinite-canvas/backend/internal/model"
+	"infinite-canvas/backend/internal/repository"
+
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func TestCancelTaskRejectsRunningTask(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+newID()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.Task{}); err != nil {
+		t.Fatal(err)
+	}
+	startedAt := time.Now()
+	task := model.Task{
+		ID:        "running-task",
+		UserID:    "user-1",
+		Status:    model.TaskStatusRunning,
+		Stage:     "调用生成模型",
+		StartedAt: &startedAt,
+	}
+	if err := db.Create(&task).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &Service{repo: repository.New(db)}
+	if _, err := svc.CancelTask(context.Background(), task.UserID, task.ID); err == nil || err.Error() != "任务已开始生成，无法取消" {
+		t.Fatalf("CancelTask() error = %v", err)
+	}
+
+	stored, err := svc.repo.TaskForUser(task.UserID, task.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stored.Status != model.TaskStatusRunning || stored.CompletedAt != nil {
+		t.Fatalf("running task changed after cancellation attempt: status=%s completedAt=%v", stored.Status, stored.CompletedAt)
+	}
+}

--- a/web/src/components/media-preview.tsx
+++ b/web/src/components/media-preview.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 const DEFAULT_UNAVAILABLE_LABEL = "预览不可用，素材可能已删除";
 
-export function TaskMediaPreview({
+export function MediaPreview({
     src,
     kind,
     alt = "",
@@ -40,7 +40,7 @@ export function TaskMediaPreview({
 
     if (unavailable) {
         return (
-            <span className={cn("task-media-unavailable", fallbackClassName)} role="img" aria-label={fallbackLabel} title={fallbackLabel}>
+            <span className={cn("media-unavailable", fallbackClassName)} role="img" aria-label={fallbackLabel} title={fallbackLabel}>
                 <ImageOff aria-hidden="true" />
                 <span>{fallbackLabel}</span>
             </span>

--- a/web/src/pages/admin/logs/logs-page.tsx
+++ b/web/src/pages/admin/logs/logs-page.tsx
@@ -6,6 +6,7 @@ import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
 import { PaginationBar } from "@/components/layout/workspace-page";
+import { MediaPreview } from "@/components/media-preview";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { exportAdminApiLogs, listAdminApiLogs, type ApiCallLog } from "@/services/api/auth";
 import { ApiLogDetailDrawer } from "../components/api-log-detail-drawer";
@@ -83,7 +84,7 @@ export default function LogsPage() {
             />
             <ApiLogDetailDrawer logId={detailLogId} onClose={() => setDetailLogId(null)} onLogUpdated={(next) => setLogs((items) => items.map((item) => item.id === next.id ? next : item))} />
             <Modal title={mediaPreview?.title || "媒体预览"} open={Boolean(mediaPreview)} width={880} onCancel={() => setMediaPreview(null)} footer={mediaPreview ? <Button icon={<Download className="size-4" />} onClick={() => downloadMedia(mediaPreview.url, mediaPreview.kind)}>下载原文件</Button> : null} destroyOnHidden>
-                {mediaPreview?.kind === "video" ? <video src={mediaPreview.url} controls playsInline preload="metadata" className="max-h-[72vh] w-full bg-black object-contain" /> : mediaPreview ? <img src={mediaPreview.url} alt={mediaPreview.title} className="max-h-[72vh] w-full bg-black object-contain" /> : null}
+                {mediaPreview ? <MediaPreview src={mediaPreview.url} kind={mediaPreview.kind} alt={mediaPreview.title} controls={mediaPreview.kind === "video"} className="max-h-[72vh] w-full bg-black object-contain" fallbackClassName="min-h-[360px] rounded-lg bg-black/90 text-white/55" /> : null}
             </Modal>
         </AdminPageFrame>
     );
@@ -100,12 +101,14 @@ function formatCost(log: ApiCallLog) { return `${log.currency || "USD"} ${(log.e
 function MediaResult({ log, onPreview }: { log: ApiCallLog; onPreview: (url: string, kind: "image" | "video") => void }) {
     const url = log.mediaPreviewUrl;
     const kind = log.mediaPreviewKind;
+    const [unavailableUrl, setUnavailableUrl] = useState("");
     if (!url || (kind !== "image" && kind !== "video")) return <span className="text-foreground/30">--</span>;
+    const previewUnavailable = unavailableUrl === url;
     return <div className="flex w-[90px] items-center gap-1.5">
-        <button type="button" title={`预览${kind === "video" ? "视频" : "图片"}`} className="group relative h-11 w-16 shrink-0 overflow-hidden rounded border border-border/75 bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={() => onPreview(url, kind)}>
-            {kind === "video" ? <video src={url} muted playsInline preload="metadata" className="size-full object-cover" /> : <img src={url} alt="生成结果" loading="lazy" decoding="async" className="size-full object-cover" />}
-            <span className="absolute inset-0 grid place-items-center bg-black/0 text-white opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100 group-focus-visible:bg-black/35 group-focus-visible:opacity-100">{kind === "video" ? <Play className="size-4 fill-current" /> : <Eye className="size-4" />}</span>
-            {log.mediaCount > 1 ? <span className="absolute bottom-0.5 right-0.5 rounded-sm bg-black/65 px-1 text-[var(--fs-micro)] leading-4 text-white">{log.mediaCount}</span> : null}
+        <button type="button" title={previewUnavailable ? "预览不可用，素材可能已删除" : `预览${kind === "video" ? "视频" : "图片"}`} aria-label={previewUnavailable ? "预览不可用，素材可能已删除" : `预览${kind === "video" ? "视频" : "图片"}`} disabled={previewUnavailable} className="group relative h-11 w-16 shrink-0 overflow-hidden rounded border border-border/75 bg-black/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={() => onPreview(url, kind)}>
+            <MediaPreview src={url} kind={kind} alt="生成结果" loading="lazy" className="size-full object-cover" fallbackClassName="text-white/55" fallbackLabel="预览不可用" onUnavailable={() => setUnavailableUrl(url)} />
+            {!previewUnavailable ? <span className="absolute inset-0 grid place-items-center bg-black/0 text-white opacity-0 transition group-hover:bg-black/35 group-hover:opacity-100 group-focus-visible:bg-black/35 group-focus-visible:opacity-100">{kind === "video" ? <Play className="size-4 fill-current" /> : <Eye className="size-4" />}</span> : null}
+            {!previewUnavailable && log.mediaCount > 1 ? <span className="absolute bottom-0.5 right-0.5 rounded-sm bg-black/65 px-1 text-[var(--fs-micro)] leading-4 text-white">{log.mediaCount}</span> : null}
         </button>
         <Button type="text" size="small" className="!size-7 !min-w-7 !p-0" icon={<Download className="size-3.5" />} onClick={() => downloadMedia(url, kind)} title="下载原文件" aria-label="下载原文件" />
     </div>;

--- a/web/src/pages/tasks/index.tsx
+++ b/web/src/pages/tasks/index.tsx
@@ -20,7 +20,7 @@ import { listProjects, type ProjectSummary } from "@/services/api/projects";
 import { TaskGridCard } from "./task-grid-card";
 import { TaskGroupHeader, type TaskGroup } from "./task-group-header";
 import { TaskListRow } from "./task-list-row";
-import { formatModelName, getTaskCanvasContext, isTaskFailed, providerCancelStatusLabel, taskMediaKind } from "./task-shared";
+import { formatModelName, getTaskCanvasContext, isTaskCancellable, isTaskFailed, providerCancelStatusLabel, taskMediaKind } from "./task-shared";
 import { TaskStatusFilterBar, type TaskStatusFilter } from "./task-status-filter";
 
 type TaskKindFilter = "all" | "text" | "image" | "video";
@@ -292,6 +292,10 @@ export default function TasksPage() {
 
     const runAction = async (id: string, action: "retry" | "cancel") => {
         const currentTask = tasksRef.current.find((task) => task.id === id);
+        if (action === "cancel" && currentTask && !isTaskCancellable(currentTask)) {
+            message.warning("任务已开始生成，无法取消");
+            return;
+        }
         if (action === "retry" && currentTask && isGenerationTaskSubmissionUncertain(currentTask)) {
             message.warning("提交结果尚未确认，不能自动重试；请先核对官方状态，避免重复生成。");
             return;
@@ -551,7 +555,7 @@ export default function TasksPage() {
                                     更新官方状态
                                 </Button>
                             ) : null}
-                            {detailTask.provider === "dreamina-cli" && (detailTask.status === "queued" || detailTask.status === "running") ? (
+                            {detailTask.provider === "dreamina-cli" && isTaskCancellable(detailTask) ? (
                                 <Button danger loading={actingId === detailTask.id} onClick={() => void runAction(detailTask.id, "cancel")}>
                                     {localDreaminaCancellationCopy(detailTask)?.action || "取消任务"}
                                 </Button>

--- a/web/src/pages/tasks/index.tsx
+++ b/web/src/pages/tasks/index.tsx
@@ -3,6 +3,7 @@ import { LayoutGrid, List, Plus, RefreshCw, Search, Trash2 } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "react-router";
 
+import { MediaPreview } from "@/components/media-preview";
 import { ListToolbar, PageHeader, PaginationBar, WorkspacePage } from "@/components/layout/workspace-page";
 import { WorkspaceState } from "@/components/layout/workspace-state";
 import { CONTENT_MODERATION_ERROR_CODE, generationErrorMessage, isContentModerationError } from "@/lib/generation-error";
@@ -19,7 +20,6 @@ import { listProjects, type ProjectSummary } from "@/services/api/projects";
 import { TaskGridCard } from "./task-grid-card";
 import { TaskGroupHeader, type TaskGroup } from "./task-group-header";
 import { TaskListRow } from "./task-list-row";
-import { TaskMediaPreview } from "./task-media-preview";
 import { formatModelName, getTaskCanvasContext, isTaskFailed, providerCancelStatusLabel, taskMediaKind } from "./task-shared";
 import { TaskStatusFilterBar, type TaskStatusFilter } from "./task-status-filter";
 
@@ -587,7 +587,7 @@ export default function TasksPage() {
                 className="library-modal task-media-preview-modal"
             >
                 {mediaPreview ? (
-                    <TaskMediaPreview
+                    <MediaPreview
                         src={mediaPreview.url}
                         kind={mediaPreview.kind}
                         alt={mediaPreview.title}
@@ -628,7 +628,7 @@ function TaskResultMedia({ value, taskType }: { value?: string; taskType: string
                 {urls.map((url, index) => {
                     const isVideo = isVideoResult(url, taskType);
                     return (
-                        <TaskMediaPreview
+                        <MediaPreview
                             key={`${url}-${index}`}
                             src={url}
                             kind={isVideo ? "video" : "image"}

--- a/web/src/pages/tasks/task-grid-card.tsx
+++ b/web/src/pages/tasks/task-grid-card.tsx
@@ -5,10 +5,11 @@ import { MediaPreview } from "@/components/media-preview";
 import { CONTENT_MODERATION_ERROR_CODE, isContentModerationError } from "@/lib/generation-error";
 import { statusLabel } from "@/lib/generation-task-display";
 import type { GenerationTask } from "@/services/api/task-center";
-import { isTaskFailed, statusDotClassName, TaskDate } from "./task-shared";
+import { isTaskCancellable, isTaskFailed, statusDotClassName, TaskDate } from "./task-shared";
 
 export function TaskGridCard({ task, actingId, onOpen, onRetry, onCancel }: { task: GenerationTask; actingId: string; onOpen: () => void; onRetry: () => void; onCancel: () => void }) {
     const isActive = task.status === "queued" || task.status === "running";
+    const isCancellable = isTaskCancellable(task);
     const isFailed = isTaskFailed(task);
     const isVideo = task.previewKind === "video";
     const fallbackVideo = task.type.includes("video");
@@ -38,7 +39,7 @@ export function TaskGridCard({ task, actingId, onOpen, onRetry, onCancel }: { ta
                             />
                         </Tooltip>
                     ) : null}
-                    {isActive ? (
+                    {isCancellable ? (
                         <Tooltip title="取消任务">
                             <Button type="text" size="small" danger icon={<X className="size-3.5" />} aria-label="取消任务" loading={actingId === task.id} onClick={onCancel} />
                         </Tooltip>

--- a/web/src/pages/tasks/task-grid-card.tsx
+++ b/web/src/pages/tasks/task-grid-card.tsx
@@ -1,10 +1,10 @@
 import { Button, Tooltip } from "antd";
 import { Eye, FileText, Image as ImageIcon, RotateCcw, Video, X } from "lucide-react";
 
+import { MediaPreview } from "@/components/media-preview";
 import { CONTENT_MODERATION_ERROR_CODE, isContentModerationError } from "@/lib/generation-error";
 import { statusLabel } from "@/lib/generation-task-display";
 import type { GenerationTask } from "@/services/api/task-center";
-import { TaskMediaPreview } from "./task-media-preview";
 import { isTaskFailed, statusDotClassName, TaskDate } from "./task-shared";
 
 export function TaskGridCard({ task, actingId, onOpen, onRetry, onCancel }: { task: GenerationTask; actingId: string; onOpen: () => void; onRetry: () => void; onCancel: () => void }) {
@@ -17,7 +17,7 @@ export function TaskGridCard({ task, actingId, onOpen, onRetry, onCancel }: { ta
         <article className={`task-grid-card${isFailed ? " is-attention" : ""}`}>
             <div className="task-grid-thumb">
                 {task.previewUrl ? (
-                    <TaskMediaPreview src={task.previewUrl} kind={isVideo ? "video" : "image"} loading="lazy" className="h-full w-full object-cover" />
+                    <MediaPreview src={task.previewUrl} kind={isVideo ? "video" : "image"} loading="lazy" className="h-full w-full object-cover" />
                 ) : (
                     <Icon />
                 )}

--- a/web/src/pages/tasks/task-list-row.tsx
+++ b/web/src/pages/tasks/task-list-row.tsx
@@ -2,11 +2,11 @@ import { Button, Tooltip } from "antd";
 import { Eye, FileText, FolderKanban, Image as ImageIcon, Play, RotateCcw, Video, X } from "lucide-react";
 import { useState } from "react";
 
+import { MediaPreview } from "@/components/media-preview";
 import { CONTENT_MODERATION_ERROR_CODE, generationErrorMessage, isContentModerationError } from "@/lib/generation-error";
 import { formatTaskKind, statusLabel } from "@/lib/generation-task-display";
 import type { GenerationTask } from "@/services/api/task-center";
 import type { AiConfig } from "@/stores/use-config-store";
-import { TaskMediaPreview } from "./task-media-preview";
 import { formatModelName, getTaskCanvasContext, isTaskFailed, statusDotClassName, taskAttentionReason, TaskBilling, TaskDate } from "./task-shared";
 
 export function TaskListRow({
@@ -126,7 +126,7 @@ function TaskPreviewThumbnail({ task, onOpen }: { task: GenerationTask; onOpen: 
             aria-label={previewUnavailable ? "预览不可用，素材可能已删除" : isVideo ? "放大预览生成视频" : "放大预览生成图片"}
             title={previewUnavailable ? "预览不可用，素材可能已删除" : undefined}
         >
-            <TaskMediaPreview src={task.previewUrl} kind={isVideo ? "video" : "image"} width={68} height={48} loading="lazy" className="h-full w-full object-cover" fallbackLabel="预览不可用" onUnavailable={() => setUnavailableUrl(task.previewUrl || "")} />
+            <MediaPreview src={task.previewUrl} kind={isVideo ? "video" : "image"} width={68} height={48} loading="lazy" className="h-full w-full object-cover" fallbackLabel="预览不可用" onUnavailable={() => setUnavailableUrl(task.previewUrl || "")} />
             {!previewUnavailable ? (
                 <span className="absolute inset-0 grid place-items-center bg-black/0 text-white opacity-0 transition-[background-color,opacity] duration-150 group-hover:bg-black/30 group-hover:opacity-100 group-focus-visible:bg-black/30 group-focus-visible:opacity-100">
                     {isVideo ? <Play className="size-4 fill-current" /> : <Eye className="size-4" />}

--- a/web/src/pages/tasks/task-list-row.tsx
+++ b/web/src/pages/tasks/task-list-row.tsx
@@ -7,7 +7,7 @@ import { CONTENT_MODERATION_ERROR_CODE, generationErrorMessage, isContentModerat
 import { formatTaskKind, statusLabel } from "@/lib/generation-task-display";
 import type { GenerationTask } from "@/services/api/task-center";
 import type { AiConfig } from "@/stores/use-config-store";
-import { formatModelName, getTaskCanvasContext, isTaskFailed, statusDotClassName, taskAttentionReason, TaskBilling, TaskDate } from "./task-shared";
+import { formatModelName, getTaskCanvasContext, isTaskCancellable, isTaskFailed, statusDotClassName, taskAttentionReason, TaskBilling, TaskDate } from "./task-shared";
 
 export function TaskListRow({
     task,
@@ -34,6 +34,7 @@ export function TaskListRow({
 }) {
     const context = getTaskCanvasContext(task, canvasById, projectNameById);
     const isActive = task.status === "queued" || task.status === "running";
+    const isCancellable = isTaskCancellable(task);
     const isFailed = isTaskFailed(task);
     return (
         <article className={`task-record-row group${isFailed ? " is-attention" : ""}`}>
@@ -94,7 +95,7 @@ export function TaskListRow({
                         />
                     </Tooltip>
                 ) : null}
-                {isActive ? (
+                {isCancellable ? (
                     <Tooltip title="取消任务">
                         <Button type="text" size="small" danger icon={<X className="size-3.5" />} aria-label="取消任务" loading={actingId === task.id} onClick={onCancel} />
                     </Tooltip>

--- a/web/src/pages/tasks/task-shared.tsx
+++ b/web/src/pages/tasks/task-shared.tsx
@@ -17,6 +17,10 @@ export function isTaskFailed(task: GenerationTask) {
     return task.status === "failed" || task.status === "cancelled";
 }
 
+export function isTaskCancellable(task: GenerationTask) {
+    return task.status === "queued";
+}
+
 export function taskAttentionReason(task: GenerationTask) {
     if (task.status === "cancelled") return providerCancelStatusLabel(task);
     if (task.errorCode === CONTENT_MODERATION_ERROR_CODE || isContentModerationError(task.error)) return "内容审核未通过，请修改输入后新建任务";

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -4334,9 +4334,9 @@
     .task-record-thumb { position: relative; display: grid; width: 84px; height: 60px; flex: 0 0 auto; place-items: center; overflow: hidden; border: 0; border-radius: var(--r-md); background: color-mix(in srgb, var(--foreground) 4%, transparent); padding: 0; color: color-mix(in srgb, var(--foreground) 28%, transparent); }
     /* 媒体脱离 Grid 固有尺寸计算，避免竖图按原始宽高比把固定缩略图撑出任务行。 */
     .task-record-thumb img, .task-record-thumb video { position: absolute; inset: 0; display: block; width: 100%; height: 100%; object-fit: cover; }
-    /* 资源已被删除或失效时，由组件接管原生破图，任务记录本身仍保持可读。 */
-    .task-media-unavailable { display: flex; width: 100%; height: 100%; flex-direction: column; align-items: center; justify-content: center; gap: 5px; color: color-mix(in srgb, var(--foreground) 38%, transparent); font-size: var(--fs-tiny); line-height: 1.25; text-align: center; }
-    .task-media-unavailable > svg { width: 18px; height: 18px; flex: 0 0 auto; }
+    /* 资源已被删除或失效时，由组件接管原生破图，相关页面仍保持可读。 */
+    .media-unavailable { display: flex; width: 100%; height: 100%; flex-direction: column; align-items: center; justify-content: center; gap: 5px; color: color-mix(in srgb, var(--foreground) 38%, transparent); font-size: var(--fs-tiny); line-height: 1.25; text-align: center; }
+    .media-unavailable > svg { width: 18px; height: 18px; flex: 0 0 auto; }
     .task-record-thumb:disabled { cursor: default; }
     .task-record-meta { display: flex; min-width: 0; align-items: center; gap: 8px; margin-top: 7px; overflow: hidden; color: color-mix(in srgb, var(--foreground) 40%, transparent); font-size: var(--fs-label); white-space: nowrap; }
     .task-record-meta-canvas { display: inline-flex; min-width: 0; align-items: center; gap: 4px; overflow: hidden; text-overflow: ellipsis; }
@@ -4391,7 +4391,7 @@
     .task-grid-card.is-attention .task-grid-body { background: color-mix(in srgb, var(--palette-status-error) 5%, transparent); }
     .task-grid-thumb { position: relative; display: grid; aspect-ratio: 16 / 9; place-items: center; overflow: hidden; background: color-mix(in srgb, var(--foreground) 4%, transparent); color: color-mix(in srgb, var(--foreground) 30%, transparent); }
     .task-grid-thumb > svg { width: 26px; height: 26px; }
-    .task-grid-thumb .task-media-unavailable > svg { width: 26px; height: 26px; }
+    .task-grid-thumb .media-unavailable > svg { width: 26px; height: 26px; }
     .task-grid-thumb img, .task-grid-thumb video { width: 100%; height: 100%; object-fit: cover; }
     .task-grid-overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; gap: 6px; background: color-mix(in srgb, var(--background) 58%, transparent); opacity: 0; backdrop-filter: blur(3px); -webkit-backdrop-filter: blur(3px); transition: opacity 200ms ease-out; }
     .task-grid-card:hover .task-grid-overlay, .task-grid-card:focus-within .task-grid-overlay { opacity: 1; }

--- a/web/test/task-media-fallback.test.ts
+++ b/web/test/task-media-fallback.test.ts
@@ -6,9 +6,9 @@ function source(path: string) {
     return readFileSync(resolve(import.meta.dir, path), "utf8");
 }
 
-describe("task media fallback", () => {
+describe("media fallback", () => {
     test("replaces failed image and video elements with an unavailable state", () => {
-        const preview = source("../src/pages/tasks/task-media-preview.tsx");
+        const preview = source("../src/components/media-preview.tsx");
 
         expect(preview).toContain("failedSrc === src");
         expect(preview).toContain("onError={handleUnavailable}");
@@ -21,9 +21,17 @@ describe("task media fallback", () => {
         const grid = source("../src/pages/tasks/task-grid-card.tsx");
         const page = source("../src/pages/tasks/index.tsx");
 
-        expect(list).toContain("<TaskMediaPreview");
+        expect(list).toContain("<MediaPreview");
         expect(list).toContain("disabled={previewUnavailable}");
-        expect(grid).toContain("<TaskMediaPreview");
-        expect(page.match(/<TaskMediaPreview/g)).toHaveLength(2);
+        expect(grid).toContain("<MediaPreview");
+        expect(page.match(/<MediaPreview/g)).toHaveLength(2);
+    });
+
+    test("uses the fallback in admin log thumbnails and enlarged previews", () => {
+        const page = source("../src/pages/admin/logs/logs-page.tsx");
+
+        expect(page.match(/<MediaPreview/g)).toHaveLength(2);
+        expect(page).toContain("disabled={previewUnavailable}");
+        expect(page).toContain("onUnavailable={() => setUnavailableUrl(url)}");
     });
 });

--- a/web/test/task-media-fallback.test.ts
+++ b/web/test/task-media-fallback.test.ts
@@ -35,3 +35,22 @@ describe("media fallback", () => {
         expect(page).toContain("onUnavailable={() => setUnavailableUrl(url)}");
     });
 });
+
+describe("task cancellation policy", () => {
+    test("offers cancellation only while a task is queued", () => {
+        const shared = source("../src/pages/tasks/task-shared.tsx");
+        const list = source("../src/pages/tasks/task-list-row.tsx");
+        const grid = source("../src/pages/tasks/task-grid-card.tsx");
+        const page = source("../src/pages/tasks/index.tsx");
+
+        expect(shared).toContain('return task.status === "queued";');
+        expect(list).toContain("const isCancellable = isTaskCancellable(task);");
+        expect(list).toContain("{isCancellable ? (");
+        expect(grid).toContain("const isCancellable = isTaskCancellable(task);");
+        expect(grid).toContain("{isCancellable ? (");
+        expect(page).toContain('if (action === "cancel" && currentTask && !isTaskCancellable(currentTask))');
+        expect(page).toContain('message.warning("任务已开始生成，无法取消")');
+        expect(page).toContain('detailTask.provider === "dreamina-cli" && isTaskCancellable(detailTask)');
+        expect(page).not.toContain('detailTask.status === "queued" || detailTask.status === "running"');
+    });
+});


### PR DESCRIPTION
## 背景

上游模型服务商在创建生成任务后通常已经产生费用。现有逻辑允许用户取消 `running` 任务，但这无法避免上游扣费，还会引入任务状态与计费对账不确定的问题。

## 改动内容

- `/tasks` 列表、网格和详情区域仅对 `queued` 任务展示取消入口
- 增加前端状态保护，阻止对已开始任务发起取消请求
- 后端 `CancelTask` 拒绝取消 `running` 任务，防止绕过前端调用接口
- 保留排队任务取消及预扣积分退回逻辑
- 覆盖任务状态竞争场景：任务从排队切换为运行后，取消请求会被拒绝
- 新增前后端回归测试

## 验证

- `bun test test/task-media-fallback.test.ts`：4 项通过
- `go test ./... -run '^$'`：后端所有包编译通过