### PR TITLE
修复视频生成价格档的参考素材分类

### DIFF
--- a/backend/internal/service/model_router.go
+++ b/backend/internal/service/model_router.go
@@ -684,6 +684,14 @@ func skuSelectorForIntent(intent ModelRequestIntent) map[string]string {
 	}
 	switch normalizeCapability(intent.Capability) {
 	case "video":
+		// 价格档按实际参考素材归类。供应商执行仍可使用 reference_to_video、extend
+		// 等细分操作；计价时视频参考优先归为视频生视频，其余图片参考无论数量
+		// 都归为图生视频。
+		if intent.Inputs["video"] > 0 {
+			selector["operation"] = "video_to_video"
+		} else if intent.Inputs["image"] > 0 {
+			selector["operation"] = "image_to_video"
+		}
 		if count := intent.Inputs["image"]; count > 0 {
 			selector["imageCount"] = strconv.Itoa(count)
 		}

--- a/backend/internal/service/model_router_test.go
+++ b/backend/internal/service/model_router_test.go
@@ -31,3 +31,50 @@ func TestSKUSelectorIncludesVideoReferenceImageCount(t *testing.T) {
 		t.Fatalf("matched tier = %#v", matched)
 	}
 }
+
+func TestSKUSelectorTreatsAnyVideoReferenceAsVideoToVideo(t *testing.T) {
+	intent := ModelRequestIntentFromTaskInput(map[string]any{
+		"mode":              "video",
+		"referenceImages":   []any{map[string]any{"url": "https://example.com/reference.png"}},
+		"referenceVideos":   []any{map[string]any{"url": "https://example.com/reference.mp4"}},
+		"referenceAudios":   []any{map[string]any{"url": "https://example.com/reference.mp3"}},
+		"capabilityOptions": map[string]any{"vquality": "720p"},
+	}, "canvas_video", "reference_to_video")
+	selector := skuSelectorForIntent(intent)
+	if selector["operation"] != "video_to_video" {
+		t.Fatalf("operation = %q, want video_to_video; selector = %#v", selector["operation"], selector)
+	}
+
+	modelWithTiers := model.ChannelModel{PriceTiers: []model.ChannelModelPriceTier{
+		{SelectorJSON: `{}`, Enabled: true, PriceConfigured: true},
+		{SelectorJSON: `{"operation":"video_to_video"}`, Enabled: true, PriceConfigured: true},
+	}}
+	matched := channelModelPriceTierForIntent(modelWithTiers, intent)
+	if matched == nil || matched.SelectorJSON != `{"operation":"video_to_video"}` {
+		t.Fatalf("matched tier = %#v", matched)
+	}
+}
+
+func TestSKUSelectorTreatsAnyImageReferenceCountAsImageToVideo(t *testing.T) {
+	intent := ModelRequestIntentFromTaskInput(map[string]any{
+		"mode": "video",
+		"referenceImages": []any{
+			map[string]any{"url": "https://example.com/reference-1.png"},
+			map[string]any{"url": "https://example.com/reference-2.png"},
+			map[string]any{"url": "https://example.com/reference-3.png"},
+		},
+	}, "canvas_video", "reference_to_video")
+	selector := skuSelectorForIntent(intent)
+	if selector["operation"] != "image_to_video" || selector["imageCount"] != "3" {
+		t.Fatalf("selector = %#v, want image_to_video with imageCount 3", selector)
+	}
+
+	modelWithTiers := model.ChannelModel{PriceTiers: []model.ChannelModelPriceTier{
+		{SelectorJSON: `{}`, Enabled: true, PriceConfigured: true},
+		{SelectorJSON: `{"operation":"image_to_video"}`, Enabled: true, PriceConfigured: true},
+	}}
+	matched := channelModelPriceTierForIntent(modelWithTiers, intent)
+	if matched == nil || matched.SelectorJSON != `{"operation":"image_to_video"}` {
+		t.Fatalf("matched tier = %#v", matched)
+	}
+}


### PR DESCRIPTION
## 变更说明

- 价格档匹配改为以任务实际参考素材为准：只要 `referenceVideos` 中包含视频，计价规格归类为 `video_to_video`。
- 不含参考视频但包含参考图时，无论参考图数量多少，计价规格统一归类为 `image_to_video`；具体数量继续通过 `imageCount` 规格区分。
- 保留供应商执行使用的 `reference_to_video`、`extend` 等细分 operation，不改变模型能力校验和协议调用。
- 增加回归测试，覆盖视频与图片等素材混合输入、三张参考图、精确价格档优先于通配档。

## 测试

- `gofmt` 与 `git diff --check`
- `go test ./internal/service -run 'Test(ModelRequestIntent|SKUSelector)' -count=1`

## CI 说明

上游 `main` 当前基线的全仓 Go 格式检查本身处于失败状态；本 PR 修改的两个 Go 文件已单独格式化。PR 未修改 Web 文件，Web 工作流中的既有测试失败与本次改动无关。