### PR TITLE
fix(video): stabilize async provider recovery and timing

### DIFF
--- a/backend/internal/model/models_task.go
+++ b/backend/internal/model/models_task.go
@@ -42,6 +42,7 @@ type Task struct {
 	Attempts                  int                  `json:"attempts"`
 	StartedAt                 *time.Time           `json:"startedAt"`
 	CompletedAt               *time.Time           `json:"completedAt"`
+	APIDurationMs             int64                `json:"apiDurationMs,omitempty" gorm:"-"`
 	CreatedAt                 time.Time            `json:"createdAt" gorm:"index:idx_tasks_user_created,priority:2;index:idx_tasks_status_created,priority:2;index:idx_tasks_claim,priority:3"`
 	UpdatedAt                 time.Time            `json:"updatedAt"`
 }

--- a/backend/internal/protocol/builtin.go
+++ b/backend/internal/protocol/builtin.go
@@ -697,7 +697,7 @@ func parseAsyncCreate(payload map[string]any) (CreateResult, error) {
 	if status == "" {
 		status = StatusPending
 	}
-	return CreateResult{TaskID: id, Status: status, Message: firstString(payload, "message", "error")}, nil
+	return CreateResult{TaskID: id, Status: status, Message: asyncMessage(payload)}, nil
 }
 
 func parseAsyncMediaPoll(c PollContext, payload map[string]any, capability Capability) (PollResult, error) {
@@ -724,11 +724,16 @@ func parseAsyncMediaPoll(c PollContext, payload map[string]any, capability Capab
 		references = append(references, mediaFromArray([]any{content}, capability)...)
 	}
 	keys := []string{resultKind + "_url", resultKind + "Url", "result_url", "url"}
-	if resultKind == "video" {
-		keys = append(keys, "object")
-	}
 	if value := firstString(payload, keys...); value != "" {
 		references = append(references, MediaReference{URL: value, Kind: resultKind})
+	}
+	// Some legacy video APIs put the result URL in `object`, while OpenAI-style
+	// responses use it as a type marker such as "video.generation". Only retain
+	// it when it is actually an absolute media URL.
+	if resultKind == "video" {
+		if value := firstString(payload, "object"); strings.HasPrefix(value, "https://") || strings.HasPrefix(value, "http://") {
+			references = append(references, MediaReference{URL: value, Kind: resultKind})
+		}
 	}
 	switch capability {
 	case CapabilityImage:
@@ -741,7 +746,7 @@ func parseAsyncMediaPoll(c PollContext, payload map[string]any, capability Capab
 	if status == StatusSucceeded && len(references) == 0 {
 		result = nil
 	}
-	return PollResult{TaskID: defaultValue(firstString(payload, "id", "task_id", "taskId"), c.TaskID), Status: status, Result: result, Message: firstString(payload, "message", "error", "fail_reason")}, nil
+	return PollResult{TaskID: defaultValue(firstString(payload, "id", "task_id", "taskId"), c.TaskID), Status: status, Result: result, Message: asyncMessage(payload)}, nil
 }
 
 func parseAudioResponse(payload map[string]any) (CreateResult, error) {
@@ -790,6 +795,15 @@ func firstString(payload map[string]any, keys ...string) string {
 		if value, ok := payload[key].(string); ok && strings.TrimSpace(value) != "" {
 			return strings.TrimSpace(value)
 		}
+	}
+	return ""
+}
+func asyncMessage(payload map[string]any) string {
+	if value := firstString(payload, "message", "fail_reason", "failure_reason", "error"); value != "" {
+		return value
+	}
+	if failure := object(payload["error"]); failure != nil {
+		return firstString(failure, "message", "msg", "detail", "code", "type")
 	}
 	return ""
 }

--- a/backend/internal/protocol/builtin_test.go
+++ b/backend/internal/protocol/builtin_test.go
@@ -150,6 +150,29 @@ func TestImageAndVideoAdaptersMapProviderShapes(t *testing.T) {
 	}
 }
 
+func TestAsyncStatusErrorAndObjectFieldNormalization(t *testing.T) {
+	for raw, want := range map[string]Status{
+		"COMPLETED": StatusSucceeded, "SUCCEEDED": StatusSucceeded, "SUCCESS": StatusSucceeded,
+		"PROCESSING": StatusProcessing, "IN_PROGRESS": StatusProcessing, "PENDING": StatusPending,
+		"FAILED": StatusFailed, "FAILURE": StatusFailed, "CANCELED": StatusFailed, "CANCELLED": StatusFailed, "EXPIRED": StatusFailed,
+	} {
+		if got := normalizeStatus(raw); got != want {
+			t.Errorf("normalizeStatus(%q) = %q, want %q", raw, got, want)
+		}
+	}
+
+	adapter, _ := Builtins().Get("newapi-channel-2")
+	failed, err := adapter.ParsePoll(context.Background(), PollContext{TaskID: "task-error"}, []byte(`{"status":"FAILED","error":{"code":"400","message":"参数不支持","type":"api_error"}}`))
+	if err != nil || failed.Status != StatusFailed || failed.Message != "参数不支持" {
+		t.Fatalf("failed poll = %#v, err = %v", failed, err)
+	}
+
+	succeeded, err := adapter.ParsePoll(context.Background(), PollContext{TaskID: "task-ok"}, []byte(`{"id":"task-ok","object":"video.generation","status":"COMPLETED","data":[{"url":"https://cdn.example/result.mp4"}]}`))
+	if err != nil || succeeded.Result == nil || len(succeeded.Result.Videos) != 1 || succeeded.Result.Videos[0].URL != "https://cdn.example/result.mp4" {
+		t.Fatalf("succeeded poll = %#v, err = %v", succeeded, err)
+	}
+}
+
 func TestArkVideoAdapterMapsFullModalReferences(t *testing.T) {
 	adapter, ok := Builtins().Get("volcengine-ark-video")
 	if !ok {

--- a/backend/internal/repository/analytics.go
+++ b/backend/internal/repository/analytics.go
@@ -28,6 +28,32 @@ type APICallLogFilter struct {
 	Limit   int
 }
 
+func (r *Repository) APICallDurationsByTaskIDs(userID string, taskIDs []string) (map[string]int64, error) {
+	result := make(map[string]int64)
+	if strings.TrimSpace(userID) == "" || len(taskIDs) == 0 {
+		return result, nil
+	}
+	type durationRow struct {
+		TaskID     string
+		DurationMs int64
+	}
+	var rows []durationRow
+	err := r.db.Model(&model.ApiCallLog{}).
+		Select("task_id, MAX(duration_ms) AS duration_ms").
+		Where("user_id = ? AND task_id IN ? AND duration_ms > 0", userID, taskIDs).
+		Group("task_id").
+		Scan(&rows).Error
+	if err != nil {
+		return nil, err
+	}
+	for _, row := range rows {
+		if row.TaskID != "" && row.DurationMs > 0 {
+			result[row.TaskID] = row.DurationMs
+		}
+	}
+	return result, nil
+}
+
 func (r *Repository) RecordUserActivity(userID string, event string, count int, now time.Time) error {
 	if userID == "" {
 		return nil

--- a/backend/internal/repository/analytics_test.go
+++ b/backend/internal/repository/analytics_test.go
@@ -6,13 +6,43 @@ import (
 	"testing"
 	"time"
 
+	"infinite-canvas/backend/internal/model"
+
 	"gorm.io/driver/postgres"
+	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
 
 type sqlCaptureLogger struct {
 	statements []string
+}
+
+func TestAPICallDurationsByTaskIDsUsesLargestDurationPerOwnedTask(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:api-call-durations?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.ApiCallLog{}); err != nil {
+		t.Fatal(err)
+	}
+	logs := []model.ApiCallLog{
+		{ID: "log-1", UserID: "user-1", TaskID: "task-1", DurationMs: 1200},
+		{ID: "log-2", UserID: "user-1", TaskID: "task-1", DurationMs: 1800},
+		{ID: "log-3", UserID: "user-1", TaskID: "task-2", DurationMs: 900},
+		{ID: "log-4", UserID: "user-2", TaskID: "task-1", DurationMs: 9999},
+	}
+	if err := db.Create(&logs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	durations, err := New(db).APICallDurationsByTaskIDs("user-1", []string{"task-1", "task-2", "missing"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if durations["task-1"] != 1800 || durations["task-2"] != 900 || durations["missing"] != 0 {
+		t.Fatalf("durations = %#v", durations)
+	}
 }
 
 func (l *sqlCaptureLogger) LogMode(logger.LogLevel) logger.Interface { return l }

--- a/backend/internal/service/admin.go
+++ b/backend/internal/service/admin.go
@@ -703,6 +703,7 @@ func (s *Service) mergeVideoAPICallLog(log model.ApiCallLog) (bool, error) {
 	if log.ProviderRequestID != "" {
 		root.ProviderRequestID = log.ProviderRequestID
 	}
+	providerWasTerminal := terminalProviderStatus(root.ProviderStatus)
 	if log.ProviderStatus != "" {
 		root.ProviderStatus = log.ProviderStatus
 	}
@@ -711,7 +712,12 @@ func (s *Service) mergeVideoAPICallLog(log model.ApiCallLog) (bool, error) {
 		startedAt = root.CreatedAt.Add(-time.Duration(root.DurationMs) * time.Millisecond)
 		root.StartedAt = startedAt
 	}
-	root.DurationMs = max(root.DurationMs, log.CreatedAt.Sub(startedAt).Milliseconds())
+	// Keep the upstream generation duration. Once the provider has reported a
+	// terminal state, later downloads or recovery queries must not turn this
+	// into the task's total wall-clock lifetime.
+	if !providerWasTerminal {
+		root.DurationMs = max(root.DurationMs, log.CreatedAt.Sub(startedAt).Milliseconds())
+	}
 	root.StatusCode = log.StatusCode
 	root.ConcurrencyLimit = log.ConcurrencyLimit
 	if log.Status == model.ApiCallStatusFailed {
@@ -730,6 +736,15 @@ func (s *Service) mergeVideoAPICallLog(log model.ApiCallLog) (bool, error) {
 		root.CachedTokens = log.CachedTokens
 	}
 	return true, s.repo.Save(root)
+}
+
+func terminalProviderStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "succeeded", "success", "done", "failed", "cancelled", "canceled", "expired":
+		return true
+	default:
+		return false
+	}
 }
 
 func (s *Service) APICallLogs(actor *model.User, limit int) ([]model.ApiCallLog, error) {

--- a/backend/internal/service/admin_provider_status_test.go
+++ b/backend/internal/service/admin_provider_status_test.go
@@ -1,0 +1,16 @@
+package service
+
+import "testing"
+
+func TestTerminalProviderStatus(t *testing.T) {
+	for _, status := range []string{"completed", "SUCCEEDED", " success ", "done", "failed", "cancelled", "canceled", "expired"} {
+		if !terminalProviderStatus(status) {
+			t.Fatalf("terminalProviderStatus(%q) = false, want true", status)
+		}
+	}
+	for _, status := range []string{"", "queued", "processing", "running", "submitted"} {
+		if terminalProviderStatus(status) {
+			t.Fatalf("terminalProviderStatus(%q) = true, want false", status)
+		}
+	}
+}

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -1945,6 +1945,10 @@ func runDeclarativeProtocolTask(ctx context.Context, input canvasGenerationInput
 }
 
 func protocolRequestFromInput(input canvasGenerationInput) protocol.GenerationRequest {
+	resolution := input.Config.VQuality
+	if canonical := videoResolutionNameRequest(input.VideoCapability, resolution); canonical != "" {
+		resolution = canonical
+	}
 	request := protocol.GenerationRequest{
 		Model:         input.Config.Model,
 		Prompt:        input.Prompt,
@@ -1952,17 +1956,22 @@ func protocolRequestFromInput(input canvasGenerationInput) protocol.GenerationRe
 		Videos:        protocolMediaReferences(input.ReferenceVideos, "video"),
 		Audios:        protocolMediaReferences(input.ReferenceAudios, "audio"),
 		AspectRatio:   input.Config.Size,
-		Resolution:    input.Config.VQuality,
+		Resolution:    resolution,
 		Quality:       input.Config.Quality,
 		GenerateAudio: parseBool(input.Config.VideoGenerateAudio, false),
 		Watermark:     parseBool(input.Config.VideoWatermark, false),
-		Operation:     metadataString(input.Metadata, "videoOperation"),
+		Operation:     metadataString(input.Metadata, "videoEditOperation"),
 		Extra: map[string]any{
 			"videoSeconds": input.Config.VideoSeconds,
 			"audioVoice":   input.Config.AudioVoice,
 			"audioFormat":  input.Config.AudioFormat,
 			"count":        input.Config.Count,
 		},
+	}
+	for _, key := range []string{"negative_prompt", "web_search", "seed"} {
+		if value, ok := input.Metadata[key]; ok {
+			request.Extra[key] = value
+		}
 	}
 	if duration, err := strconv.Atoi(strings.TrimSpace(input.Config.VideoSeconds)); err == nil && duration > 0 {
 		request.Duration = duration

--- a/backend/internal/service/provider_task_recovery.go
+++ b/backend/internal/service/provider_task_recovery.go
@@ -19,6 +19,7 @@ type ProviderTaskQueryResult struct {
 	ProviderStatus string      `json:"providerStatus"`
 	Recovered      bool        `json:"recovered"`
 	BillingSettled bool        `json:"billingSettled"`
+	RefundRetained bool        `json:"refundRetained"`
 }
 
 func (s *Service) QueryFailedVideoTask(ctx context.Context, userID string, taskID string) (*ProviderTaskQueryResult, error) {
@@ -79,6 +80,7 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 	if providerRequestID == "" {
 		return nil, BadAuthRequest("该任务没有可恢复的上游任务 ID")
 	}
+	billingAlreadyRefunded := false
 	if task.BillingOrderID != "" {
 		order, err := s.repo.BillingOrder(task.BillingOrderID)
 		if err != nil {
@@ -88,7 +90,13 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 			return nil, BadAuthRequest("任务与计费订单归属不一致")
 		}
 		if order.Status == model.BillingStatusRefunded {
-			return nil, BadAuthRequest("该任务已退款，不能恢复并重新扣费")
+			// A completed upstream task can still fail locally while downloading or
+			// persisting its media. Allow that narrowly-scoped recovery without
+			// silently charging a refund back to the user.
+			if !refundedProviderResultRecoveryAllowed(task.Error) {
+				return nil, BadAuthRequest("该任务已退款，不能恢复并重新扣费")
+			}
+			billingAlreadyRefunded = true
 		}
 	}
 
@@ -164,7 +172,9 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 		_ = s.log(task.UserID, task.ID, "error", "任务恢复成功但项目产物登记失败", err.Error())
 	}
 	billingSettled := true
-	if err := billing.SettleBilling(task.BillingOrderID, providerRequestID); err != nil {
+	if billingAlreadyRefunded {
+		_ = s.log(task.UserID, task.ID, "info", "人工查询确认生成成功，任务已恢复；本地结果处理失败产生的退款予以保留", providerStatus)
+	} else if err := billing.SettleBilling(task.BillingOrderID, providerRequestID); err != nil {
 		billingSettled = false
 		uncertainErr := billing.MarkBillingUncertain(task.BillingOrderID, "人工查询确认生成成功，但积分结算失败："+err.Error())
 		_ = s.log(task.UserID, task.ID, "error", "任务恢复成功但积分结算失败，已进入待核对", err.Error())
@@ -174,5 +184,12 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 	} else {
 		_ = s.log(task.UserID, task.ID, "info", "人工查询确认生成成功，任务已恢复并完成结算", providerStatus)
 	}
-	return &ProviderTaskQueryResult{Task: taskForOutput(*task), ProviderStatus: providerStatus, Recovered: true, BillingSettled: billingSettled}, nil
+	return &ProviderTaskQueryResult{Task: taskForOutput(*task), ProviderStatus: providerStatus, Recovered: true, BillingSettled: billingSettled, RefundRetained: billingAlreadyRefunded}, nil
+}
+
+func refundedProviderResultRecoveryAllowed(errorText string) bool {
+	message := strings.TrimSpace(errorText)
+	return strings.HasPrefix(message, "声明式协议媒体结果下载失败：") ||
+		strings.HasPrefix(message, "声明式协议已完成但没有返回") ||
+		strings.Contains(message, "结果保存失败")
 }

--- a/backend/internal/service/provider_task_recovery_test.go
+++ b/backend/internal/service/provider_task_recovery_test.go
@@ -1,0 +1,20 @@
+package service
+
+import "testing"
+
+func TestRefundedProviderResultRecoveryAllowed(t *testing.T) {
+	for _, message := range []string{
+		"声明式协议媒体结果下载失败：外部服务地址无效",
+		"声明式协议已完成但没有返回媒体地址",
+		"人工查询已取得视频，但结果保存失败",
+	} {
+		if !refundedProviderResultRecoveryAllowed(message) {
+			t.Errorf("expected recovery to be allowed for %q", message)
+		}
+	}
+	for _, message := range []string{"模型服务拒绝了请求", "上游 HTTP 404", "任务超时"} {
+		if refundedProviderResultRecoveryAllowed(message) {
+			t.Errorf("unexpected refunded recovery permission for %q", message)
+		}
+	}
+}

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -311,6 +311,25 @@ func TestRunAgentToolTaskFallsBackToolChoice(t *testing.T) {
 	}
 }
 
+func TestProtocolRequestFromInputUsesCanonicalVideoResolution(t *testing.T) {
+	request := protocolRequestFromInput(canvasGenerationInput{
+		Config:          providerConfig{VQuality: "480"},
+		VideoCapability: &VideoCapabilityConfig{Resolutions: []string{"480p", "720p", "1080p"}},
+		Metadata: map[string]interface{}{
+			"videoEditOperation": "image_to_video",
+			"negative_prompt":    "blur",
+			"web_search":         true,
+			"seed":               42,
+		},
+	})
+	if request.Resolution != "480p" {
+		t.Fatalf("resolution = %q, want 480p", request.Resolution)
+	}
+	if request.Operation != "image_to_video" || request.Extra["negative_prompt"] != "blur" || request.Extra["web_search"] != true || request.Extra["seed"] != 42 {
+		t.Fatalf("request metadata = operation:%q extra:%#v", request.Operation, request.Extra)
+	}
+}
+
 func TestPostStreamingTextSetsStreamHeaders(t *testing.T) {
 	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "true")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/service/service.go
+++ b/backend/internal/service/service.go
@@ -149,6 +149,9 @@ func (s *Service) SessionDetail(userID string, id string) (*SessionDetail, error
 	if err != nil {
 		return nil, err
 	}
+	if err := s.hydrateTaskAPIDurations(userID, tasks); err != nil {
+		return nil, err
+	}
 	taskSummaries := taskSummariesForOutput(tasks)
 	results, err := s.repo.SessionResults(userID, id)
 	if err != nil {
@@ -166,6 +169,9 @@ func (s *Service) TasksWithOptions(userID string, options TaskListOptions) ([]Ta
 	if err != nil {
 		return nil, err
 	}
+	if err := s.hydrateTaskAPIDurations(userID, tasks); err != nil {
+		return nil, err
+	}
 	orders, err := s.repo.BillingOrdersByTaskIDs(userID, taskBillingTaskIDs(tasks))
 	if err != nil {
 		return nil, err
@@ -179,7 +185,29 @@ func (s *Service) Task(userID string, id string) (*model.Task, error) {
 		return nil, err
 	}
 	s.hydrateTaskProviderRequestID(task)
+	if durations, durationErr := s.repo.APICallDurationsByTaskIDs(userID, []string{task.ID}); durationErr != nil {
+		return nil, durationErr
+	} else {
+		task.APIDurationMs = durations[task.ID]
+	}
 	return taskForOutput(*task), nil
+}
+
+func (s *Service) hydrateTaskAPIDurations(userID string, tasks []model.Task) error {
+	ids := make([]string, 0, len(tasks))
+	for _, task := range tasks {
+		if task.ID != "" {
+			ids = append(ids, task.ID)
+		}
+	}
+	durations, err := s.repo.APICallDurationsByTaskIDs(userID, ids)
+	if err != nil {
+		return err
+	}
+	for index := range tasks {
+		tasks[index].APIDurationMs = durations[tasks[index].ID]
+	}
+	return nil
 }
 
 func (s *Service) hydrateTaskProviderRequestID(task *model.Task) {

--- a/backend/internal/service/task_output.go
+++ b/backend/internal/service/task_output.go
@@ -34,6 +34,7 @@ type TaskSummary struct {
 	Attempts                  int                        `json:"attempts"`
 	StartedAt                 *time.Time                 `json:"startedAt"`
 	CompletedAt               *time.Time                 `json:"completedAt"`
+	APIDurationMs             int64                      `json:"apiDurationMs,omitempty"`
 	CreatedAt                 time.Time                  `json:"createdAt"`
 	UpdatedAt                 time.Time                  `json:"updatedAt"`
 	Billing                   *TaskBillingSummary        `json:"billing,omitempty"`
@@ -117,6 +118,7 @@ func taskSummaryForOutput(task model.Task) TaskSummary {
 		Attempts:                  task.Attempts,
 		StartedAt:                 task.StartedAt,
 		CompletedAt:               task.CompletedAt,
+		APIDurationMs:             task.APIDurationMs,
 		CreatedAt:                 task.CreatedAt,
 		UpdatedAt:                 task.UpdatedAt,
 		ClientContext:             taskClientContext(task.InputJSON),


### PR DESCRIPTION
## 背景

异步视频任务存在三类通用生命周期问题：声明式协议的嵌套错误和 `object` 类型标记可能被误解析；请求侧分辨率与生成方式字段没有使用规范值；上游完成后的下载/恢复日志会放大 API 耗时，且本地结果处理失败已退款后无法恢复已有上游结果。

## 主要改动

- 规范异步媒体响应解析：读取嵌套错误，避免把 `video.generation` 等 `object` 类型标记当成媒体 URL。
- 规范声明式视频请求：发送能力目录中的标准分辨率，读取 `videoEditOperation`，透传受支持的 `negative_prompt`、`web_search` 和 `seed`。
- 为任务详情、任务列表和会话任务补充真实 `apiDurationMs`，并在上游进入终态后停止用下载或恢复请求扩展生成耗时。
- 仅当失败明确发生在上游成功后的媒体下载或结果保存阶段时，允许恢复已退款任务；恢复成功后保留退款，不重新扣费，并返回 `refundRetained`。

## 验证

- `go test ./...`
- `go vet ./...`
- `git diff --check`

以上检查均通过。

## 范围说明

本 PR 只包含通用 Go 后端修复，明确排除了：

- 所有前端文件；
- 可美协议注册、适配器、能力配置、文档和测试；
- 本机 `docker-compose.local.yml` 调试配置。

不需要数据库迁移、环境变量或部署步骤。

## 风险与回滚

- 任务列表和详情会额外按任务 ID 聚合一次 API 调用耗时；查询限定当前用户并使用任务 ID 范围。
- 已退款恢复采用严格错误前缀白名单，其他失败仍拒绝恢复，避免退款后重新扣费。
- 如需回滚，可分别撤销协议规范化提交和任务恢复/耗时提交。