### PR TITLE
style(admin): refine management workspace layout

### DIFF
--- a/web/src/components/layout/workspace-page.tsx
+++ b/web/src/components/layout/workspace-page.tsx
@@ -30,7 +30,25 @@ export function PageHeader({ title, description, meta, actions }: { title: strin
     );
 }
 
-export function ListToolbar({ children, filters, activeFilters, trailing, active, onReset, className }: { children: ReactNode; filters?: ReactNode; activeFilters?: ReactNode; trailing?: ReactNode; active?: boolean; onReset?: () => void; className?: string }) {
+export function ListToolbar({
+    children,
+    filters,
+    filtersAlwaysVisible = false,
+    activeFilters,
+    trailing,
+    active,
+    onReset,
+    className,
+}: {
+    children: ReactNode;
+    filters?: ReactNode;
+    filtersAlwaysVisible?: boolean;
+    activeFilters?: ReactNode;
+    trailing?: ReactNode;
+    active?: boolean;
+    onReset?: () => void;
+    className?: string;
+}) {
     const [filtersOpen, setFiltersOpen] = useState(false);
 
     useEffect(() => {
@@ -43,16 +61,22 @@ export function ListToolbar({ children, filters, activeFilters, trailing, active
                 {children}
                 {filters ? (
                     <>
-                        <Button type="default" className="admin-filter-toggle" aria-expanded={filtersOpen} icon={<ListFilter className="size-3.5" />} onClick={() => setFiltersOpen((open) => !open)}>
-                            筛选{active ? <span className="admin-filter-active-dot" aria-label="有已应用筛选" /> : null}
-                        </Button>
-                        <div className={cn("admin-list-toolbar-filters flex flex-wrap items-center gap-2", filtersOpen && "is-open")}>{filters}</div>
+                        {!filtersAlwaysVisible ? (
+                            <Button type="default" className="admin-filter-toggle" aria-expanded={filtersOpen} icon={<ListFilter className="size-3.5" />} onClick={() => setFiltersOpen((open) => !open)}>
+                                筛选{active ? <span className="admin-filter-active-dot" aria-label="有已应用筛选" /> : null}
+                            </Button>
+                        ) : null}
+                        <div className={cn("admin-list-toolbar-filters flex flex-wrap items-center gap-2", (filtersAlwaysVisible || filtersOpen) && "is-open")}>{filters}</div>
                     </>
                 ) : null}
                 {activeFilters ? <div className="admin-list-toolbar-chips">{activeFilters}</div> : null}
             </div>
             <div className="admin-list-toolbar-actions flex shrink-0 flex-wrap items-center gap-2">
-                {active && onReset ? <Button type="text" icon={<RotateCcw className="size-3.5" />} onClick={onReset}>重置</Button> : null}
+                {active && onReset ? (
+                    <Button type="text" icon={<RotateCcw className="size-3.5" />} onClick={onReset}>
+                        重置
+                    </Button>
+                ) : null}
                 {trailing}
             </div>
         </div>
@@ -75,7 +99,21 @@ function pageItems(current: number, pages: number): (number | "…")[] {
     return [1, "…", current - 1, current, current + 1, "…", pages];
 }
 
-export function PaginationBar({ current, pageSize, total, onChange, pageSizeOptions = [20, 50, 100], alwaysShow = false }: { current: number; pageSize: number; total: number; onChange: (page: number, pageSize: number) => void; pageSizeOptions?: number[]; alwaysShow?: boolean }) {
+export function PaginationBar({
+    current,
+    pageSize,
+    total,
+    onChange,
+    pageSizeOptions = [20, 50, 100],
+    alwaysShow = false,
+}: {
+    current: number;
+    pageSize: number;
+    total: number;
+    onChange: (page: number, pageSize: number) => void;
+    pageSizeOptions?: number[];
+    alwaysShow?: boolean;
+}) {
     if (!alwaysShow && total <= pageSize && current === 1) return null;
     const pages = Math.max(1, Math.ceil(total / pageSize));
     const start = total === 0 ? 0 : (current - 1) * pageSize + 1;
@@ -84,21 +122,25 @@ export function PaginationBar({ current, pageSize, total, onChange, pageSizeOpti
     return (
         <div className="app-pagination-bar admin-pagination-bar mt-4 flex min-h-10 min-w-0 items-center justify-end gap-2 px-2 py-1.5">
             <span className="admin-pagination-total">{total === 0 ? "共 0 条" : `${start}-${end} / 共 ${total} 条`}</span>
-            <Select
-                size="small"
-                value={pageSize}
-                className="app-pagination-size"
-                options={pageSizeOptions.map((size) => ({ value: size, label: `${size} 条/页` }))}
-                onChange={(value) => onChange(1, Number(value))}
-            />
+            <Select size="small" value={pageSize} className="app-pagination-size" options={pageSizeOptions.map((size) => ({ value: size, label: `${size} 条/页` }))} onChange={(value) => onChange(1, Number(value))} />
             <div className="app-pagination-pages" role="navigation" aria-label="分页">
-                <button type="button" className="app-pagination-btn app-pagination-prev" disabled={current <= 1} aria-label="上一页" onClick={() => onChange(current - 1, pageSize)}><ChevronLeft className="size-4" /></button>
-                {items.map((item) => item === "…" ? (
-                    <span key={`ellipsis-${items.indexOf(item)}`} className="app-pagination-ellipsis">…</span>
-                ) : (
-                    <button key={item} type="button" className={`app-pagination-btn${item === current ? " is-active" : ""}`} aria-current={item === current ? "page" : undefined} onClick={() => onChange(item, pageSize)}>{item}</button>
-                ))}
-                <button type="button" className="app-pagination-btn app-pagination-next" disabled={current >= pages} aria-label="下一页" onClick={() => onChange(current + 1, pageSize)}><ChevronRight className="size-4" /></button>
+                <button type="button" className="app-pagination-btn app-pagination-prev" disabled={current <= 1} aria-label="上一页" onClick={() => onChange(current - 1, pageSize)}>
+                    <ChevronLeft className="size-4" />
+                </button>
+                {items.map((item) =>
+                    item === "…" ? (
+                        <span key={`ellipsis-${items.indexOf(item)}`} className="app-pagination-ellipsis">
+                            …
+                        </span>
+                    ) : (
+                        <button key={item} type="button" className={`app-pagination-btn${item === current ? " is-active" : ""}`} aria-current={item === current ? "page" : undefined} onClick={() => onChange(item, pageSize)}>
+                            {item}
+                        </button>
+                    ),
+                )}
+                <button type="button" className="app-pagination-btn app-pagination-next" disabled={current >= pages} aria-label="下一页" onClick={() => onChange(current + 1, pageSize)}>
+                    <ChevronRight className="size-4" />
+                </button>
             </div>
         </div>
     );

--- a/web/src/components/model-capability-editor.tsx
+++ b/web/src/components/model-capability-editor.tsx
@@ -25,14 +25,15 @@ type Props = {
     capability?: "text" | "image" | "video";
     model?: string;
     disabled?: boolean;
+    section?: "all" | "protocol" | "references";
 };
 
-export function ModelCapabilityEditor({ value, onChange, protocol, capability = "video", model = "", disabled = false }: Props) {
+export function ModelCapabilityEditor({ value, onChange, protocol, capability = "video", model = "", disabled = false, section = "all" }: Props) {
     if (capability === "text") {
-        return <TextCapabilityEditor value={value} onChange={onChange} protocol={protocol} disabled={disabled} />;
+        return <TextCapabilityEditor value={value} onChange={onChange} protocol={protocol} disabled={disabled} section={section} />;
     }
     if (capability === "image") {
-        return <ImageCapabilityEditor value={value} onChange={onChange} protocol={protocol} model={model} disabled={disabled} />;
+        return <ImageCapabilityEditor value={value} onChange={onChange} protocol={protocol} model={model} disabled={disabled} section={section} />;
     }
     const profile = normalizeModelCapabilityConfig(value || defaultModelCapabilityConfig(protocol)).video!;
     const update = (patch: Partial<VideoCapabilityConfig>) => onChange?.({ version: 1, video: { ...profile, ...patch } });
@@ -41,70 +42,330 @@ export function ModelCapabilityEditor({ value, onChange, protocol, capability = 
     const durationValues = (profile.duration.values || []).join(",");
     const resolutionOptions = Array.from(new Set([...VIDEO_RESOLUTION_CAPABILITY_OPTIONS, ...profile.resolutions]));
 
+    if (section === "references") {
+        return (
+            <div className="admin-capability-reference-editor">
+                <div className="admin-capability-reference-grid">
+                    <ReferenceCard title="图片引用" description="首帧、参考图与多图输入限制">
+                        <NumberField label="最少图片引用" value={profile.references.minImages} min={0} max={profile.references.maxImages} disabled={disabled} onChange={(value) => updateReferences({ minImages: value || 0 })} />
+                        <NumberField
+                            label="最大图片引用"
+                            value={profile.references.maxImages}
+                            min={0}
+                            disabled={disabled}
+                            onChange={(value) => {
+                                const maxImages = value || 0;
+                                updateReferences({ maxImages, minImages: Math.min(profile.references.minImages, maxImages) });
+                            }}
+                        />
+                        <NumberField label="单张图片上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxImageBytes: mbToBytes(value) })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="音频引用" description="音频输入与同步输出限制">
+                        <NumberField label="最大音频引用" value={profile.references.maxAudios} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudios: value || 0 })} />
+                        <NumberField label="单个音频上限 MB" value={bytesToMB(profile.references.maxAudioBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioBytes: mbToBytes(value) })} />
+                        <NumberField label="单个音频最长秒数" value={profile.references.maxAudioDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioDurationSeconds: value || 0 })} />
+                        <BooleanField label="同步音频" value={profile.generateAudio} disabled={disabled} onChange={(generateAudio) => update({ generateAudio })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="视频引用" description="视频数量、大小与时长限制">
+                        <NumberField label="最大视频引用" value={profile.references.maxVideos} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideos: value || 0 })} />
+                        <NumberField label="单个视频上限 MB" value={bytesToMB(profile.references.maxVideoBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoBytes: mbToBytes(value) })} />
+                        <NumberField label="单个视频最长秒数" value={profile.references.maxVideoDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoDurationSeconds: value || 0 })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="通用限制" description="所有视频请求共用的基础约束">
+                        <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(value) => updateReferences({ promptMaxChars: value || 1 })} />
+                        <BooleanField label="水印" value={profile.watermark} disabled={disabled} onChange={(watermark) => update({ watermark })} />
+                    </ReferenceCard>
+                </div>
+            </div>
+        );
+    }
+
+    if (section === "protocol") {
+        return (
+            <div className="admin-capability-protocol-editor">
+                <div className="admin-capability-protocol-grid">
+                    <ProtocolParameterCard step="01" title="生成方式" description="允许的任务类型与默认任务">
+                        <Field label="支持模式">
+                            <Select
+                                mode="multiple"
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.operations}
+                                options={operationOptions}
+                                onChange={(operations) => update({ operations, defaultOperation: operations.includes(profile.defaultOperation) ? profile.defaultOperation : operations[0] || "text_to_video" })}
+                            />
+                        </Field>
+                        <Field label="默认模式">
+                            <Select
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.defaultOperation}
+                                options={operationOptions.filter((item) => profile.operations.includes(item.value))}
+                                onChange={(defaultOperation) => update({ defaultOperation })}
+                            />
+                        </Field>
+                    </ProtocolParameterCard>
+                    <ProtocolParameterCard step="02" title="输出时长" description="定义可用秒数及默认时长">
+                        <Segmented
+                            block
+                            disabled={disabled}
+                            value={profile.duration.selection}
+                            options={[
+                                { label: "范围", value: "range" },
+                                { label: "固定值", value: "enum" },
+                            ]}
+                            onChange={(value) =>
+                                updateDuration(
+                                    value === "enum"
+                                        ? { selection: "enum", values: profile.duration.values?.length ? profile.duration.values : [profile.duration.default] }
+                                        : { selection: "range", min: profile.duration.min || 1, max: profile.duration.max || 15, step: profile.duration.step || 1 },
+                                )
+                            }
+                        />
+                        {profile.duration.selection === "enum" ? (
+                            <Field label="固定时长（秒）">
+                                <Input
+                                    disabled={disabled}
+                                    value={durationValues}
+                                    placeholder="例如：5,10"
+                                    onChange={(event) => updateDuration({ values: parseIntegerList(event.target.value), default: parseIntegerList(event.target.value)[0] || profile.duration.default })}
+                                />
+                            </Field>
+                        ) : (
+                            <div className="admin-capability-duration-grid">
+                                <NumberField label="最短" value={profile.duration.min} min={1} disabled={disabled} onChange={(value) => updateDuration({ min: value || 1 })} />
+                                <NumberField label="最长" value={profile.duration.max} min={1} disabled={disabled} onChange={(value) => updateDuration({ max: value || 1 })} />
+                                <NumberField label="步长" value={profile.duration.step} min={1} disabled={disabled} onChange={(value) => updateDuration({ step: value || 1 })} />
+                                <NumberField label="默认" value={profile.duration.default} min={1} disabled={disabled} onChange={(value) => updateDuration({ default: value || 1 })} />
+                            </div>
+                        )}
+                    </ProtocolParameterCard>
+                    <ProtocolParameterCard step="03" title="画面规格" description="控制比例、分辨率及默认输出">
+                        <div className="admin-capability-spec-grid">
+                            <Field label="支持比例">
+                                <Select
+                                    mode="multiple"
+                                    className="w-full"
+                                    disabled={disabled}
+                                    value={profile.ratios}
+                                    options={ratioOptions.map((item) => ({ label: item, value: item }))}
+                                    onChange={(ratios) => update({ ratios, defaultRatio: ratios.includes(profile.defaultRatio) ? profile.defaultRatio : ratios[0] || "16:9" })}
+                                />
+                            </Field>
+                            <Field label="默认比例">
+                                <Select className="w-full" disabled={disabled} value={profile.defaultRatio} options={profile.ratios.map((item) => ({ label: item, value: item }))} onChange={(defaultRatio) => update({ defaultRatio })} />
+                            </Field>
+                            <Field label="输出分辨率">
+                                <Select
+                                    mode="tags"
+                                    className="admin-capability-tags w-full"
+                                    disabled={disabled}
+                                    value={profile.resolutions}
+                                    tokenSeparators={[","]}
+                                    placeholder="选择或输入模型档位"
+                                    options={resolutionOptions.map((item) => ({ label: item.toUpperCase(), value: item }))}
+                                    onChange={(resolutions) => update({ resolutions, defaultResolution: resolutions.includes(profile.defaultResolution) ? profile.defaultResolution : resolutions[0] || "" })}
+                                />
+                            </Field>
+                            <Field label="默认分辨率">
+                                <Select
+                                    className="w-full"
+                                    disabled={disabled}
+                                    value={profile.defaultResolution}
+                                    options={profile.resolutions.map((item) => ({ label: item.toUpperCase(), value: item }))}
+                                    onChange={(defaultResolution) => update({ defaultResolution })}
+                                />
+                            </Field>
+                        </div>
+                    </ProtocolParameterCard>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="admin-capability-editor space-y-3 rounded-md bg-muted/10 p-3">
-            <div className="flex items-center justify-between gap-3">
-                <div><div className="text-sm font-medium">视频能力参数</div><div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/48">这些参数会同步到创造页、画布和生成校验</div></div>
+            <div className="admin-capability-editor-heading flex flex-wrap items-start justify-between gap-2">
+                <div>
+                    <div className="text-sm font-medium">视频能力参数</div>
+                    <div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/48">这些参数会同步到创造页、画布和生成校验</div>
+                </div>
                 <span className="text-[var(--fs-tiny)] text-foreground/40">协议模板可继续调整</span>
             </div>
 
-            <CapabilityGroup title="引用限制">
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    <NumberField label="提示词字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(value) => updateReferences({ promptMaxChars: value || 1 })} />
-                    <NumberField label="最少图片引用" value={profile.references.minImages} min={0} max={profile.references.maxImages} disabled={disabled} onChange={(value) => updateReferences({ minImages: value || 0 })} />
-                    <NumberField label="最大图片引用" value={profile.references.maxImages} min={0} disabled={disabled} onChange={(value) => { const maxImages = value || 0; updateReferences({ maxImages, minImages: Math.min(profile.references.minImages, maxImages) }); }} />
-                    <NumberField label="图片上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxImageBytes: mbToBytes(value) })} />
-                    <NumberField label="最大视频引用" value={profile.references.maxVideos} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideos: value || 0 })} />
-                    <NumberField label="视频上限 MB" value={bytesToMB(profile.references.maxVideoBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoBytes: mbToBytes(value) })} />
-                    <NumberField label="视频最长秒数" value={profile.references.maxVideoDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoDurationSeconds: value || 0 })} />
-                    <NumberField label="最大音频引用" value={profile.references.maxAudios} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudios: value || 0 })} />
-                    <NumberField label="音频上限 MB" value={bytesToMB(profile.references.maxAudioBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioBytes: mbToBytes(value) })} />
-                    <NumberField label="音频最长秒数" value={profile.references.maxAudioDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioDurationSeconds: value || 0 })} />
-                </div>
-            </CapabilityGroup>
-
-            <CapabilityGroup title="视频时长">
-                <Segmented block disabled={disabled} value={profile.duration.selection} options={[{ label: "范围", value: "range" }, { label: "固定值", value: "enum" }]} onChange={(value) => updateDuration(value === "enum" ? { selection: "enum", values: profile.duration.values?.length ? profile.duration.values : [profile.duration.default] } : { selection: "range", min: profile.duration.min || 1, max: profile.duration.max || 15, step: profile.duration.step || 1 })} />
-                {profile.duration.selection === "enum" ? (
-                    <Field label="固定时长（秒）"><Input disabled={disabled} value={durationValues} placeholder="例如：5,10" onChange={(event) => updateDuration({ values: parseIntegerList(event.target.value), default: parseIntegerList(event.target.value)[0] || profile.duration.default })} /></Field>
-                ) : (
-                    <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                        <NumberField label="最短" value={profile.duration.min} min={1} disabled={disabled} onChange={(value) => updateDuration({ min: value || 1 })} />
-                        <NumberField label="最长" value={profile.duration.max} min={1} disabled={disabled} onChange={(value) => updateDuration({ max: value || 1 })} />
-                        <NumberField label="步长" value={profile.duration.step} min={1} disabled={disabled} onChange={(value) => updateDuration({ step: value || 1 })} />
-                        <NumberField label="默认" value={profile.duration.default} min={1} disabled={disabled} onChange={(value) => updateDuration({ default: value || 1 })} />
+            <CapabilityGroup title="视频" description="生成方式、输出规格与视频引用约束">
+                <CapabilityBlock title="生成方式">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <Field label="支持模式">
+                            <Select
+                                mode="multiple"
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.operations}
+                                options={operationOptions}
+                                onChange={(operations) => update({ operations, defaultOperation: operations.includes(profile.defaultOperation) ? profile.defaultOperation : operations[0] || "text_to_video" })}
+                            />
+                        </Field>
+                        <Field label="默认模式">
+                            <Select
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.defaultOperation}
+                                options={operationOptions.filter((item) => profile.operations.includes(item.value))}
+                                onChange={(defaultOperation) => update({ defaultOperation })}
+                            />
+                        </Field>
                     </div>
-                )}
+                </CapabilityBlock>
+                <CapabilityBlock title="输出时长">
+                    <Segmented
+                        block
+                        disabled={disabled}
+                        value={profile.duration.selection}
+                        options={[
+                            { label: "范围", value: "range" },
+                            { label: "固定值", value: "enum" },
+                        ]}
+                        onChange={(value) =>
+                            updateDuration(
+                                value === "enum"
+                                    ? { selection: "enum", values: profile.duration.values?.length ? profile.duration.values : [profile.duration.default] }
+                                    : { selection: "range", min: profile.duration.min || 1, max: profile.duration.max || 15, step: profile.duration.step || 1 },
+                            )
+                        }
+                    />
+                    {profile.duration.selection === "enum" ? (
+                        <Field label="固定时长（秒）">
+                            <Input
+                                disabled={disabled}
+                                value={durationValues}
+                                placeholder="例如：5,10"
+                                onChange={(event) => updateDuration({ values: parseIntegerList(event.target.value), default: parseIntegerList(event.target.value)[0] || profile.duration.default })}
+                            />
+                        </Field>
+                    ) : (
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                            <NumberField label="最短" value={profile.duration.min} min={1} disabled={disabled} onChange={(value) => updateDuration({ min: value || 1 })} />
+                            <NumberField label="最长" value={profile.duration.max} min={1} disabled={disabled} onChange={(value) => updateDuration({ max: value || 1 })} />
+                            <NumberField label="步长" value={profile.duration.step} min={1} disabled={disabled} onChange={(value) => updateDuration({ step: value || 1 })} />
+                            <NumberField label="默认" value={profile.duration.default} min={1} disabled={disabled} onChange={(value) => updateDuration({ default: value || 1 })} />
+                        </div>
+                    )}
+                </CapabilityBlock>
+                <CapabilityBlock title="画面规格">
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <Field label="画面比例">
+                            <Select
+                                mode="multiple"
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.ratios}
+                                options={ratioOptions.map((item) => ({ label: item, value: item }))}
+                                onChange={(ratios) => update({ ratios, defaultRatio: ratios.includes(profile.defaultRatio) ? profile.defaultRatio : ratios[0] || "16:9" })}
+                            />
+                        </Field>
+                        <Field label="默认比例">
+                            <Select className="w-full" disabled={disabled} value={profile.defaultRatio} options={profile.ratios.map((item) => ({ label: item, value: item }))} onChange={(defaultRatio) => update({ defaultRatio })} />
+                        </Field>
+                        <Field label="输出分辨率">
+                            <Select
+                                mode="tags"
+                                className="admin-capability-tags w-full"
+                                disabled={disabled}
+                                value={profile.resolutions}
+                                tokenSeparators={[","]}
+                                placeholder="选择标准档位或输入 768p 等模型专属值"
+                                options={resolutionOptions.map((item) => ({ label: item.toUpperCase(), value: item }))}
+                                onChange={(resolutions) => update({ resolutions, defaultResolution: resolutions.includes(profile.defaultResolution) ? profile.defaultResolution : resolutions[0] || "" })}
+                            />
+                        </Field>
+                        <Field label="默认分辨率">
+                            <Select
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.defaultResolution}
+                                options={profile.resolutions.map((item) => ({ label: item.toUpperCase(), value: item }))}
+                                onChange={(defaultResolution) => update({ defaultResolution })}
+                            />
+                        </Field>
+                    </div>
+                </CapabilityBlock>
+                {section === "all" ? (
+                    <CapabilityBlock title="视频引用">
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            <NumberField label="最大视频引用" value={profile.references.maxVideos} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideos: value || 0 })} />
+                            <NumberField label="单个视频上限 MB" value={bytesToMB(profile.references.maxVideoBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoBytes: mbToBytes(value) })} />
+                            <NumberField label="单个视频最长秒数" value={profile.references.maxVideoDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxVideoDurationSeconds: value || 0 })} />
+                        </div>
+                    </CapabilityBlock>
+                ) : null}
             </CapabilityGroup>
 
-            <CapabilityGroup title="输出参数">
-                <div className="grid gap-2 sm:grid-cols-2">
-                    <Field label="画面比例"><Select mode="multiple" className="w-full" disabled={disabled} value={profile.ratios} options={ratioOptions.map((item) => ({ label: item, value: item }))} onChange={(ratios) => update({ ratios, defaultRatio: ratios.includes(profile.defaultRatio) ? profile.defaultRatio : ratios[0] || "16:9" })} /></Field>
-                    <Field label="默认比例"><Select className="w-full" disabled={disabled} value={profile.defaultRatio} options={profile.ratios.map((item) => ({ label: item, value: item }))} onChange={(defaultRatio) => update({ defaultRatio })} /></Field>
-                    <Field label="输出分辨率"><Select mode="tags" className="admin-capability-tags w-full" disabled={disabled} value={profile.resolutions} tokenSeparators={[","]} placeholder="选择标准档位或输入 768p 等模型专属值" options={resolutionOptions.map((item) => ({ label: item.toUpperCase(), value: item }))} onChange={(resolutions) => update({ resolutions, defaultResolution: resolutions.includes(profile.defaultResolution) ? profile.defaultResolution : resolutions[0] || "" })} /></Field>
-                    <Field label="默认分辨率"><Select className="w-full" disabled={disabled} value={profile.defaultResolution} options={profile.resolutions.map((item) => ({ label: item.toUpperCase(), value: item }))} onChange={(defaultResolution) => update({ defaultResolution })} /></Field>
-                </div>
-                <div className="grid gap-2 sm:grid-cols-2">
-                    <BooleanField label="同步音频" value={profile.generateAudio} disabled={disabled} onChange={(generateAudio) => update({ generateAudio })} />
-                    <BooleanField label="水印" value={profile.watermark} disabled={disabled} onChange={(watermark) => update({ watermark })} />
-                </div>
-            </CapabilityGroup>
+            {section === "all" ? (
+                <>
+                    <CapabilityGroup title="图片" description="首帧、参考图与多图输入约束">
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            <NumberField label="最少图片引用" value={profile.references.minImages} min={0} max={profile.references.maxImages} disabled={disabled} onChange={(value) => updateReferences({ minImages: value || 0 })} />
+                            <NumberField
+                                label="最大图片引用"
+                                value={profile.references.maxImages}
+                                min={0}
+                                disabled={disabled}
+                                onChange={(value) => {
+                                    const maxImages = value || 0;
+                                    updateReferences({ maxImages, minImages: Math.min(profile.references.minImages, maxImages) });
+                                }}
+                            />
+                            <NumberField label="单张图片上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxImageBytes: mbToBytes(value) })} />
+                        </div>
+                    </CapabilityGroup>
 
-            <CapabilityGroup title="生成模式">
-                <div className="grid gap-2 sm:grid-cols-2">
-                    <Field label="支持模式"><Select mode="multiple" className="w-full" disabled={disabled} value={profile.operations} options={operationOptions} onChange={(operations) => update({ operations, defaultOperation: operations.includes(profile.defaultOperation) ? profile.defaultOperation : operations[0] || "text_to_video" })} /></Field>
-                    <Field label="默认模式"><Select className="w-full" disabled={disabled} value={profile.defaultOperation} options={operationOptions.filter((item) => profile.operations.includes(item.value))} onChange={(defaultOperation) => update({ defaultOperation })} /></Field>
-                </div>
-            </CapabilityGroup>
+                    <CapabilityGroup title="音频" description="音频引用与视频同步音频输出">
+                        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                            <NumberField label="最大音频引用" value={profile.references.maxAudios} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudios: value || 0 })} />
+                            <NumberField label="单个音频上限 MB" value={bytesToMB(profile.references.maxAudioBytes)} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioBytes: mbToBytes(value) })} />
+                            <NumberField label="单个音频最长秒数" value={profile.references.maxAudioDurationSeconds} min={0} disabled={disabled} onChange={(value) => updateReferences({ maxAudioDurationSeconds: value || 0 })} />
+                        </div>
+                        <BooleanField label="同步音频" value={profile.generateAudio} disabled={disabled} onChange={(generateAudio) => update({ generateAudio })} />
+                    </CapabilityGroup>
+
+                    <CapabilityGroup title="通用限制" description="不属于单一媒体类型的请求与输出约束">
+                        <div className="grid gap-3 sm:grid-cols-2">
+                            <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(value) => updateReferences({ promptMaxChars: value || 1 })} />
+                            <BooleanField label="水印" value={profile.watermark} disabled={disabled} onChange={(watermark) => update({ watermark })} />
+                        </div>
+                    </CapabilityGroup>
+                </>
+            ) : null}
         </div>
     );
 }
 
-function TextCapabilityEditor({ value, onChange, protocol, disabled }: Pick<Props, "value" | "onChange" | "protocol" | "disabled">) {
+function TextCapabilityEditor({ value, onChange, protocol, disabled, section }: Pick<Props, "value" | "onChange" | "protocol" | "disabled" | "section">) {
     const profile = value?.text || defaultModelCapabilityConfig(protocol).text!;
     const updateReferences = (patch: Partial<TextCapabilityConfig["references"]>) => {
         onChange?.({ version: 1, text: { references: { ...profile.references, ...patch } } });
     };
+
+    if (section === "references") {
+        return (
+            <div className="admin-capability-reference-editor">
+                <div className="admin-capability-reference-grid is-three">
+                    <ReferenceCard title="图片引用" description="文本模型可接收的图片范围">
+                        <NumberField label="最大参考图片数" value={profile.references.maxImages} min={0} max={100} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxImages: next || 0 })} />
+                        <NumberField label="单张图片上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxImageBytes: mbToBytes(next) })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="视频引用" description="文本模型可接收的视频范围">
+                        <NumberField label="最大参考视频数" value={profile.references.maxVideos} min={0} max={100} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxVideos: next || 0 })} />
+                        <NumberField label="单个视频上限 MB" value={bytesToMB(profile.references.maxVideoBytes)} min={0} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxVideoBytes: mbToBytes(next) })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="通用限制" description="所有文本请求共用的基础约束">
+                        <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} max={1_000_000} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ promptMaxChars: next || 1 })} />
+                    </ReferenceCard>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="admin-capability-editor space-y-3 rounded-md bg-muted/20 p-3">
@@ -112,97 +373,345 @@ function TextCapabilityEditor({ value, onChange, protocol, disabled }: Pick<Prop
                 <div className="text-sm font-medium">文本理解能力</div>
                 <div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/48">默认不假设支持图片或视频，只有明确配置后相关请求才会进入该模型。</div>
             </div>
-            <CapabilityGroup title="输入限制">
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                    <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} max={1_000_000} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ promptMaxChars: next || 1 })} />
+            <CapabilityGroup title="图片" description="文本模型可接收的图片参考范围">
+                <div className="grid gap-3 sm:grid-cols-2">
                     <NumberField label="最大参考图片数" value={profile.references.maxImages} min={0} max={100} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxImages: next || 0 })} />
                     <NumberField label="单张图片上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxImageBytes: mbToBytes(next) })} />
+                </div>
+            </CapabilityGroup>
+            <CapabilityGroup title="视频" description="文本模型可接收的视频参考范围">
+                <div className="grid gap-3 sm:grid-cols-2">
                     <NumberField label="最大参考视频数" value={profile.references.maxVideos} min={0} max={100} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxVideos: next || 0 })} />
                     <NumberField label="单个视频上限 MB" value={bytesToMB(profile.references.maxVideoBytes)} min={0} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ maxVideoBytes: mbToBytes(next) })} />
                 </div>
+            </CapabilityGroup>
+            <CapabilityGroup title="通用限制" description="所有文本请求共用的基础约束">
+                <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} max={1_000_000} disabled={Boolean(disabled)} onChange={(next) => updateReferences({ promptMaxChars: next || 1 })} />
             </CapabilityGroup>
         </div>
     );
 }
 
-function ImageCapabilityEditor({ value, onChange, protocol, model, disabled }: Required<Pick<Props, "model" | "disabled">> & Pick<Props, "value" | "onChange" | "protocol">) {
+function ImageCapabilityEditor({ value, onChange, protocol, model, disabled, section }: Required<Pick<Props, "model" | "disabled">> & Pick<Props, "value" | "onChange" | "protocol" | "section">) {
     const profile = normalizeModelCapabilityConfig(value || { version: 1, image: defaultImageCapabilityConfig(protocol, model) }).image!;
     const update = (patch: Partial<ImageCapabilityConfig>) => onChange?.({ version: 1, image: { ...profile, ...patch } });
     const updateReferences = (patch: Partial<ImageCapabilityConfig["references"]>) => update({ references: { ...profile.references, ...patch } });
     const updateSize = (patch: Partial<ImageCapabilityConfig["size"]>) => update({ size: { ...profile.size, ...patch } });
     const updateQuality = (patch: Partial<ImageCapabilityConfig["quality"]>) => update({ quality: { ...profile.quality, ...patch } });
 
+    if (section === "references") {
+        return (
+            <div className="admin-capability-reference-editor">
+                <div className="admin-capability-reference-grid is-two">
+                    <ReferenceCard title="图片引用" description="参考图、文件大小与蒙版能力">
+                        <NumberField label="最大参考图" value={profile.references.maxImages} min={0} disabled={disabled} onChange={(maxImages) => updateReferences({ maxImages: maxImages || 0 })} />
+                        <NumberField label="单图上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={disabled} onChange={(maxImageBytes) => updateReferences({ maxImageBytes: mbToBytes(maxImageBytes) })} />
+                        <ParameterField label="蒙版编辑" description="允许图片编辑接口提交 mask" supported={profile.references.maskSupported} disabled={disabled} onChange={(maskSupported) => updateReferences({ maskSupported })} />
+                    </ReferenceCard>
+                    <ReferenceCard title="通用限制" description="所有图片请求共用的基础约束">
+                        <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(promptMaxChars) => updateReferences({ promptMaxChars: promptMaxChars || 1 })} />
+                    </ReferenceCard>
+                </div>
+            </div>
+        );
+    }
+
+    if (section === "protocol") {
+        return (
+            <div className="admin-capability-protocol-editor">
+                <div className="admin-capability-protocol-grid">
+                    <ProtocolParameterCard step="01" title="输出数量" description="设置单次生成图片数量">
+                        <NumberField label="单次生成张数" value={profile.maxOutputs} min={1} disabled={disabled} onChange={(maxOutputs) => update({ maxOutputs: maxOutputs || 1 })} />
+                    </ProtocolParameterCard>
+                    <ProtocolParameterCard step="02" title="尺寸参数" description="定义尺寸字段、支持值与默认值">
+                        <Segmented
+                            block
+                            disabled={disabled}
+                            value={profile.size.parameter}
+                            options={[
+                                { label: "不发送", value: "none" },
+                                { label: "size", value: "size" },
+                                { label: "aspect_ratio", value: "aspect_ratio" },
+                            ]}
+                            onChange={(value) => {
+                                const parameter = value as ImageCapabilityConfig["size"]["parameter"];
+                                updateSize(
+                                    parameter === "none"
+                                        ? { parameter, values: [], default: "auto", allowCustom: false }
+                                        : { parameter, values: profile.size.values.length ? profile.size.values : ["1:1"], default: profile.size.default === "auto" ? "1:1" : profile.size.default },
+                                );
+                            }}
+                        />
+                        {profile.size.parameter !== "none" ? (
+                            <>
+                                <Field label="支持值">
+                                    <Select
+                                        mode="tags"
+                                        className="admin-capability-tags w-full"
+                                        disabled={disabled}
+                                        value={profile.size.values}
+                                        tokenSeparators={[","]}
+                                        placeholder="例如 1:1、1024x1024"
+                                        onChange={(values) => updateSize({ values, default: values.includes(profile.size.default) || profile.size.allowCustom ? profile.size.default : values[0] || "auto" })}
+                                    />
+                                </Field>
+                                <Field label="默认值">
+                                    <Select
+                                        className="w-full"
+                                        disabled={disabled}
+                                        value={profile.size.default}
+                                        options={profile.size.values.map((item) => ({ label: item, value: item }))}
+                                        onChange={(defaultValue) => updateSize({ default: defaultValue })}
+                                    />
+                                </Field>
+                                <ParameterField label="允许自定义" description="允许支持值之外的尺寸" supported={profile.size.allowCustom} disabled={disabled} onChange={(allowCustom) => updateSize({ allowCustom })} />
+                            </>
+                        ) : null}
+                    </ProtocolParameterCard>
+                    <ProtocolParameterCard step="03" title="可选参数" description="控制质量、背景与响应格式">
+                        <ParameterField label="图片质量" description="发送 quality 参数" supported={profile.quality.supported} disabled={disabled} onChange={(supported) => updateQuality({ supported })} />
+                        {profile.quality.supported ? (
+                            <div className="admin-capability-spec-grid">
+                                <Field label="质量支持值">
+                                    <Select
+                                        mode="tags"
+                                        className="admin-capability-tags w-full"
+                                        disabled={disabled}
+                                        value={profile.quality.values}
+                                        tokenSeparators={[","]}
+                                        onChange={(values) => updateQuality({ values, default: values.includes(profile.quality.default) ? profile.quality.default : values[0] || "auto" })}
+                                    />
+                                </Field>
+                                <Field label="默认质量">
+                                    <Select
+                                        className="w-full"
+                                        disabled={disabled}
+                                        value={profile.quality.default}
+                                        options={profile.quality.values.map((item) => ({ label: item, value: item }))}
+                                        onChange={(defaultValue) => updateQuality({ default: defaultValue })}
+                                    />
+                                </Field>
+                            </div>
+                        ) : null}
+                        <BooleanField label="透明背景" value={profile.transparentBackground} disabled={disabled} onChange={(transparentBackground) => update({ transparentBackground })} />
+                        <ParameterField label="response_format" description="发送 b64_json 响应格式" supported={profile.responseFormat.supported} disabled={disabled} onChange={(supported) => update({ responseFormat: { supported } })} />
+                        <ParameterField label="output_format" description="发送 PNG 输出格式" supported={profile.outputFormat.supported} disabled={disabled} onChange={(supported) => update({ outputFormat: { supported } })} />
+                    </ProtocolParameterCard>
+                </div>
+            </div>
+        );
+    }
+
     return (
         <div className="admin-capability-editor space-y-3 rounded-md bg-muted/10 p-3">
-            <div className="flex items-center justify-between gap-3">
-                <div><div className="text-sm font-medium">图片能力参数</div><div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/48">生成界面和后端请求都会按此处裁剪参数</div></div>
+            <div className="admin-capability-editor-heading flex flex-wrap items-start justify-between gap-2">
+                <div>
+                    <div className="text-sm font-medium">图片能力参数</div>
+                    <div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/48">生成界面和后端请求都会按此处裁剪参数</div>
+                </div>
                 <span className="text-[var(--fs-tiny)] text-foreground/40">当前模型独立生效</span>
             </div>
 
-            <CapabilityGroup title="输入与输出限制">
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-                    <NumberField label="提示词字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(promptMaxChars) => updateReferences({ promptMaxChars: promptMaxChars || 1 })} />
+            <CapabilityGroup title="图片" description="参考图、蒙版与图片输入约束">
+                <div className="grid gap-3 sm:grid-cols-2">
                     <NumberField label="最大参考图" value={profile.references.maxImages} min={0} disabled={disabled} onChange={(maxImages) => updateReferences({ maxImages: maxImages || 0 })} />
                     <NumberField label="单图上限 MB" value={bytesToMB(profile.references.maxImageBytes)} min={0} disabled={disabled} onChange={(maxImageBytes) => updateReferences({ maxImageBytes: mbToBytes(maxImageBytes) })} />
-                    <NumberField label="单次生成张数" value={profile.maxOutputs} min={1} disabled={disabled} onChange={(maxOutputs) => update({ maxOutputs: maxOutputs || 1 })} />
                 </div>
                 <ParameterField label="蒙版编辑" description="允许调用图片编辑接口并提交 mask" supported={profile.references.maskSupported} disabled={disabled} onChange={(maskSupported) => updateReferences({ maskSupported })} />
             </CapabilityGroup>
 
-            <CapabilityGroup title="尺寸参数">
-                <Segmented
-                    block
-                    disabled={disabled}
-                    value={profile.size.parameter}
-                    options={[{ label: "不发送", value: "none" }, { label: "size", value: "size" }, { label: "aspect_ratio", value: "aspect_ratio" }]}
-                    onChange={(value) => {
-                        const parameter = value as ImageCapabilityConfig["size"]["parameter"];
-                        updateSize(parameter === "none" ? { parameter, values: [], default: "auto", allowCustom: false } : { parameter, values: profile.size.values.length ? profile.size.values : ["1:1"], default: profile.size.default === "auto" ? "1:1" : profile.size.default });
-                    }}
-                />
-                {profile.size.parameter !== "none" ? <>
-                    <Field label="支持值"><Select mode="tags" className="admin-capability-tags w-full" disabled={disabled} value={profile.size.values} tokenSeparators={[","]} placeholder="例如 1:1、1024x1024" onChange={(values) => updateSize({ values, default: values.includes(profile.size.default) || profile.size.allowCustom ? profile.size.default : values[0] || "auto" })} /></Field>
-                    <div className="grid gap-2 sm:grid-cols-2">
-                        <Field label="默认值"><Select className="w-full" disabled={disabled} value={profile.size.default} options={profile.size.values.map((item) => ({ label: item, value: item }))} onChange={(defaultValue) => updateSize({ default: defaultValue })} /></Field>
-                        <ParameterField label="允许自定义" description="允许用户输入支持值之外的尺寸" supported={profile.size.allowCustom} disabled={disabled} onChange={(allowCustom) => updateSize({ allowCustom })} />
-                    </div>
-                </> : null}
+            <CapabilityGroup title="输出规格" description="单次生成数量、尺寸参数与默认值">
+                <CapabilityBlock title="生成数量">
+                    <NumberField label="单次生成张数" value={profile.maxOutputs} min={1} disabled={disabled} onChange={(maxOutputs) => update({ maxOutputs: maxOutputs || 1 })} />
+                </CapabilityBlock>
+                <CapabilityBlock title="尺寸参数">
+                    <Segmented
+                        block
+                        disabled={disabled}
+                        value={profile.size.parameter}
+                        options={[
+                            { label: "不发送", value: "none" },
+                            { label: "size", value: "size" },
+                            { label: "aspect_ratio", value: "aspect_ratio" },
+                        ]}
+                        onChange={(value) => {
+                            const parameter = value as ImageCapabilityConfig["size"]["parameter"];
+                            updateSize(
+                                parameter === "none"
+                                    ? { parameter, values: [], default: "auto", allowCustom: false }
+                                    : { parameter, values: profile.size.values.length ? profile.size.values : ["1:1"], default: profile.size.default === "auto" ? "1:1" : profile.size.default },
+                            );
+                        }}
+                    />
+                    {profile.size.parameter !== "none" ? (
+                        <>
+                            <Field label="支持值">
+                                <Select
+                                    mode="tags"
+                                    className="admin-capability-tags w-full"
+                                    disabled={disabled}
+                                    value={profile.size.values}
+                                    tokenSeparators={[","]}
+                                    placeholder="例如 1:1、1024x1024"
+                                    onChange={(values) => updateSize({ values, default: values.includes(profile.size.default) || profile.size.allowCustom ? profile.size.default : values[0] || "auto" })}
+                                />
+                            </Field>
+                            <div className="grid gap-3 sm:grid-cols-2">
+                                <Field label="默认值">
+                                    <Select
+                                        className="w-full"
+                                        disabled={disabled}
+                                        value={profile.size.default}
+                                        options={profile.size.values.map((item) => ({ label: item, value: item }))}
+                                        onChange={(defaultValue) => updateSize({ default: defaultValue })}
+                                    />
+                                </Field>
+                                <ParameterField label="允许自定义" description="允许用户输入支持值之外的尺寸" supported={profile.size.allowCustom} disabled={disabled} onChange={(allowCustom) => updateSize({ allowCustom })} />
+                            </div>
+                        </>
+                    ) : null}
+                </CapabilityBlock>
             </CapabilityGroup>
 
-            <CapabilityGroup title="可选生成参数">
+            <CapabilityGroup title="可选参数" description="质量、背景与响应格式等非必填能力">
                 <ParameterField label="图片质量" description="发送 quality 参数" supported={profile.quality.supported} disabled={disabled} onChange={(supported) => updateQuality({ supported })} />
-                {profile.quality.supported ? <div className="grid gap-2 sm:grid-cols-2">
-                    <Field label="质量支持值"><Select mode="tags" className="admin-capability-tags w-full" disabled={disabled} value={profile.quality.values} tokenSeparators={[","]} onChange={(values) => updateQuality({ values, default: values.includes(profile.quality.default) ? profile.quality.default : values[0] || "auto" })} /></Field>
-                    <Field label="默认质量"><Select className="w-full" disabled={disabled} value={profile.quality.default} options={profile.quality.values.map((item) => ({ label: item, value: item }))} onChange={(defaultValue) => updateQuality({ default: defaultValue })} /></Field>
-                </div> : null}
+                {profile.quality.supported ? (
+                    <div className="grid gap-3 sm:grid-cols-2">
+                        <Field label="质量支持值">
+                            <Select
+                                mode="tags"
+                                className="admin-capability-tags w-full"
+                                disabled={disabled}
+                                value={profile.quality.values}
+                                tokenSeparators={[","]}
+                                onChange={(values) => updateQuality({ values, default: values.includes(profile.quality.default) ? profile.quality.default : values[0] || "auto" })}
+                            />
+                        </Field>
+                        <Field label="默认质量">
+                            <Select
+                                className="w-full"
+                                disabled={disabled}
+                                value={profile.quality.default}
+                                options={profile.quality.values.map((item) => ({ label: item, value: item }))}
+                                onChange={(defaultValue) => updateQuality({ default: defaultValue })}
+                            />
+                        </Field>
+                    </div>
+                ) : null}
                 <BooleanField label="透明背景" value={profile.transparentBackground} disabled={disabled} onChange={(transparentBackground) => update({ transparentBackground })} />
-                <div className="grid gap-2 sm:grid-cols-2">
+                <div className="grid gap-3 sm:grid-cols-2">
                     <ParameterField label="response_format" description="发送 b64_json 响应格式" supported={profile.responseFormat.supported} disabled={disabled} onChange={(supported) => update({ responseFormat: { supported } })} />
                     <ParameterField label="output_format" description="发送 PNG 输出格式" supported={profile.outputFormat.supported} disabled={disabled} onChange={(supported) => update({ outputFormat: { supported } })} />
                 </div>
+            </CapabilityGroup>
+
+            <CapabilityGroup title="通用限制" description="所有图片请求共用的基础约束">
+                <NumberField label="提示词最大字符数" value={profile.references.promptMaxChars} min={1} disabled={disabled} onChange={(promptMaxChars) => updateReferences({ promptMaxChars: promptMaxChars || 1 })} />
             </CapabilityGroup>
         </div>
     );
 }
 
-function CapabilityGroup({ title, children }: { title: string; children: ReactNode }) {
-    return <details open className="admin-capability-group rounded-lg bg-muted/10 p-3"><summary className="cursor-pointer list-none text-xs font-semibold text-foreground/70">{title}</summary><div className="mt-3 space-y-2">{children}</div></details>;
+function CapabilityGroup({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
+    return (
+        <details open className="admin-capability-group rounded-lg bg-muted/10 p-3">
+            <summary className="cursor-pointer list-none pr-5">
+                <span className="admin-capability-group-title block text-xs font-semibold text-foreground/70">{title}</span>
+                {description ? <span className="admin-capability-group-description mt-0.5 block text-[var(--fs-tiny)] font-normal text-foreground/45">{description}</span> : null}
+            </summary>
+            <div className="mt-3 space-y-2">{children}</div>
+        </details>
+    );
+}
+
+function CapabilityBlock({ title, children }: { title: string; children: ReactNode }) {
+    return (
+        <section className="admin-capability-block">
+            <div className="admin-capability-block-title">{title}</div>
+            <div className="space-y-2">{children}</div>
+        </section>
+    );
+}
+
+function ReferenceCard({ title, description, children }: { title: string; description: string; children: ReactNode }) {
+    return (
+        <section className="admin-capability-reference-card">
+            <header className="admin-capability-reference-card-heading">
+                <h3>{title}</h3>
+                <p>{description}</p>
+            </header>
+            <div className="admin-capability-reference-fields">{children}</div>
+        </section>
+    );
+}
+
+function ProtocolParameterCard({ step, title, description, children }: { step: string; title: string; description: string; children: ReactNode }) {
+    return (
+        <section className="admin-capability-protocol-card">
+            <header className="admin-capability-protocol-card-heading">
+                <span>{step}</span>
+                <div>
+                    <h3>{title}</h3>
+                    <p>{description}</p>
+                </div>
+            </header>
+            <div className="admin-capability-protocol-fields">{children}</div>
+        </section>
+    );
 }
 
 function Field({ label, children }: { label: string; children: ReactNode }) {
-    return <label className="block min-w-0"><span className="mb-1 block text-[var(--fs-tiny)] text-foreground/48">{label}</span>{children}</label>;
+    return (
+        <label className="block min-w-0">
+            <span className="mb-1 block text-[var(--fs-tiny)] text-foreground/48">{label}</span>
+            {children}
+        </label>
+    );
 }
 
 function NumberField({ label, value, min, max, disabled, onChange }: { label: string; value?: number; min: number; max?: number; disabled: boolean; onChange: (value: number | null) => void }) {
-    return <div className="flex items-center justify-between gap-3"><span className="min-w-0 text-xs text-foreground/62">{label}</span><InputNumber className="w-32 shrink-0" disabled={disabled} min={min} max={max} precision={0} value={value} onChange={onChange} /></div>;
+    return (
+        <label className="admin-capability-number-field block min-w-0">
+            <span className="admin-capability-field-label mb-1.5 block text-xs text-foreground/62">{label}</span>
+            <InputNumber className="w-full" disabled={disabled} min={min} max={max} precision={0} value={value} onChange={onChange} />
+        </label>
+    );
 }
 
 function BooleanField({ label, value, disabled, onChange }: { label: string; value: { supported: boolean; default: boolean }; disabled: boolean; onChange: (value: { supported: boolean; default: boolean }) => void }) {
-    return <div className="flex items-center justify-between rounded-md border border-border/60 px-2.5 py-2"><div><div className="text-xs font-medium">{label}</div><div className="text-[var(--fs-tiny)] text-foreground/45">支持该参数</div></div><div className="flex items-center gap-2"><Switch size="small" disabled={disabled} checked={value.supported} onChange={(supported) => onChange({ ...value, supported })} /><Switch size="small" disabled={disabled || !value.supported} checked={value.default} onChange={(defaultValue) => onChange({ ...value, default: defaultValue })} /></div></div>;
+    return (
+        <div className="admin-capability-boolean-field flex items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2.5">
+            <div className="min-w-0">
+                <div className="text-xs font-medium">{label}</div>
+                <div className="text-[var(--fs-tiny)] text-foreground/45">可发送参数与默认值</div>
+            </div>
+            <div className="flex shrink-0 items-center gap-3">
+                <label className="grid justify-items-center gap-1 text-[var(--fs-tiny)] text-foreground/45">
+                    <span>支持</span>
+                    <Switch aria-label={`${label}支持`} size="small" disabled={disabled} checked={value.supported} onChange={(supported) => onChange({ ...value, supported })} />
+                </label>
+                <label className="grid justify-items-center gap-1 text-[var(--fs-tiny)] text-foreground/45">
+                    <span>默认</span>
+                    <Switch aria-label={`${label}默认值`} size="small" disabled={disabled || !value.supported} checked={value.default} onChange={(defaultValue) => onChange({ ...value, default: defaultValue })} />
+                </label>
+            </div>
+        </div>
+    );
 }
 
 function ParameterField({ label, description, supported, disabled, onChange }: { label: string; description: string; supported: boolean; disabled: boolean; onChange: (supported: boolean) => void }) {
-    return <div className="flex min-h-11 items-center justify-between gap-3 rounded-md border border-border/60 px-2.5 py-2"><div className="min-w-0"><div className="truncate text-xs font-medium">{label}</div><div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/45">{description}</div></div><Switch size="small" disabled={disabled} checked={supported} onChange={onChange} /></div>;
+    return (
+        <div className="admin-capability-parameter-field flex min-h-12 items-center justify-between gap-3 rounded-md border border-border/60 px-3 py-2.5">
+            <div className="min-w-0">
+                <div className="break-all text-xs font-medium">{label}</div>
+                <div className="mt-0.5 text-[var(--fs-tiny)] leading-5 text-foreground/45">{description}</div>
+            </div>
+            <label className="grid shrink-0 justify-items-center gap-1 text-[var(--fs-tiny)] text-foreground/45">
+                <span>支持</span>
+                <Switch aria-label={`${label}支持`} size="small" disabled={disabled} checked={supported} onChange={onChange} />
+            </label>
+        </div>
+    );
 }
 
 function bytesToMB(value: number) {
@@ -214,5 +723,12 @@ function mbToBytes(value: number | null) {
 }
 
 function parseIntegerList(value: string) {
-    return Array.from(new Set(value.split(",").map((item) => Number(item.trim())).filter((item) => Number.isInteger(item) && item > 0))).sort((left, right) => left - right);
+    return Array.from(
+        new Set(
+            value
+                .split(",")
+                .map((item) => Number(item.trim()))
+                .filter((item) => Number.isInteger(item) && item > 0),
+        ),
+    ).sort((left, right) => left - right);
 }

--- a/web/src/components/model-protocol-picker.tsx
+++ b/web/src/components/model-protocol-picker.tsx
@@ -57,7 +57,19 @@ export function CapabilityCardPicker({ value, onChange, density = "comfortable" 
     );
 }
 
-export function ProtocolCardPicker({ capability, value, onChange, density = "comfortable", protocols = [] }: { capability?: ModelCapabilityChoice; value?: ModelProtocol; onChange?: (value: ModelProtocol) => void; density?: PickerDensity; protocols?: ModelProtocolDefinition[] }) {
+export function ProtocolCardPicker({
+    capability,
+    value,
+    onChange,
+    density = "comfortable",
+    protocols = [],
+}: {
+    capability?: ModelCapabilityChoice;
+    value?: ModelProtocol;
+    onChange?: (value: ModelProtocol) => void;
+    density?: PickerDensity;
+    protocols?: ModelProtocolDefinition[];
+}) {
     const availableProtocols = protocols.filter((item) => item.capability === capability && item.enabled !== false);
     return (
         <div className={cn("grid grid-cols-1 gap-2 sm:grid-cols-2", density === "compact" && "gap-1.5 xl:grid-cols-3")} role="radiogroup" aria-label="模型请求协议">
@@ -79,8 +91,8 @@ export function ProtocolCardPicker({ capability, value, onChange, density = "com
                         <div className={cn("flex min-w-0 items-start", density === "compact" ? "gap-1.5 pr-4" : "gap-2.5 pr-6")}>
                             <ProtocolBrandMark protocol={protocol} compact={density === "compact"} />
                             <div className="min-w-0 flex-1">
-                                <div className={cn("truncate font-semibold", density === "compact" ? "text-xs" : "text-sm")}>{protocol.label}</div>
-                                <div className={cn("mt-0.5 truncate font-mono text-foreground/48", density === "compact" ? "text-[var(--fs-micro)]" : "text-[var(--fs-tiny)]")}>{protocol.create}</div>
+                                <div className={cn("model-protocol-card-title truncate font-semibold", density === "compact" ? "text-xs" : "text-sm")}>{protocol.label}</div>
+                                <div className={cn("model-protocol-card-endpoint mt-0.5 truncate font-mono text-foreground/48", density === "compact" ? "text-[var(--fs-micro)]" : "text-[var(--fs-tiny)]")}>{protocol.create}</div>
                             </div>
                         </div>
                         {selected ? (
@@ -104,7 +116,15 @@ export function ProtocolCardPicker({ capability, value, onChange, density = "com
     );
 }
 
-export function ModelCapabilityProtocolModal({ value, onChange, protocols = [] }: { value: { capability: ModelCapabilityChoice; protocol: ModelProtocol }; onChange: (value: { capability: ModelCapabilityChoice; protocol: ModelProtocol }) => void; protocols?: ModelProtocolDefinition[] }) {
+export function ModelCapabilityProtocolModal({
+    value,
+    onChange,
+    protocols = [],
+}: {
+    value: { capability: ModelCapabilityChoice; protocol: ModelProtocol };
+    onChange: (value: { capability: ModelCapabilityChoice; protocol: ModelProtocol }) => void;
+    protocols?: ModelProtocolDefinition[];
+}) {
     const [open, setOpen] = useState(false);
     const [draft, setDraft] = useState(value);
 

--- a/web/src/pages/admin/components/admin-shell.tsx
+++ b/web/src/pages/admin/components/admin-shell.tsx
@@ -97,26 +97,26 @@ export function AdminShell() {
         <ConfigProvider theme={getAdminAntThemeConfig(dark)}>
             <main className="admin-shell app-user-workspace flex h-full min-h-0 overflow-hidden text-foreground">
                 <aside className={cn("app-workspace-sidebar admin-sidebar hidden shrink-0 flex-col overflow-hidden lg:flex", collapsed && "is-collapsed")}>
-                    <div className={cn("flex h-13 shrink-0 items-center", collapsed ? "justify-center" : "gap-2 px-3")}>
+                    <div className={cn("admin-sidebar-header flex shrink-0 items-center", collapsed ? "justify-center" : "gap-2 px-3")}>
                         {!collapsed ? (
                             <Link to="/" className="app-workspace-brand-link flex min-w-0 flex-1 items-center gap-2" title="影策">
-                                <span className="grid size-7 shrink-0 place-items-center rounded-md bg-foreground text-background">
+                                <span className="admin-sidebar-brand-mark grid shrink-0 place-items-center bg-foreground text-background">
                                     <InfinityIcon className="size-4" />
                                 </span>
-                                <span className="min-w-0">
-                                    <span className="block truncate text-[var(--fs-body)] font-semibold">影策</span>
-                                    <span className="block truncate text-[var(--fs-micro)] text-foreground/42">管理后台</span>
+                                <span className="admin-sidebar-brand-copy min-w-0">
+                                    <span className="block truncate font-semibold">影策</span>
+                                    <span className="block truncate">管理后台</span>
                                 </span>
                             </Link>
                         ) : null}
                         <Tooltip mouseEnterDelay={0.1} title={collapsed ? "展开侧栏" : "折叠侧栏"} placement="right">
-                            <button type="button" className="app-workspace-icon-button shrink-0" onClick={toggleCollapsed} aria-label={collapsed ? "展开侧栏" : "折叠侧栏"}>
+                            <button type="button" className="app-workspace-icon-button admin-sidebar-toggle shrink-0" onClick={toggleCollapsed} aria-label={collapsed ? "展开侧栏" : "折叠侧栏"}>
                                 {collapsed ? <PanelLeftOpen className="size-4" /> : <PanelLeftClose className="size-4" />}
                             </button>
                         </Tooltip>
                     </div>
                     <AdminNavigation collapsed={collapsed} />
-                    <div className="shrink-0 border-t border-border/70 p-2">
+                    <div className="admin-sidebar-footer shrink-0">
                         <Tooltip mouseEnterDelay={0.1} title={collapsed ? "更新日志" : undefined} placement="right">
                             <AppChangelogButton
                                 className={cn("flex h-8 w-full items-center rounded text-[var(--fs-label)] text-foreground/52 transition-colors hover:bg-surface-hover hover:text-foreground", collapsed ? "justify-center px-0" : "gap-2 px-2")}
@@ -140,11 +140,11 @@ export function AdminShell() {
     );
 }
 
-export function AdminPageFrame({ title, actions, back, scroll = false, children }: { title: string; description?: string; actions?: ReactNode; back?: { label: string; onClick: () => void }; scroll?: boolean; children: ReactNode }) {
+export function AdminPageFrame({ title, description, actions, back, scroll = false, children }: { title: string; description?: string; actions?: ReactNode; back?: { label: string; onClick: () => void }; scroll?: boolean; children: ReactNode }) {
     return (
         <WorkspacePage scroll={scroll} fluid className={cn("admin-page-root", scroll && "admin-page-root-scrollable")}>
             <div className={cn("admin-page-frame", scroll && "admin-page-frame-scrollable")}>
-                <header className="admin-page-header flex min-h-12 shrink-0 flex-col gap-2 pb-3 sm:flex-row sm:items-center sm:justify-between">
+                <header className="admin-page-header flex shrink-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="flex min-w-0 items-center gap-2.5">
                         {back ? (
                             <Tooltip title={back.label}>
@@ -153,7 +153,10 @@ export function AdminPageFrame({ title, actions, back, scroll = false, children 
                                 </button>
                             </Tooltip>
                         ) : null}
-                        <h1 className="truncate text-base font-semibold leading-6">{title}</h1>
+                        <div className="admin-page-title-block min-w-0">
+                            <h1 className="admin-page-title truncate font-semibold">{title}</h1>
+                            {description ? <p className="admin-page-description">{description}</p> : null}
+                        </div>
                     </div>
                     {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
                 </header>
@@ -191,19 +194,19 @@ function AdminNavigation({ collapsed }: { collapsed: boolean }) {
     const features = useUserStore((state) => state.features);
 
     return (
-        <nav className="thin-scrollbar flex-1 overflow-y-auto px-2 py-2" aria-label="管理后台菜单">
+        <nav className="admin-sidebar-nav thin-scrollbar flex-1 overflow-y-auto" aria-label="管理后台菜单">
             {adminNavigation.map((group) => {
                 const visibleItems = group.items.filter((item) => !item.requireFeature || features[item.requireFeature]);
                 if (visibleItems.length === 0) return null;
 
                 return (
-                    <div key={group.label} className="mb-3">
+                    <div key={group.label} className="admin-nav-group">
                         {!collapsed ? (
                             <div className="admin-nav-group-label mb-1 px-2.5 text-[var(--fs-tiny)] font-medium text-foreground/38">
                                 <span>{group.label}</span>
                             </div>
                         ) : (
-                            <div className="mx-auto mb-1.5 h-px w-7 bg-border/80" />
+                            <div className="admin-nav-collapsed-separator" />
                         )}
                         <div className="space-y-0.5">
                             {visibleItems.map((item) => (

--- a/web/src/pages/admin/components/admin-ui.tsx
+++ b/web/src/pages/admin/components/admin-ui.tsx
@@ -13,7 +13,11 @@ export const configuredSecretText = "已配置 · 留空不改";
 export type AdminStatusTone = "neutral" | "success" | "warning" | "error" | "info";
 
 export function AdminStatusBadge({ label, tone = "neutral", title }: { label: string; tone?: AdminStatusTone; title?: string }) {
-    return <span className="admin-status-badge" data-tone={tone} title={title}>{label}</span>;
+    return (
+        <span className="admin-status-badge" data-tone={tone} title={title}>
+            {label}
+        </span>
+    );
 }
 
 export function AdminStatTile({ label, value, detail, trend }: { label: string; value: string | number; detail?: string; trend?: { value: string; tone?: AdminStatusTone } }) {
@@ -36,6 +40,7 @@ export function AdminDataTable<RecordType extends object>({
     toolbar,
     toolbarActive,
     toolbarFilters,
+    toolbarFiltersAlwaysVisible = true,
     toolbarActiveFilters,
     onReset,
     trailing,
@@ -50,6 +55,7 @@ export function AdminDataTable<RecordType extends object>({
     toolbar?: ReactNode;
     toolbarActive?: boolean;
     toolbarFilters?: ReactNode;
+    toolbarFiltersAlwaysVisible?: boolean;
     toolbarActiveFilters?: ReactNode;
     onReset?: () => void;
     trailing?: ReactNode;
@@ -66,14 +72,18 @@ export function AdminDataTable<RecordType extends object>({
 
     return (
         <div className="admin-data-table">
-            {toolbar ? <ListToolbar active={toolbarActive} filters={toolbarFilters} activeFilters={toolbarActiveFilters} onReset={onReset} trailing={trailing}>{toolbar}</ListToolbar> : null}
+            {toolbar ? (
+                <ListToolbar active={toolbarActive} filters={toolbarFilters} filtersAlwaysVisible={toolbarFiltersAlwaysVisible} activeFilters={toolbarActiveFilters} onReset={onReset} trailing={trailing}>
+                    {toolbar}
+                </ListToolbar>
+            ) : null}
             {batchActions}
-            <div className={cn("admin-table-surface", className)}>
-                <div className="admin-table-scroll">
-                    {showSkeleton ? <AdminTableSkeleton rows={skeletonRows} columns={skeletonColumns} /> : <Table {...table} locale={{ ...table.locale, emptyText: empty ?? table.locale?.emptyText }} />}
+            <div className={cn("admin-table-frame", footer && "has-pagination")}>
+                <div className={cn("admin-table-surface", className)}>
+                    <div className="admin-table-scroll">{showSkeleton ? <AdminTableSkeleton rows={skeletonRows} columns={skeletonColumns} /> : <Table {...table} locale={{ ...table.locale, emptyText: empty ?? table.locale?.emptyText }} />}</div>
                 </div>
+                {footer ? <div className="admin-table-pagination">{footer}</div> : null}
             </div>
-            {footer ? <div className="admin-table-pagination">{footer}</div> : null}
         </div>
     );
 }
@@ -114,20 +124,14 @@ export function AdminExportButton({
         }
     };
 
-    return <Button {...buttonProps} size={size} icon={<Download className={size === "small" ? "size-3.5" : "size-4"} />} loading={exporting} onClick={() => void runExport()}>{label}</Button>;
+    return (
+        <Button {...buttonProps} size={size} icon={<Download className={size === "small" ? "size-3.5" : "size-4"} />} loading={exporting} onClick={() => void runExport()}>
+            {label}
+        </Button>
+    );
 }
 
-export function AdminTableEmpty({
-    filtered = false,
-    title,
-    description,
-    action,
-}: {
-    filtered?: boolean;
-    title?: string;
-    description?: string;
-    action?: ReactNode;
-}) {
+export function AdminTableEmpty({ filtered = false, title, description, action }: { filtered?: boolean; title?: string; description?: string; action?: ReactNode }) {
     return (
         <div className="flex min-h-40 flex-col items-center justify-center px-6 py-8 text-center">
             <span className="grid size-9 place-items-center rounded-md bg-muted/35 text-foreground/45">
@@ -154,7 +158,9 @@ export function AdminTableSkeleton({ rows = 8, columns = 6 }: { rows?: number; c
     return (
         <div className="animate-pulse motion-reduce:animate-none" aria-label="正在加载表格" role="status">
             <div className="grid h-11 items-center gap-4 border-b border-border bg-muted/30 px-4" style={{ gridTemplateColumns: `repeat(${columns}, minmax(72px, 1fr))` }}>
-                {Array.from({ length: columns }).map((_, index) => <span key={index} className="h-3 w-16 max-w-full rounded bg-foreground/10" />)}
+                {Array.from({ length: columns }).map((_, index) => (
+                    <span key={index} className="h-3 w-16 max-w-full rounded bg-foreground/10" />
+                ))}
             </div>
             {Array.from({ length: Math.max(8, rows) }).map((_, rowIndex) => (
                 <div key={rowIndex} className="grid min-h-14 items-center gap-4 border-b border-border/70 px-4 last:border-b-0" style={{ gridTemplateColumns: `repeat(${columns}, minmax(72px, 1fr))` }}>
@@ -171,8 +177,16 @@ export function AdminBatchBar({ count, onClear, children }: { count: number; onC
     if (count <= 0) return null;
     return (
         <div className="sticky top-0 z-20 mt-3 flex min-h-11 flex-wrap items-center justify-between gap-3 rounded-md border border-border bg-background/95 px-3 py-2 shadow-sm backdrop-blur">
-            <div className="flex items-center gap-2 text-sm font-medium"><CheckSquare2 className="size-4 text-foreground/60" />已选择 {count} 项</div>
-            <div className="flex flex-wrap items-center gap-2">{children}<Button type="text" size="small" icon={<X className="size-3.5" />} onClick={onClear}>取消选择</Button></div>
+            <div className="flex items-center gap-2 text-sm font-medium">
+                <CheckSquare2 className="size-4 text-foreground/60" />
+                已选择 {count} 项
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+                {children}
+                <Button type="text" size="small" icon={<X className="size-3.5" />} onClick={onClear}>
+                    取消选择
+                </Button>
+            </div>
         </div>
     );
 }
@@ -191,18 +205,10 @@ export type AdminRowAction = {
     };
 };
 
-export function AdminRowActions({
-    primary,
-    actions,
-    visibleActionCount,
-}: {
-    primary?: { label: ReactNode; icon?: ReactNode; onClick: () => void | Promise<void>; disabled?: boolean };
-    actions: AdminRowAction[];
-    visibleActionCount?: number;
-}) {
+export function AdminRowActions({ primary, actions, visibleActionCount }: { primary?: { label: ReactNode; icon?: ReactNode; onClick: () => void | Promise<void>; disabled?: boolean }; actions: AdminRowAction[]; visibleActionCount?: number }) {
     const { modal } = App.useApp();
-    // 少量操作直接露出，只有真正过多时才收进菜单，避免“更多”成为默认操作列。
-    const resolvedVisibleActionCount = visibleActionCount ?? (actions.length <= 3 ? actions.length : 2);
+    // 行内只保留一个最常用的次操作；低频或危险操作收进菜单，避免操作列堆成一排文字链接。
+    const resolvedVisibleActionCount = visibleActionCount ?? (actions.length <= 1 ? actions.length : 1);
     const visibleActions = actions.slice(0, Math.max(0, resolvedVisibleActionCount));
     const menuActions = actions.slice(Math.max(0, resolvedVisibleActionCount));
     const items: MenuProps["items"] = menuActions.map((action) => ({
@@ -229,14 +235,7 @@ export function AdminRowActions({
     };
 
     const renderActionButton = (action: AdminRowAction) => (
-        <Button
-            key={action.key}
-            type="text"
-            size="small"
-            className={cn("admin-row-action", action.danger && "admin-row-action-danger")}
-            disabled={action.disabled}
-            onClick={() => runAction(action)}
-        >
+        <Button key={action.key} type="text" size="small" className={cn("admin-row-action", action.danger && "admin-row-action-danger")} icon={action.icon} disabled={action.disabled} onClick={() => runAction(action)}>
             {action.label}
         </Button>
     );
@@ -244,7 +243,7 @@ export function AdminRowActions({
     return (
         <div className="admin-row-actions">
             {primary ? (
-                <Button type="text" size="small" className="admin-row-action admin-row-action-primary" disabled={primary.disabled} onClick={primary.onClick}>
+                <Button type="text" size="small" className="admin-row-action admin-row-action-primary" icon={primary.icon} disabled={primary.disabled} onClick={primary.onClick}>
                     {primary.label}
                 </Button>
             ) : null}
@@ -293,8 +292,8 @@ export function SettingsSectionCard({
 }) {
     const isStacked = layout === "stacked";
     return (
-        <section className={cn("admin-settings-section", isStacked ? "" : "lg:grid lg:grid-cols-4", className)}>
-            <div className={cn("flex flex-wrap items-start justify-between gap-3 px-4 py-4", isStacked ? "" : "lg:col-span-1 lg:block")}>
+        <section className={cn("admin-settings-section", isStacked ? "is-stacked" : "lg:grid lg:grid-cols-4", className)}>
+            <div className={cn("admin-settings-section-summary flex flex-wrap items-start justify-between gap-3 px-4 py-4", isStacked ? "" : "lg:col-span-1 lg:block")}>
                 <div className="flex min-w-0 items-start gap-3">
                     {icon ? <span className="grid size-8 shrink-0 place-items-center rounded-md bg-muted/40">{icon}</span> : null}
                     <div className="min-w-0">
@@ -302,11 +301,19 @@ export function SettingsSectionCard({
                         {description ? <p className="mt-1 text-xs leading-5 text-foreground/55">{description}</p> : null}
                     </div>
                 </div>
-                {status ? <div className={cn("shrink-0", isStacked ? "" : "lg:mt-4")}>{isStatusConfig(status) ? <AdminStatusBadge label={status.label} tone={status.color === "success" ? "success" : status.color === "warning" ? "warning" : status.color === "error" ? "error" : status.color === "blue" ? "info" : "neutral"} /> : status}</div> : null}
+                {status ? (
+                    <div className={cn("shrink-0", isStacked ? "" : "lg:mt-4")}>
+                        {isStatusConfig(status) ? (
+                            <AdminStatusBadge label={status.label} tone={status.color === "success" ? "success" : status.color === "warning" ? "warning" : status.color === "error" ? "error" : status.color === "blue" ? "info" : "neutral"} />
+                        ) : (
+                            status
+                        )}
+                    </div>
+                ) : null}
             </div>
-            <div className={cn("min-w-0", isStacked ? "" : "lg:col-span-3", contentClassName)}>
+            <div className={cn("admin-settings-section-content min-w-0", isStacked ? "" : "lg:col-span-3", contentClassName)}>
                 {children}
-                {footer ? <div className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">{footer}</div> : null}
+                {footer ? <div className="admin-settings-section-footer flex flex-wrap items-center justify-between gap-3 px-4 py-3">{footer}</div> : null}
             </div>
         </section>
     );

--- a/web/src/pages/admin/components/analytics-panel.tsx
+++ b/web/src/pages/admin/components/analytics-panel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { App, Button, DatePicker, Form, Input, InputNumber, Modal, Select, Tabs, Tag, Tooltip } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import dayjs, { type Dayjs } from "dayjs";
-import { Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { BarChart3, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { Area, CartesianGrid, ComposedChart, Legend, Line, ResponsiveContainer, Tooltip as ChartTooltip, XAxis, YAxis } from "recharts";
 import { useSearchParams } from "react-router";
 
@@ -272,11 +272,26 @@ export default function AnalyticsPanel({ users, channels }: Props) {
         {
             title: "操作",
             width: 170,
-            render: (_, row) => <AdminRowActions primary={{ label: "编辑", icon: <Pencil className="size-3.5" />, onClick: () => openPricing(row) }} actions={[{ key: "delete", label: "删除", icon: <Trash2 className="size-3.5" />, danger: true, confirm: { title: "删除价格配置？", description: "删除后新的调用不再使用这条价格配置，历史费用不受影响。", okText: "确认删除" }, onClick: () => removePricing(row.id) }]} />,
+            render: (_, row) => (
+                <AdminRowActions
+                    primary={{ label: "编辑", icon: <Pencil className="size-3.5" />, onClick: () => openPricing(row) }}
+                    actions={[
+                        {
+                            key: "delete",
+                            label: "删除",
+                            icon: <Trash2 className="size-3.5" />,
+                            danger: true,
+                            confirm: { title: "删除价格配置？", description: "删除后新的调用不再使用这条价格配置，历史费用不受影响。", okText: "确认删除" },
+                            onClick: () => removePricing(row.id),
+                        },
+                    ]}
+                />
+            ),
         },
     ];
 
     const trend = data?.trend || [];
+    const hasTrendActivity = trend.some((item) => item.tasks > 0 || item.requests > 0);
     const currentTrend = trend[trend.length - 1];
     const previousTrend = trend[trend.length - 2];
     const modelRows = data?.models || [];
@@ -289,17 +304,44 @@ export default function AnalyticsPanel({ users, channels }: Props) {
         <div className="space-y-5">
             <ListToolbar
                 active={Boolean(userId || model || channelId || capability)}
-                activeFilters={(
+                activeFilters={
                     <>
                         {userId ? <AdminFilterChip label={`用户：${userOptions.find((user) => user.id === userId)?.displayName || userId}`} onRemove={() => setUserId(undefined)} /> : null}
                         {model ? <AdminFilterChip label={`模型：${model}`} onRemove={() => setModel(undefined)} /> : null}
                         {channelId ? <AdminFilterChip label={`渠道：${channels.find((channel) => channel.id === channelId)?.name || channelId}`} onRemove={() => setChannelId(undefined)} /> : null}
                         {capability ? <AdminFilterChip label={`能力：${capabilityLabel(capability)}`} onRemove={() => setCapability(undefined)} /> : null}
                     </>
-                )}
-                onReset={() => { setUserId(undefined); setModel(undefined); setChannelId(undefined); setCapability(undefined); }}
-                trailing={<><Button icon={<RefreshCw className="size-4" />} loading={loading} onClick={() => void reload()}>刷新</Button><AdminExportButton exportFile={() => exportAdminAnalytics(filters)} fileName={() => `usage-${filters.from}-${filters.to}.csv`} label="导出 CSV" /></>}
-                filters={<><FilterSelect label="用户" value={userId} onChange={setUserId} options={userOptions.map((user) => ({ label: user.displayName || user.username, value: user.id }))} filterOption={false} loading={searchingUsers} onSearch={(value) => void searchUsers(value)} /><FilterSelect label="模型" value={model} onChange={setModel} options={modelOptions} width={210} /><FilterSelect label="渠道" value={channelId} onChange={setChannelId} options={channels.map((channel) => ({ label: channel.name, value: channel.id }))} /><FilterSelect label="能力" value={capability} onChange={setCapability} options={capabilityOptions} /></>}
+                }
+                onReset={() => {
+                    setUserId(undefined);
+                    setModel(undefined);
+                    setChannelId(undefined);
+                    setCapability(undefined);
+                }}
+                trailing={
+                    <>
+                        <Button icon={<RefreshCw className="size-4" />} loading={loading} onClick={() => void reload()}>
+                            刷新
+                        </Button>
+                        <AdminExportButton exportFile={() => exportAdminAnalytics(filters)} fileName={() => `usage-${filters.from}-${filters.to}.csv`} label="导出 CSV" />
+                    </>
+                }
+                filters={
+                    <>
+                        <FilterSelect
+                            label="用户"
+                            value={userId}
+                            onChange={setUserId}
+                            options={userOptions.map((user) => ({ label: user.displayName || user.username, value: user.id }))}
+                            filterOption={false}
+                            loading={searchingUsers}
+                            onSearch={(value) => void searchUsers(value)}
+                        />
+                        <FilterSelect label="模型" value={model} onChange={setModel} options={modelOptions} width={210} />
+                        <FilterSelect label="渠道" value={channelId} onChange={setChannelId} options={channels.map((channel) => ({ label: channel.name, value: channel.id }))} />
+                        <FilterSelect label="能力" value={capability} onChange={setCapability} options={capabilityOptions} />
+                    </>
+                }
             >
                 <div>
                     <div className="mb-1 text-xs text-foreground/55">时间范围</div>
@@ -308,37 +350,68 @@ export default function AnalyticsPanel({ users, channels }: Props) {
             </ListToolbar>
 
             <div className="grid overflow-hidden rounded-md border border-border sm:grid-cols-2 xl:grid-cols-4">
-                <AdminStatTile label="活跃用户" value={data ? formatNumber(data.kpi.activeUsers) : "--"} trend={formatCountDelta(currentTrend?.activeUsers, previousTrend?.activeUsers)} detail={data ? `DAU ${formatNumber(data.kpi.dau)} · WAU ${formatNumber(data.kpi.wau)} · MAU ${formatNumber(data.kpi.mau)}` : undefined} />
+                <AdminStatTile
+                    label="活跃用户"
+                    value={data ? formatNumber(data.kpi.activeUsers) : "--"}
+                    trend={formatCountDelta(currentTrend?.activeUsers, previousTrend?.activeUsers)}
+                    detail={data ? `DAU ${formatNumber(data.kpi.dau)} · WAU ${formatNumber(data.kpi.wau)} · MAU ${formatNumber(data.kpi.mau)}` : undefined}
+                />
                 <AdminStatTile label="上游请求" value={data ? formatNumber(data.kpi.upstreamRequests) : "--"} trend={formatCountDelta(currentTrend?.requests, previousTrend?.requests)} detail="当前统计范围" />
-                <AdminStatTile label="生成任务" value={data ? formatNumber(data.kpi.generationTasks) : "--"} trend={formatCountDelta(currentTrend?.tasks, previousTrend?.tasks)} detail={data ? `队列 ${formatNumber(data.kpi.currentQueuedTasks)}` : undefined} />
-                <AdminStatTile label="请求成功率" value={data ? percent(data.kpi.successRate) : "--"} trend={formatRateDelta(currentTrend?.requestSuccessRate, previousTrend?.requestSuccessRate)} detail={data ? `P95 ${formatDuration(data.kpi.p95DurationMs)}` : undefined} />
+                <AdminStatTile
+                    label="生成任务"
+                    value={data ? formatNumber(data.kpi.generationTasks) : "--"}
+                    trend={formatCountDelta(currentTrend?.tasks, previousTrend?.tasks)}
+                    detail={data ? `队列 ${formatNumber(data.kpi.currentQueuedTasks)}` : undefined}
+                />
+                <AdminStatTile
+                    label="请求成功率"
+                    value={data ? percent(data.kpi.successRate) : "--"}
+                    trend={formatRateDelta(currentTrend?.requestSuccessRate, previousTrend?.requestSuccessRate)}
+                    detail={data ? `P95 ${formatDuration(data.kpi.p95DurationMs)}` : undefined}
+                />
             </div>
             <div className="grid gap-x-4 gap-y-2 border-b border-border pb-4 text-xs text-foreground/55 sm:grid-cols-3">
-                <div>当前队列 <span className="ml-1 font-medium text-foreground">{data ? formatNumber(data.kpi.currentQueuedTasks) : "--"}</span></div>
-                <div>P95 耗时 <span className="ml-1 font-medium text-foreground">{data ? formatDuration(data.kpi.p95DurationMs) : "--"}</span></div>
-                <div>估算费用 <span className="ml-1 font-medium text-foreground">{data ? formatCost(data.kpi.estimatedCostMicros, data.kpi.currency, data.kpi.costAvailable) : "--"}</span></div>
+                <div>
+                    当前队列 <span className="ml-1 font-medium text-foreground">{data ? formatNumber(data.kpi.currentQueuedTasks) : "--"}</span>
+                </div>
+                <div>
+                    P95 耗时 <span className="ml-1 font-medium text-foreground">{data ? formatDuration(data.kpi.p95DurationMs) : "--"}</span>
+                </div>
+                <div>
+                    估算费用 <span className="ml-1 font-medium text-foreground">{data ? formatCost(data.kpi.estimatedCostMicros, data.kpi.currency, data.kpi.costAvailable) : "--"}</span>
+                </div>
             </div>
 
-            <section className="border-y border-border py-4">
+            <section className="admin-analytics-trend-section">
                 <div className="mb-3">
                     <h3 className="text-sm font-medium">使用趋势</h3>
                     <p className="text-xs text-foreground/50">生成任务与真实上游请求分开统计，成功率按上游请求计算。</p>
                 </div>
-                <div className="h-[300px] w-full">
-                    <ResponsiveContainer width="100%" height="100%">
-                        <ComposedChart data={data?.trend || []} margin={{ top: 8, right: 12, bottom: 0, left: -16 }}>
-                            <CartesianGrid stroke="currentColor" className="text-foreground/10" vertical={false} />
-                            <XAxis dataKey="day" tickFormatter={(value) => value.slice(5)} tick={{ fontSize: 11 }} />
-                            <YAxis yAxisId="count" allowDecimals={false} tick={{ fontSize: 11 }} />
-                            <YAxis yAxisId="rate" orientation="right" domain={[0, 100]} tickFormatter={(value) => `${value}%`} tick={{ fontSize: 11 }} />
-                            <ChartTooltip labelFormatter={(value) => `日期 ${value}`} />
-                            <Legend wrapperStyle={{ fontSize: 12 }} />
-                            <Area yAxisId="count" type="monotone" dataKey="tasks" name="生成任务" stroke="var(--admin-chart-primary)" fill="var(--admin-chart-primary)" fillOpacity={0.1} />
-                            <Area yAxisId="count" type="monotone" dataKey="requests" name="上游请求" stroke="var(--admin-chart-secondary)" fill="var(--admin-chart-secondary)" fillOpacity={0.08} />
-                            <Line yAxisId="rate" type="monotone" dataKey="requestSuccessRate" name="成功率" stroke="var(--admin-chart-warning)" dot={false} strokeWidth={2} />
-                        </ComposedChart>
-                    </ResponsiveContainer>
-                </div>
+                {hasTrendActivity ? (
+                    <div className="h-[300px] w-full">
+                        <ResponsiveContainer width="100%" height="100%">
+                            <ComposedChart data={data?.trend || []} margin={{ top: 8, right: 12, bottom: 0, left: -16 }}>
+                                <CartesianGrid stroke="currentColor" className="text-foreground/10" vertical={false} />
+                                <XAxis dataKey="day" tickFormatter={(value) => value.slice(5)} tick={{ fontSize: 11 }} />
+                                <YAxis yAxisId="count" allowDecimals={false} tick={{ fontSize: 11 }} />
+                                <YAxis yAxisId="rate" orientation="right" domain={[0, 100]} tickFormatter={(value) => `${value}%`} tick={{ fontSize: 11 }} />
+                                <ChartTooltip labelFormatter={(value) => `日期 ${value}`} />
+                                <Legend wrapperStyle={{ fontSize: 12 }} />
+                                <Area yAxisId="count" type="monotone" dataKey="tasks" name="生成任务" stroke="var(--admin-chart-primary)" fill="var(--admin-chart-primary)" fillOpacity={0.1} />
+                                <Area yAxisId="count" type="monotone" dataKey="requests" name="上游请求" stroke="var(--admin-chart-secondary)" fill="var(--admin-chart-secondary)" fillOpacity={0.08} />
+                                <Line yAxisId="rate" type="monotone" dataKey="requestSuccessRate" name="成功率" stroke="var(--admin-chart-warning)" dot={false} strokeWidth={2} />
+                            </ComposedChart>
+                        </ResponsiveContainer>
+                    </div>
+                ) : (
+                    <div className="admin-analytics-empty-chart">
+                        <span>
+                            <BarChart3 className="size-5" />
+                        </span>
+                        <div className="font-medium">当前范围暂无使用数据</div>
+                        <p>可以调整时间范围或筛选条件后重新查看。</p>
+                    </div>
+                )}
             </section>
 
             <Tabs
@@ -346,13 +419,38 @@ export default function AnalyticsPanel({ users, channels }: Props) {
                     {
                         key: "models",
                         label: "模型分析",
-                        children: <AdminDataTable table={{ rowKey: (row) => `${row.model}:${row.capability}`, size: "small", loading, columns: modelColumns, dataSource: pageRows(modelRows, modelPage), pagination: false, scroll: { x: 1250 } }} empty={<AdminTableEmpty />} skeletonColumns={9} footer={<PaginationBar alwaysShow current={modelPage} pageSize={analyticsPageSize} total={modelRows.length} onChange={(page) => setModelPage(page)} pageSizeOptions={[analyticsPageSize]} />} />,
+                        children: (
+                            <AdminDataTable
+                                table={{ rowKey: (row) => `${row.model}:${row.capability}`, size: "small", loading, columns: modelColumns, dataSource: pageRows(modelRows, modelPage), pagination: false, scroll: { x: 1250 } }}
+                                empty={<AdminTableEmpty />}
+                                skeletonColumns={9}
+                                footer={<PaginationBar alwaysShow current={modelPage} pageSize={analyticsPageSize} total={modelRows.length} onChange={(page) => setModelPage(page)} pageSizeOptions={[analyticsPageSize]} />}
+                            />
+                        ),
                     },
-                    { key: "users", label: "用户活动", children: <AdminDataTable table={{ rowKey: "userId", size: "small", loading, columns: userColumns, dataSource: pageRows(userRows, userPage), pagination: false, scroll: { x: 900 } }} empty={<AdminTableEmpty />} skeletonColumns={7} footer={<PaginationBar alwaysShow current={userPage} pageSize={analyticsPageSize} total={userRows.length} onChange={(page) => setUserPage(page)} pageSizeOptions={[analyticsPageSize]} />} /> },
+                    {
+                        key: "users",
+                        label: "用户活动",
+                        children: (
+                            <AdminDataTable
+                                table={{ rowKey: "userId", size: "small", loading, columns: userColumns, dataSource: pageRows(userRows, userPage), pagination: false, scroll: { x: 900 } }}
+                                empty={<AdminTableEmpty />}
+                                skeletonColumns={7}
+                                footer={<PaginationBar alwaysShow current={userPage} pageSize={analyticsPageSize} total={userRows.length} onChange={(page) => setUserPage(page)} pageSizeOptions={[analyticsPageSize]} />}
+                            />
+                        ),
+                    },
                     {
                         key: "failures",
                         label: `异常定位${data?.failures.length ? ` (${data.failures.reduce((sum, item) => sum + item.count, 0)})` : ""}`,
-                        children: <AdminDataTable table={{ rowKey: (row) => `${row.type}:${row.model}`, size: "small", loading, columns: failureColumns, dataSource: pageRows(failureRows, failurePage), pagination: false, scroll: { x: 900 } }} empty={<AdminTableEmpty />} skeletonColumns={5} footer={<PaginationBar alwaysShow current={failurePage} pageSize={analyticsPageSize} total={failureRows.length} onChange={(page) => setFailurePage(page)} pageSizeOptions={[analyticsPageSize]} />} />,
+                        children: (
+                            <AdminDataTable
+                                table={{ rowKey: (row) => `${row.type}:${row.model}`, size: "small", loading, columns: failureColumns, dataSource: pageRows(failureRows, failurePage), pagination: false, scroll: { x: 900 } }}
+                                empty={<AdminTableEmpty />}
+                                skeletonColumns={5}
+                                footer={<PaginationBar alwaysShow current={failurePage} pageSize={analyticsPageSize} total={failureRows.length} onChange={(page) => setFailurePage(page)} pageSizeOptions={[analyticsPageSize]} />}
+                            />
+                        ),
                     },
                     {
                         key: "pricing",
@@ -364,7 +462,12 @@ export default function AnalyticsPanel({ users, channels }: Props) {
                                         新增价格
                                     </Button>
                                 </div>
-                                <AdminDataTable table={{ rowKey: "id", size: "small", loading, columns: pricingColumns, dataSource: pageRows(pricingRows, pricingPage), pagination: false, scroll: { x: 980 } }} empty={<AdminTableEmpty />} skeletonColumns={5} footer={<PaginationBar alwaysShow current={pricingPage} pageSize={analyticsPageSize} total={pricingRows.length} onChange={(page) => setPricingPage(page)} pageSizeOptions={[analyticsPageSize]} />} />
+                                <AdminDataTable
+                                    table={{ rowKey: "id", size: "small", loading, columns: pricingColumns, dataSource: pageRows(pricingRows, pricingPage), pagination: false, scroll: { x: 980 } }}
+                                    empty={<AdminTableEmpty />}
+                                    skeletonColumns={5}
+                                    footer={<PaginationBar alwaysShow current={pricingPage} pageSize={analyticsPageSize} total={pricingRows.length} onChange={(page) => setPricingPage(page)} pageSizeOptions={[analyticsPageSize]} />}
+                                />
                             </div>
                         ),
                     },
@@ -399,7 +502,25 @@ export default function AnalyticsPanel({ users, channels }: Props) {
     );
 }
 
-function FilterSelect({ label, value, onChange, options, width = 150, filterOption = true, loading, onSearch }: { label: string; value?: string; onChange: (value?: string) => void; options: Array<{ label: string; value: string }>; width?: number; filterOption?: boolean; loading?: boolean; onSearch?: (value: string) => void }) {
+function FilterSelect({
+    label,
+    value,
+    onChange,
+    options,
+    width = 150,
+    filterOption = true,
+    loading,
+    onSearch,
+}: {
+    label: string;
+    value?: string;
+    onChange: (value?: string) => void;
+    options: Array<{ label: string; value: string }>;
+    width?: number;
+    filterOption?: boolean;
+    loading?: boolean;
+    onSearch?: (value: string) => void;
+}) {
     return (
         <div>
             <div className="mb-1 text-xs text-foreground/55">{label}</div>
@@ -438,14 +559,14 @@ function formatCountDelta(current?: number, previous?: number) {
     const delta = current - previous;
     const direction = delta > 0 ? "↑" : delta < 0 ? "↓" : "→";
     const value = previous === 0 ? formatNumber(Math.abs(delta)) : `${Math.abs((delta / previous) * 100).toFixed(1)}%`;
-    return { value: `${direction} ${value}`, tone: delta >= 0 ? "success" as const : "warning" as const };
+    return { value: `${direction} ${value}`, tone: delta >= 0 ? ("success" as const) : ("warning" as const) };
 }
 
 function formatRateDelta(current?: number, previous?: number) {
     if (current === undefined || previous === undefined) return undefined;
     const delta = current - previous;
     const direction = delta > 0 ? "↑" : delta < 0 ? "↓" : "→";
-    return { value: `${direction} ${Math.abs(delta).toFixed(1)}pp`, tone: delta >= 0 ? "success" as const : "warning" as const };
+    return { value: `${direction} ${Math.abs(delta).toFixed(1)}pp`, tone: delta >= 0 ? ("success" as const) : ("warning" as const) };
 }
 
 function formatCost(micros: number, currency?: string, available?: boolean) {

--- a/web/src/pages/admin/components/channel-model-manager.tsx
+++ b/web/src/pages/admin/components/channel-model-manager.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { App, Button, Drawer, Form, Input, InputNumber, Popconfirm, Segmented, Select, Space, Switch, type FormInstance } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { FlaskConical, Plus, RefreshCw, Search, Trash2, X } from "lucide-react";
+import { FlaskConical, Plus, RefreshCw, Search, Trash2 } from "lucide-react";
 
 import { PaginationBar } from "@/components/layout/workspace-page";
 import { ModelIcon } from "@/components/model-picker";
@@ -23,18 +23,18 @@ type FormValues = {
     displayName?: string;
     capability: EditableCapability;
     protocol?: ModelProtocol;
-	priceTiers: PriceTierFormValues[];
+    priceTiers: PriceTierFormValues[];
     enabled: boolean;
     capabilityConfig?: ModelCapabilityConfig;
 };
 
 type PriceTierFormValues = {
-	operation: string;
-	quality: string;
-	size: string;
-	resolution: string;
-	videoSeconds: number;
-	imageCount: number;
+    operation: string;
+    quality: string;
+    size: string;
+    resolution: string;
+    videoSeconds: number;
+    imageCount: number;
     providerModelKey?: string;
     billingMode: ChannelModel["billingMode"];
     unitPrice: number;
@@ -65,7 +65,8 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
     const modelProtocol = Form.useWatch("protocol", form);
     const modelKey = Form.useWatch("modelKey", form) || "";
     const providerModelKey = Form.useWatch("providerModelKey", form) || "";
-	const capabilityConfig = Form.useWatch("capabilityConfig", form);
+    const capabilityConfig = Form.useWatch("capabilityConfig", form);
+    const modelEnabled = Form.useWatch("enabled", form) !== false;
 
     const reload = async () => {
         if (!channel) return;
@@ -81,7 +82,9 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
 
     useEffect(() => {
         void reload();
-        void fetchProtocolCatalog("admin.system-channel").then(setAvailableProtocols).catch(() => setAvailableProtocols([]));
+        void fetchProtocolCatalog("admin.system-channel")
+            .then(setAvailableProtocols)
+            .catch(() => setAvailableProtocols([]));
         setEditing(null);
         setEditorOpen(false);
         setKeyword("");
@@ -115,7 +118,7 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
             displayName: "",
             capability: "text",
             protocol: availableProtocols.find((item) => item.capability === "text")?.value,
-			priceTiers: [defaultPriceTier()],
+            priceTiers: [defaultPriceTier()],
             enabled: true,
             capabilityConfig: defaultModelCapabilityConfig(availableProtocols.find((item) => item.capability === "text")?.value, ""),
         });
@@ -130,11 +133,12 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
             displayName: item.displayName,
             capability: item.capability || undefined,
             protocol: item.protocol,
-			priceTiers: item.priceTiers?.length ? item.priceTiers.map(priceTierToForm) : [legacyPriceTierToForm(item)],
+            priceTiers: item.priceTiers?.length ? item.priceTiers.map(priceTierToForm) : [legacyPriceTierToForm(item)],
             enabled: item.enabled,
-            capabilityConfig: item.capability === "text" || item.capability === "image" || item.capability === "video"
-            ? normalizeModelCapabilityConfig(item.capabilityConfig || defaultModelCapabilityConfig(item.protocol, item.providerModelKey || item.modelKey))
-                : undefined,
+            capabilityConfig:
+                item.capability === "text" || item.capability === "image" || item.capability === "video"
+                    ? normalizeModelCapabilityConfig(item.capabilityConfig || defaultModelCapabilityConfig(item.protocol, item.providerModelKey || item.modelKey))
+                    : undefined,
         });
         setEditorOpen(true);
     };
@@ -142,9 +146,8 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
     const save = async () => {
         const values = await form.validateFields();
         const upstreamModel = values.providerModelKey?.trim() || values.modelKey.trim();
-        const capabilityConfig = values.capability === "text" || values.capability === "image" || values.capability === "video"
-            ? normalizeModelCapabilityConfig(values.capabilityConfig || defaultModelCapabilityConfig(values.protocol, upstreamModel))
-            : undefined;
+        const capabilityConfig =
+            values.capability === "text" || values.capability === "image" || values.capability === "video" ? normalizeModelCapabilityConfig(values.capabilityConfig || defaultModelCapabilityConfig(values.protocol, upstreamModel)) : undefined;
         setSaving(true);
         try {
             const payload = {
@@ -153,19 +156,19 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                 displayName: values.displayName?.trim() || values.modelKey.trim(),
                 capability: values.capability,
                 protocol: values.protocol,
-				priceTiers: values.priceTiers.map((tier) => ({
-					selector: skuSelectorFromForm(values.capability, tier),
-					resolution: values.capability === "video" ? (tier.resolution || "*") : "*",
-					videoSeconds: values.capability === "video" ? Number(tier.videoSeconds || 0) : 0,
-					providerModelKey: tier.providerModelKey?.trim() || upstreamModel,
-					billingMode: tier.billingMode,
-					unitPriceMicrocredits: Math.round((tier.unitPrice || 0) * 1_000_000),
-					inputTokenPriceMicrocredits: Math.round((tier.inputTokenPrice || 0) * 1_000_000),
-					outputTokenPriceMicrocredits: Math.round((tier.outputTokenPrice || 0) * 1_000_000),
-					cachedTokenPriceMicrocredits: Math.round((tier.cachedTokenPrice || 0) * 1_000_000),
-					priceConfigured: tier.priceConfigured !== false,
-					enabled: tier.enabled !== false,
-				})),
+                priceTiers: values.priceTiers.map((tier) => ({
+                    selector: skuSelectorFromForm(values.capability, tier),
+                    resolution: values.capability === "video" ? tier.resolution || "*" : "*",
+                    videoSeconds: values.capability === "video" ? Number(tier.videoSeconds || 0) : 0,
+                    providerModelKey: tier.providerModelKey?.trim() || upstreamModel,
+                    billingMode: tier.billingMode,
+                    unitPriceMicrocredits: Math.round((tier.unitPrice || 0) * 1_000_000),
+                    inputTokenPriceMicrocredits: Math.round((tier.inputTokenPrice || 0) * 1_000_000),
+                    outputTokenPriceMicrocredits: Math.round((tier.outputTokenPrice || 0) * 1_000_000),
+                    cachedTokenPriceMicrocredits: Math.round((tier.cachedTokenPrice || 0) * 1_000_000),
+                    priceConfigured: tier.priceConfigured !== false,
+                    enabled: tier.enabled !== false,
+                })),
                 enabled: values.enabled !== false,
                 capabilityConfig,
             };
@@ -186,9 +189,8 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
     const testModel = async () => {
         const values = await form.validateFields(["modelKey", "providerModelKey", "capability", "protocol", ...(modelCapability === "text" || modelCapability === "image" || modelCapability === "video" ? ["capabilityConfig"] : [])]);
         const upstreamModel = values.providerModelKey?.trim() || values.modelKey.trim();
-        const capabilityConfig = values.capability === "text" || values.capability === "image" || values.capability === "video"
-            ? normalizeModelCapabilityConfig(values.capabilityConfig || defaultModelCapabilityConfig(values.protocol, upstreamModel))
-            : undefined;
+        const capabilityConfig =
+            values.capability === "text" || values.capability === "image" || values.capability === "video" ? normalizeModelCapabilityConfig(values.capabilityConfig || defaultModelCapabilityConfig(values.protocol, upstreamModel)) : undefined;
         setTesting(true);
         try {
             const result = await testAdminChannelModel(channel.id, {
@@ -228,17 +230,17 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
             form.setFieldValue("protocol", nextProtocol);
             form.setFieldValue("capabilityConfig", changed.capability === "text" || changed.capability === "image" || changed.capability === "video" ? defaultModelCapabilityConfig(nextProtocol, form.getFieldValue("modelKey")) : undefined);
         }
-		const nextTiers = (form.getFieldValue("priceTiers") || []).map((tier: PriceTierFormValues) => ({
-			...tier,
-			operation: tier.operation || "*",
-			quality: changed.capability === "image" ? tier.quality || "*" : "*",
-			size: changed.capability === "image" ? tier.size || "*" : "*",
-						resolution: changed.capability === "video" ? tier.resolution || "*" : "*",
-						videoSeconds: changed.capability === "video" ? tier.videoSeconds || 0 : 0,
-						imageCount: changed.capability === "video" ? tier.imageCount || 0 : 0,
-			billingMode: tier.billingMode === "per_second" && changed.capability !== "video" ? "fixed_request" : tier.billingMode,
-		}));
-		form.setFieldValue("priceTiers", nextTiers);
+        const nextTiers = (form.getFieldValue("priceTiers") || []).map((tier: PriceTierFormValues) => ({
+            ...tier,
+            operation: tier.operation || "*",
+            quality: changed.capability === "image" ? tier.quality || "*" : "*",
+            size: changed.capability === "image" ? tier.size || "*" : "*",
+            resolution: changed.capability === "video" ? tier.resolution || "*" : "*",
+            videoSeconds: changed.capability === "video" ? tier.videoSeconds || 0 : 0,
+            imageCount: changed.capability === "video" ? tier.imageCount || 0 : 0,
+            billingMode: tier.billingMode === "per_second" && changed.capability !== "video" ? "fixed_request" : tier.billingMode,
+        }));
+        form.setFieldValue("priceTiers", nextTiers);
     };
 
     const columns: ColumnsType<ChannelModel> = [
@@ -272,7 +274,7 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                     <AdminStatusBadge label="待配置" tone="warning" />
                 ),
         },
-		{ title: "规格价格", width: 280, render: (_, item) => (item.priceConfigured ? billingSummary(item) : <AdminStatusBadge label="未配置价格" tone="warning" />) },
+        { title: "规格价格", width: 280, render: (_, item) => (item.priceConfigured ? billingSummary(item) : <AdminStatusBadge label="未配置价格" tone="warning" />) },
         { title: "版本", dataIndex: "priceVersion", width: 75, render: (value) => `v${value}` },
         { title: "状态", dataIndex: "enabled", width: 85, render: (enabled) => <AdminStatusBadge label={enabled ? "启用" : "停用"} tone={enabled ? "success" : "neutral"} /> },
         {
@@ -317,18 +319,50 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
             }
         >
             <AdminDataTable
-                toolbar={<Input
-                    allowClear
-                    className="app-list-search"
-                    prefix={<Search className="size-4 text-foreground/40" />}
-                    value={keyword}
-                    placeholder="搜索模型标识或显示名称"
-                    onChange={(event) => {
-                        setKeyword(event.target.value);
-                        setPage(1);
-                    }}
-                />}
-                toolbarActiveFilters={<>{keyword ? <AdminFilterChip label={`搜索：${keyword}`} onRemove={() => { setKeyword(""); setPage(1); }} /> : null}{capability !== "all" ? <AdminFilterChip label={`能力：${capability}`} onRemove={() => { setCapability("all"); setPage(1); }} /> : null}{status !== "all" ? <AdminFilterChip label={`状态：${status === "enabled" ? "已启用" : "已停用"}`} onRemove={() => { setStatus("all"); setPage(1); }} /> : null}</>}
+                toolbar={
+                    <Input
+                        allowClear
+                        className="app-list-search"
+                        prefix={<Search className="size-4 text-foreground/40" />}
+                        value={keyword}
+                        placeholder="搜索模型标识或显示名称"
+                        onChange={(event) => {
+                            setKeyword(event.target.value);
+                            setPage(1);
+                        }}
+                    />
+                }
+                toolbarActiveFilters={
+                    <>
+                        {keyword ? (
+                            <AdminFilterChip
+                                label={`搜索：${keyword}`}
+                                onRemove={() => {
+                                    setKeyword("");
+                                    setPage(1);
+                                }}
+                            />
+                        ) : null}
+                        {capability !== "all" ? (
+                            <AdminFilterChip
+                                label={`能力：${capability}`}
+                                onRemove={() => {
+                                    setCapability("all");
+                                    setPage(1);
+                                }}
+                            />
+                        ) : null}
+                        {status !== "all" ? (
+                            <AdminFilterChip
+                                label={`状态：${status === "enabled" ? "已启用" : "已停用"}`}
+                                onRemove={() => {
+                                    setStatus("all");
+                                    setPage(1);
+                                }}
+                            />
+                        ) : null}
+                    </>
+                }
                 toolbarActive={Boolean(keyword || capability !== "all" || status !== "all")}
                 toolbarFilters={
                     <>
@@ -339,7 +373,13 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                                 setCapability(value);
                                 setPage(1);
                             }}
-                            options={[{ label: "全部能力", value: "all" }, { label: "文本", value: "text" }, { label: "图片", value: "image" }, { label: "视频", value: "video" }, { label: "音频", value: "audio" }]}
+                            options={[
+                                { label: "全部能力", value: "all" },
+                                { label: "文本", value: "text" },
+                                { label: "图片", value: "image" },
+                                { label: "视频", value: "video" },
+                                { label: "音频", value: "audio" },
+                            ]}
                         />
                         <Select
                             className="w-32"
@@ -348,7 +388,11 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                                 setStatus(value);
                                 setPage(1);
                             }}
-                            options={[{ label: "全部状态", value: "all" }, { label: "已启用", value: "enabled" }, { label: "已停用", value: "disabled" }]}
+                            options={[
+                                { label: "全部状态", value: "all" },
+                                { label: "已启用", value: "enabled" },
+                                { label: "已停用", value: "disabled" },
+                            ]}
                         />
                     </>
                 }
@@ -368,20 +412,45 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                     pagination: false,
                     scroll: { x: 990 },
                 }}
-                footer={<PaginationBar alwaysShow current={page} pageSize={pageSize} total={filteredItems.length} onChange={(nextPage, nextPageSize) => { setPage(nextPageSize !== pageSize ? 1 : nextPage); setPageSize(nextPageSize); }} />}
+                footer={
+                    <PaginationBar
+                        alwaysShow
+                        current={page}
+                        pageSize={pageSize}
+                        total={filteredItems.length}
+                        onChange={(nextPage, nextPageSize) => {
+                            setPage(nextPageSize !== pageSize ? 1 : nextPage);
+                            setPageSize(nextPageSize);
+                        }}
+                    />
+                }
             />
             <Drawer
                 title={editing ? `编辑模型 / ${editing.displayName || editing.modelKey}` : "新增模型"}
                 open={editorOpen}
                 size="min(1080px, 100vw)"
                 onClose={() => !saving && setEditorOpen(false)}
-                rootClassName="admin-drawer"
+                rootClassName="admin-drawer admin-model-editor-drawer"
                 footer={
-                    <div className="flex items-center justify-between gap-3">
-                        <Button icon={<FlaskConical className="size-4" />} loading={testing} disabled={saving} onClick={() => void testModel()}>测试模型</Button>
-                        <div className="flex items-center gap-2">
-                            <Button disabled={saving || testing} onClick={() => setEditorOpen(false)}>取消</Button>
-                            <Button type="primary" loading={saving} disabled={testing} onClick={() => void save()}>{editing ? "保存修改" : "添加模型"}</Button>
+                    <div className="admin-model-editor-footer-actions flex items-center justify-between gap-3">
+                        <Button icon={<FlaskConical className="size-4" />} loading={testing} disabled={saving} onClick={() => void testModel()}>
+                            测试模型
+                        </Button>
+                        <div className="admin-model-editor-footer-primary flex items-center gap-2">
+                            <div className="admin-model-editor-footer-status">
+                                <span className={modelEnabled ? "is-enabled" : ""} />
+                                <div>
+                                    <strong>{modelEnabled ? "模型启用" : "模型停用"}</strong>
+                                    <small>保存后生效</small>
+                                </div>
+                                <Switch aria-label="启用模型" checked={modelEnabled} disabled={saving || testing} onChange={(checked) => form.setFieldValue("enabled", checked)} />
+                            </div>
+                            <Button disabled={saving || testing} onClick={() => setEditorOpen(false)}>
+                                取消
+                            </Button>
+                            <Button type="primary" loading={saving} disabled={testing} onClick={() => void save()}>
+                                {editing ? "保存修改" : "添加模型"}
+                            </Button>
                         </div>
                     </div>
                 }
@@ -393,12 +462,16 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                     ) : null
                 }
             >
-                <Form form={form} layout="vertical" requiredMark={false} onValuesChange={handleFormValuesChange}>
-                    <section className="admin-form-section">
-                        <div className="mb-4">
-                            <h2 className="text-sm font-semibold">模型身份</h2>
-                        </div>
-                        <div className="grid gap-4 md:grid-cols-3">
+                <Form className="admin-model-editor-form" form={form} layout="vertical" requiredMark={false} onValuesChange={handleFormValuesChange}>
+                    <Form.Item name="capabilityConfig" noStyle>
+                        <CapabilityConfigField />
+                    </Form.Item>
+                    <Form.Item name="enabled" noStyle>
+                        <EnabledConfigField />
+                    </Form.Item>
+                    <section className="admin-form-section admin-model-editor-section">
+                        <SectionHeading title="模型身份" description="区分产品侧展示标识与上游实际调用 ID。" />
+                        <div className="admin-model-editor-section-content admin-model-identity-grid">
                             <Form.Item name="modelKey" label="产品模型标识" rules={[{ required: true, message: "请输入产品模型标识" }]}>
                                 <Input
                                     prefix={
@@ -418,63 +491,115 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                         </div>
                     </section>
 
-                    <section className="admin-form-section">
-                        <div className="mb-4">
-                            <h2 className="text-sm font-semibold">能力与协议</h2>
-                        </div>
-                        <div className="space-y-4">
-                            <Form.Item className="mb-0" name="capability" label="模型能力" rules={[{ required: true }]}>
+                    <section className="admin-form-section admin-model-editor-section">
+                        <SectionHeading title="模型能力" description="决定模型在前台可用于哪类生成任务。" />
+                        <div className="admin-model-editor-section-content">
+                            <Form.Item className="mb-0" name="capability" rules={[{ required: true }]}>
                                 <CapabilityCardPicker density="compact" />
                             </Form.Item>
-                            {availableProtocols.length ? <Form.Item className="mb-0" name="protocol" label="请求协议" rules={[{ required: true, message: "请选择模型请求协议" }]}>
-                                <ProtocolCardPicker capability={modelCapability} density="compact" protocols={availableProtocols} />
-                            </Form.Item> : null}
                         </div>
-                        {modelCapability === "text" || modelCapability === "image" || modelCapability === "video" ? (
-                            <Form.Item name="capabilityConfig" rules={[{ required: true, message: `请配置${capabilityLabel(modelCapability)}能力参数` }]}>
-                                <ModelCapabilityEditor capability={modelCapability} model={providerModelKey || modelKey} protocol={form.getFieldValue("protocol")} />
-                            </Form.Item>
-                        ) : null}
                     </section>
 
-                    <section className="admin-form-section">
-                        <div className="mb-4">
-                            <h2 className="text-sm font-semibold">规格价格档</h2>
-                        </div>
-						<Form.List name="priceTiers" rules={[{ validator: async (_, value) => { if (!value?.length) throw new Error("请至少配置一个价格档"); } }]}>
-							{(fields, { add, remove }, { errors }) => (
-								<div className="space-y-2">
-									{fields.map((field, index) => (
-										<PriceTierFields
-											key={field.key}
-											index={field.name}
-											ordinal={index + 1}
-											form={form}
-											capability={modelCapability}
-											protocol={modelProtocol}
-											capabilityConfig={capabilityConfig}
-											onRemove={() => remove(field.name)}
-										/>
-									))}
-									<Button icon={<Plus className="size-4" />} onClick={() => add(defaultPriceTier())}>新增价格档</Button>
-									<Form.ErrorList errors={errors} />
-								</div>
-							)}
-						</Form.List>
-                    </section>
+                    {availableProtocols.length ? (
+                        <section className="admin-form-section admin-model-editor-section">
+                            <SectionHeading title="请求协议" description="选择发送到上游的接口格式与响应处理方式。" />
+                            <div className="admin-model-editor-section-content">
+                                <Form.Item className="mb-0" name="protocol" rules={[{ required: true, message: "请选择模型请求协议" }]}>
+                                    <ProtocolCardPicker capability={modelCapability} density="compact" protocols={availableProtocols} />
+                                </Form.Item>
+                            </div>
+                        </section>
+                    ) : null}
 
-                    <section className="admin-form-section">
-                        <div className="mb-4">
-                            <h2 className="text-sm font-semibold">启用状态</h2>
+                    {modelCapability === "text" || modelCapability === "image" || modelCapability === "video" ? (
+                        <section className="admin-form-section admin-model-editor-section admin-model-editor-references">
+                            <SectionHeading title="引用与限制" description="按媒体类型纵向配置数量、大小、时长及通用约束。" />
+                            <div className="admin-model-editor-section-content">
+                                <ModelCapabilityEditor
+                                    capability={modelCapability}
+                                    model={providerModelKey || modelKey}
+                                    protocol={form.getFieldValue("protocol")}
+                                    section="references"
+                                    value={capabilityConfig}
+                                    onChange={(next) => form.setFieldValue("capabilityConfig", next)}
+                                />
+                            </div>
+                        </section>
+                    ) : null}
+
+                    {modelCapability === "image" || modelCapability === "video" ? (
+                        <section className="admin-form-section admin-model-editor-section admin-model-editor-parameters">
+                            <SectionHeading title="协议参数" description="配置可发送参数、支持值与默认值；仅影响当前模型。" />
+                            <div className="admin-model-editor-section-content">
+                                <ModelCapabilityEditor
+                                    capability={modelCapability}
+                                    model={providerModelKey || modelKey}
+                                    protocol={form.getFieldValue("protocol")}
+                                    section="protocol"
+                                    value={capabilityConfig}
+                                    onChange={(next) => form.setFieldValue("capabilityConfig", next)}
+                                />
+                            </div>
+                        </section>
+                    ) : null}
+
+                    <section className="admin-form-section admin-model-editor-section">
+                        <SectionHeading title="规格价格档" description="按请求条件匹配上游模型与计费规则。" />
+                        <div className="admin-model-editor-section-content">
+                            <Form.List
+                                name="priceTiers"
+                                rules={[
+                                    {
+                                        validator: async (_, value) => {
+                                            if (!value?.length) throw new Error("请至少配置一个价格档");
+                                        },
+                                    },
+                                ]}
+                            >
+                                {(fields, { add, remove }, { errors }) => (
+                                    <div className="space-y-3">
+                                        {fields.map((field, index) => (
+                                            <PriceTierFields
+                                                key={field.key}
+                                                index={field.name}
+                                                ordinal={index + 1}
+                                                form={form}
+                                                capability={modelCapability}
+                                                protocol={modelProtocol}
+                                                capabilityConfig={capabilityConfig}
+                                                onRemove={() => remove(field.name)}
+                                            />
+                                        ))}
+                                        <Button className="admin-model-editor-add-tier" type="dashed" block icon={<Plus className="size-4" />} onClick={() => add(defaultPriceTier())}>
+                                            新增价格档
+                                        </Button>
+                                        <Form.ErrorList errors={errors} />
+                                    </div>
+                                )}
+                            </Form.List>
                         </div>
-                        <Form.Item name="enabled" label="启用" valuePropName="checked">
-                            <Switch />
-                        </Form.Item>
                     </section>
                 </Form>
             </Drawer>
         </AdminPageFrame>
     );
+}
+
+function SectionHeading({ title, description }: { title: string; description: string }) {
+    return (
+        <header className="admin-model-editor-section-heading">
+            <h2>{title}</h2>
+            <p>{description}</p>
+        </header>
+    );
+}
+
+function CapabilityConfigField(_: { value?: ModelCapabilityConfig; onChange?: (value: ModelCapabilityConfig) => void }) {
+    return null;
+}
+
+function EnabledConfigField(_: { value?: boolean; onChange?: (value: boolean) => void }) {
+    return null;
 }
 
 function capabilityLabel(value: ChannelModel["capability"]) {
@@ -502,81 +627,125 @@ function PriceTierFields({
     const video = capabilityConfig?.video;
     const resolutionOptions = video?.resolutions || [];
     const durationOptions = video?.duration.selection === "enum" ? video.duration.values || [] : [];
-	const tokenEnabled = Boolean(capability && protocol && modelProtocolSupportsTokenBilling(capability, protocol));
-	const isVideo = capability === "video";
-	const isImage = capability === "image";
-	const selectorColumnClass = isVideo || isImage ? "lg:col-span-3" : "lg:col-span-6";
-	const controlsColumnClass = billingMode === "token" && !isVideo ? "lg:col-span-3" : "lg:col-span-5";
+    const tokenEnabled = Boolean(capability && protocol && modelProtocolSupportsTokenBilling(capability, protocol));
+    const isVideo = capability === "video";
+    const isImage = capability === "image";
     return (
-        <div className="rounded-md border border-border bg-muted/10 p-3">
-            <div className="mb-2 flex items-center justify-between gap-3">
-                <div className="text-sm font-medium">价格档 {ordinal}</div>
-                <Button type="text" danger aria-label={`删除价格档 ${ordinal}`} title="删除价格档" icon={<X className="size-4" />} onClick={onRemove} />
+        <div className="admin-price-tier-card">
+            <div className="admin-price-tier-card-header">
+                <div>
+                    <div className="text-sm font-medium">价格档 {ordinal}</div>
+                    <div className="mt-0.5 text-[var(--fs-tiny)] text-foreground/45">请求按以下条件命中后，使用本档模型与价格。</div>
+                </div>
+                <Button type="text" danger aria-label={`删除价格档 ${ordinal}`} icon={<Trash2 className="size-3.5" />} onClick={onRemove}>
+                    删除
+                </Button>
             </div>
-			<div className="grid gap-3 lg:grid-cols-12">
-				<Form.Item className={`mb-0 ${selectorColumnClass}`} name={[index, "operation"]} label="生成方式" rules={[{ required: true, message: "请选择生成方式" }]}>
-					<Select options={operationOptions(capability)} />
-				</Form.Item>
-                {isVideo ? (
-                    <Form.Item className="mb-0 lg:col-span-3" name={[index, "resolution"]} label="分辨率" rules={[{ required: true, message: "请选择分辨率" }]}>
-                        <Select options={[{ label: "任意分辨率", value: "*" }, ...resolutionOptions.map((value) => ({ label: value.toUpperCase(), value }))]} />
-                    </Form.Item>
-                ) : null}
-	                {isVideo ? (
-	                    <Form.Item className="mb-0 lg:col-span-3" name={[index, "videoSeconds"]} label="时长" rules={[{ required: true, message: "请输入时长" }]}>
-	                        {durationOptions.length ? <Select options={[{ label: "任意时长", value: 0 }, ...durationOptions.map((value) => ({ label: `${value} 秒`, value }))]} /> : <InputNumber className="w-full" min={0} precision={0} />}
-	                    </Form.Item>
-                ) : null}
-				{isVideo ? (
-					<Form.Item className="mb-0 lg:col-span-3" name={[index, "imageCount"]} label="参考图数量" rules={[{ required: true, message: "请输入参考图数量" }]}>
-						<InputNumber className="w-full" min={0} max={9} precision={0} placeholder="0 表示任意数量" />
-					</Form.Item>
-				) : null}
-				{isImage ? (
-					<Form.Item className="mb-0 lg:col-span-3" name={[index, "quality"]} label="质量/分辨率" rules={[{ required: true, message: "请选择质量或分辨率" }]}>
-						<Select options={[{ label: "任意质量", value: "*" }, { label: "1K", value: "1k" }, { label: "2K", value: "2k" }, { label: "4K", value: "4k" }]} />
-					</Form.Item>
-				) : null}
-				{isImage ? (
-					<Form.Item className="mb-0 lg:col-span-3" name={[index, "size"]} label="画幅/尺寸">
-						<Input placeholder="任意，或 1:1、16:9、1024x1024" />
-					</Form.Item>
-				) : null}
-                <Form.Item className={`mb-0 ${selectorColumnClass}`} name={[index, "providerModelKey"]} label="上游模型 ID">
-                    <Input placeholder="留空则使用模型默认上游 ID" />
-                </Form.Item>
-            </div>
-            <div className="grid items-end gap-3 lg:grid-cols-12">
-                <Form.Item className="mb-0 lg:col-span-4" name={[index, "billingMode"]} label="计费方式" rules={[{ required: true }]}>
-                    <Segmented
-                        className="w-full"
-                        options={[
-                            { label: "按次", value: "fixed_request" },
-                            { label: "按秒", value: "per_second", disabled: !isVideo },
-                            { label: "Token", value: "token", disabled: !tokenEnabled },
-                        ]}
-                    />
-                </Form.Item>
-                {billingMode === "token" ? (
-                    isVideo ? (
-                        <Form.Item className="mb-0 lg:col-span-3" name={[index, "outputTokenPrice"]} label="视频 / 百万 Token" rules={[{ required: true, message: "请输入视频 Token 价格" }]}>
-                            <InputNumber className="w-full" min={0.000001} max={1_000_000} precision={6} step={0.1} />
+            <div className="admin-price-tier-card-body">
+                <div className="admin-price-tier-block admin-price-tier-match-block">
+                    <div className="admin-price-tier-block-title">
+                        <span>01</span> 匹配条件
+                    </div>
+                    <div className="admin-price-tier-match-grid">
+                        <Form.Item className="mb-0" name={[index, "operation"]} label="生成方式" rules={[{ required: true, message: "请选择生成方式" }]}>
+                            <Select options={operationOptions(capability)} />
                         </Form.Item>
-                    ) : (
-                        <div className="grid gap-3 sm:grid-cols-3 lg:col-span-5">
-                            <Form.Item className="mb-0" name={[index, "inputTokenPrice"]} label="输入 / 百万 Token" rules={[{ required: true, message: "请输入输入价格" }]}><InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} /></Form.Item>
-                            <Form.Item className="mb-0" name={[index, "outputTokenPrice"]} label="输出 / 百万 Token" rules={[{ required: true, message: "请输入输出价格" }]}><InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} /></Form.Item>
-                            <Form.Item className="mb-0" name={[index, "cachedTokenPrice"]} label="缓存 / 百万 Token" rules={[{ required: true, message: "请输入缓存价格" }]}><InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} /></Form.Item>
+                        {isVideo ? (
+                            <Form.Item className="mb-0" name={[index, "resolution"]} label="分辨率" rules={[{ required: true, message: "请选择分辨率" }]}>
+                                <Select options={[{ label: "任意分辨率", value: "*" }, ...resolutionOptions.map((value) => ({ label: value.toUpperCase(), value }))]} />
+                            </Form.Item>
+                        ) : null}
+                        {isVideo ? (
+                            <Form.Item className="mb-0" name={[index, "videoSeconds"]} label="时长" rules={[{ required: true, message: "请输入时长" }]}>
+                                {durationOptions.length ? <Select options={[{ label: "任意时长", value: 0 }, ...durationOptions.map((value) => ({ label: `${value} 秒`, value }))]} /> : <InputNumber className="w-full" min={0} precision={0} />}
+                            </Form.Item>
+                        ) : null}
+                        {isVideo ? (
+                            <Form.Item className="mb-0" name={[index, "imageCount"]} label="参考图数量" rules={[{ required: true, message: "请输入参考图数量" }]}>
+                                <InputNumber className="w-full" min={0} max={9} precision={0} placeholder="0 表示任意数量" />
+                            </Form.Item>
+                        ) : null}
+                        {isImage ? (
+                            <Form.Item className="mb-0" name={[index, "quality"]} label="质量/分辨率" rules={[{ required: true, message: "请选择质量或分辨率" }]}>
+                                <Select
+                                    options={[
+                                        { label: "任意质量", value: "*" },
+                                        { label: "1K", value: "1k" },
+                                        { label: "2K", value: "2k" },
+                                        { label: "4K", value: "4k" },
+                                    ]}
+                                />
+                            </Form.Item>
+                        ) : null}
+                        {isImage ? (
+                            <Form.Item className="mb-0" name={[index, "size"]} label="画幅/尺寸">
+                                <Input placeholder="任意，或 1:1、16:9、1024x1024" />
+                            </Form.Item>
+                        ) : null}
+                        <Form.Item className="admin-price-tier-upstream mb-0" name={[index, "providerModelKey"]} label="命中后使用的上游模型 ID">
+                            <Input placeholder="留空则使用模型默认上游 ID" />
+                        </Form.Item>
+                    </div>
+                </div>
+                <div className="admin-price-tier-block admin-price-tier-billing-block">
+                    <div className="admin-price-tier-block-title">
+                        <span>02</span> 计费与状态
+                    </div>
+                    <div className="admin-price-tier-billing-grid">
+                        <Form.Item className="admin-price-tier-billing-mode mb-0" name={[index, "billingMode"]} label="计费方式" rules={[{ required: true }]}>
+                            <Segmented
+                                className="w-full"
+                                options={[
+                                    { label: "按次", value: "fixed_request" },
+                                    { label: "按秒", value: "per_second", disabled: !isVideo },
+                                    { label: "Token", value: "token", disabled: !tokenEnabled },
+                                ]}
+                            />
+                        </Form.Item>
+                        {billingMode === "token" ? (
+                            isVideo ? (
+                                <Form.Item className="admin-price-tier-unit-price mb-0" name={[index, "outputTokenPrice"]} label="视频 / 百万 Token" rules={[{ required: true, message: "请输入视频 Token 价格" }]}>
+                                    <InputNumber className="w-full" min={0.000001} max={1_000_000} precision={6} step={0.1} />
+                                </Form.Item>
+                            ) : (
+                                <div className="admin-price-tier-token-grid">
+                                    <Form.Item className="mb-0" name={[index, "inputTokenPrice"]} label="输入 / 百万 Token" rules={[{ required: true, message: "请输入输入价格" }]}>
+                                        <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
+                                    </Form.Item>
+                                    <Form.Item className="mb-0" name={[index, "outputTokenPrice"]} label="输出 / 百万 Token" rules={[{ required: true, message: "请输入输出价格" }]}>
+                                        <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
+                                    </Form.Item>
+                                    <Form.Item className="mb-0" name={[index, "cachedTokenPrice"]} label="缓存 / 百万 Token" rules={[{ required: true, message: "请输入缓存价格" }]}>
+                                        <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
+                                    </Form.Item>
+                                </div>
+                            )
+                        ) : (
+                            <Form.Item className="admin-price-tier-unit-price mb-0" name={[index, "unitPrice"]} label={billingMode === "per_second" ? "每秒消耗积分" : "每次消耗积分"} rules={[{ required: true, message: "请输入积分价格" }]}>
+                                <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
+                            </Form.Item>
+                        )}
+                        <div className="admin-price-tier-controls flex items-center gap-6">
+                            <div className="admin-price-tier-toggle">
+                                <div>
+                                    <strong>价格已配置</strong>
+                                    <span>允许按此价格计费</span>
+                                </div>
+                                <Form.Item name={[index, "priceConfigured"]} noStyle valuePropName="checked">
+                                    <Switch aria-label="价格已配置" />
+                                </Form.Item>
+                            </div>
+                            <div className="admin-price-tier-toggle">
+                                <div>
+                                    <strong>启用价格档</strong>
+                                    <span>允许参与请求匹配</span>
+                                </div>
+                                <Form.Item name={[index, "enabled"]} noStyle valuePropName="checked">
+                                    <Switch aria-label="启用价格档" />
+                                </Form.Item>
+                            </div>
                         </div>
-                    )
-                ) : (
-                    <Form.Item className="mb-0 lg:col-span-3" name={[index, "unitPrice"]} label={billingMode === "per_second" ? "每秒消耗积分" : "每次消耗积分"} rules={[{ required: true, message: "请输入积分价格" }]}>
-                        <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
-                    </Form.Item>
-                )}
-                <div className={`flex items-center gap-6 ${controlsColumnClass}`}>
-                    <Form.Item name={[index, "priceConfigured"]} label="价格已配置" valuePropName="checked" className="mb-0"><Switch /></Form.Item>
-                    <Form.Item name={[index, "enabled"]} label="启用此价格档" valuePropName="checked" className="mb-0"><Switch /></Form.Item>
+                    </div>
                 </div>
             </div>
         </div>
@@ -584,32 +753,73 @@ function PriceTierFields({
 }
 
 function defaultPriceTier(): PriceTierFormValues {
-	return { operation: "*", quality: "*", size: "*", resolution: "*", videoSeconds: 0, imageCount: 0, providerModelKey: "", billingMode: "fixed_request", unitPrice: 0, inputTokenPrice: 0, outputTokenPrice: 0, cachedTokenPrice: 0, priceConfigured: true, enabled: true };
+    return {
+        operation: "*",
+        quality: "*",
+        size: "*",
+        resolution: "*",
+        videoSeconds: 0,
+        imageCount: 0,
+        providerModelKey: "",
+        billingMode: "fixed_request",
+        unitPrice: 0,
+        inputTokenPrice: 0,
+        outputTokenPrice: 0,
+        cachedTokenPrice: 0,
+        priceConfigured: true,
+        enabled: true,
+    };
 }
 
 function priceTierToForm(tier: ChannelModelPriceTier): PriceTierFormValues {
     return {
-		operation: tier.selector?.operation || "*", quality: tier.selector?.quality || "*", size: tier.selector?.size || "*",
-		resolution: tier.resolution || "*", videoSeconds: tier.videoSeconds || 0, imageCount: Number(tier.selector?.imageCount || 0), providerModelKey: tier.providerModelKey || "", billingMode: tier.billingMode,
-        unitPrice: tier.unitPriceMicrocredits / 1_000_000, inputTokenPrice: tier.inputTokenPriceMicrocredits / 1_000_000,
-        outputTokenPrice: tier.outputTokenPriceMicrocredits / 1_000_000, cachedTokenPrice: tier.cachedTokenPriceMicrocredits / 1_000_000,
-        priceConfigured: tier.priceConfigured, enabled: tier.enabled,
+        operation: tier.selector?.operation || "*",
+        quality: tier.selector?.quality || "*",
+        size: tier.selector?.size || "*",
+        resolution: tier.resolution || "*",
+        videoSeconds: tier.videoSeconds || 0,
+        imageCount: Number(tier.selector?.imageCount || 0),
+        providerModelKey: tier.providerModelKey || "",
+        billingMode: tier.billingMode,
+        unitPrice: tier.unitPriceMicrocredits / 1_000_000,
+        inputTokenPrice: tier.inputTokenPriceMicrocredits / 1_000_000,
+        outputTokenPrice: tier.outputTokenPriceMicrocredits / 1_000_000,
+        cachedTokenPrice: tier.cachedTokenPriceMicrocredits / 1_000_000,
+        priceConfigured: tier.priceConfigured,
+        enabled: tier.enabled,
     };
 }
 
 function legacyPriceTierToForm(item: ChannelModel): PriceTierFormValues {
     return {
-		operation: "*", quality: "*", size: "*", resolution: "*", videoSeconds: 0, imageCount: 0, providerModelKey: item.providerModelKey || "", billingMode: item.billingMode,
-        unitPrice: item.unitPriceMicrocredits / 1_000_000, inputTokenPrice: item.inputTokenPriceMicrocredits / 1_000_000,
-        outputTokenPrice: item.outputTokenPriceMicrocredits / 1_000_000, cachedTokenPrice: item.cachedTokenPriceMicrocredits / 1_000_000,
-        priceConfigured: item.priceConfigured, enabled: item.enabled,
+        operation: "*",
+        quality: "*",
+        size: "*",
+        resolution: "*",
+        videoSeconds: 0,
+        imageCount: 0,
+        providerModelKey: item.providerModelKey || "",
+        billingMode: item.billingMode,
+        unitPrice: item.unitPriceMicrocredits / 1_000_000,
+        inputTokenPrice: item.inputTokenPriceMicrocredits / 1_000_000,
+        outputTokenPrice: item.outputTokenPriceMicrocredits / 1_000_000,
+        cachedTokenPrice: item.cachedTokenPriceMicrocredits / 1_000_000,
+        priceConfigured: item.priceConfigured,
+        enabled: item.enabled,
     };
 }
 
 function billingSummary(item: ChannelModel) {
-	const tiers = item.priceTiers?.filter((tier) => tier.enabled && tier.priceConfigured) || [];
-	if (!tiers.length) return <AdminStatusBadge label="未配置价格" tone="warning" />;
-	return <div className="space-y-1 text-xs leading-5">{tiers.slice(0, 3).map((tier) => <div key={tier.id}>{priceTierLabel(tier)}</div>)}{tiers.length > 3 ? <div className="text-foreground/45">另有 {tiers.length - 3} 个规格价格档</div> : null}</div>;
+    const tiers = item.priceTiers?.filter((tier) => tier.enabled && tier.priceConfigured) || [];
+    if (!tiers.length) return <AdminStatusBadge label="未配置价格" tone="warning" />;
+    return (
+        <div className="space-y-1 text-xs leading-5">
+            {tiers.slice(0, 3).map((tier) => (
+                <div key={tier.id}>{priceTierLabel(tier)}</div>
+            ))}
+            {tiers.length > 3 ? <div className="text-foreground/45">另有 {tiers.length - 3} 个规格价格档</div> : null}
+        </div>
+    );
 }
 
 function priceTierLabel(tier: ChannelModelPriceTier) {
@@ -619,8 +829,8 @@ function priceTierLabel(tier: ChannelModelPriceTier) {
         selector.quality && selector.quality !== "*" ? selector.quality.toUpperCase() : "",
         selector.size && selector.size !== "*" ? selector.size : "",
         tier.resolution === "*" ? "" : tier.resolution.toUpperCase(),
-		tier.videoSeconds ? `${tier.videoSeconds} 秒` : "",
-		selector.imageCount && selector.imageCount !== "*" ? `${selector.imageCount} 张参考图` : "",
+        tier.videoSeconds ? `${tier.videoSeconds} 秒` : "",
+        selector.imageCount && selector.imageCount !== "*" ? `${selector.imageCount} 张参考图` : "",
     ].filter(Boolean);
     const spec = specParts.length ? specParts.join(" / ") : "默认规格";
     if (tier.billingMode === "token") return `${spec} · ${formatCredits(tier.outputTokenPriceMicrocredits)} / 百万 Token`;
@@ -628,30 +838,30 @@ function priceTierLabel(tier: ChannelModelPriceTier) {
 }
 
 function operationOptions(capability: EditableCapability | undefined) {
-	const options = [{ label: "任意生成方式", value: "*" }];
-	if (capability === "image") return [...options, { label: "文生图", value: "text_to_image" }, { label: "图生图", value: "image_to_image" }];
-	if (capability === "video") return [...options, { label: "文生视频", value: "text_to_video" }, { label: "图生视频", value: "image_to_video" }, { label: "视频生视频", value: "video_to_video" }];
-	if (capability === "text") return [...options, { label: "文本生成", value: "text_generation" }];
-	return options;
+    const options = [{ label: "任意生成方式", value: "*" }];
+    if (capability === "image") return [...options, { label: "文生图", value: "text_to_image" }, { label: "图生图", value: "image_to_image" }];
+    if (capability === "video") return [...options, { label: "文生视频", value: "text_to_video" }, { label: "图生视频", value: "image_to_video" }, { label: "视频生视频", value: "video_to_video" }];
+    if (capability === "text") return [...options, { label: "文本生成", value: "text_generation" }];
+    return options;
 }
 
 function operationLabel(operation: string) {
-	return ({ text_to_image: "文生图", image_to_image: "图生图", text_to_video: "文生视频", image_to_video: "图生视频", video_to_video: "视频生视频", text_generation: "文本生成" } as Record<string, string>)[operation] || operation;
+    return ({ text_to_image: "文生图", image_to_image: "图生图", text_to_video: "文生视频", image_to_video: "图生视频", video_to_video: "视频生视频", text_generation: "文本生成" } as Record<string, string>)[operation] || operation;
 }
 
 function skuSelectorFromForm(capability: EditableCapability, tier: PriceTierFormValues) {
-	const selector: Record<string, string> = {};
-	if (tier.operation && tier.operation !== "*") selector.operation = tier.operation;
-	if (capability === "video") {
-		if (tier.resolution && tier.resolution !== "*") selector.vquality = tier.resolution;
-		if (Number(tier.videoSeconds) > 0) selector.videoSeconds = String(Number(tier.videoSeconds));
-		if (Number(tier.imageCount) > 0) selector.imageCount = String(Number(tier.imageCount));
-	}
-	if (capability === "image") {
-		if (tier.quality && tier.quality !== "*") selector.quality = tier.quality;
-		if (tier.size && tier.size !== "*") selector.size = tier.size;
-	}
-	return selector;
+    const selector: Record<string, string> = {};
+    if (tier.operation && tier.operation !== "*") selector.operation = tier.operation;
+    if (capability === "video") {
+        if (tier.resolution && tier.resolution !== "*") selector.vquality = tier.resolution;
+        if (Number(tier.videoSeconds) > 0) selector.videoSeconds = String(Number(tier.videoSeconds));
+        if (Number(tier.imageCount) > 0) selector.imageCount = String(Number(tier.imageCount));
+    }
+    if (capability === "image") {
+        if (tier.quality && tier.quality !== "*") selector.quality = tier.quality;
+        if (tier.size && tier.size !== "*") selector.size = tier.size;
+    }
+    return selector;
 }
 
 function formatCredits(value: number) {

--- a/web/src/pages/admin/components/credit-operations-panel.tsx
+++ b/web/src/pages/admin/components/credit-operations-panel.tsx
@@ -15,9 +15,7 @@ type AdjustmentFormValues = { userId: string; amount: number; note: string };
 type ResolutionFormValues = { note: string };
 type PolicyFormValues = { signupBonus: number; checkinBonus: number; defaultMultiplier: number; modelMultipliers: string };
 type BillingResolutionAction = "settle" | "refund";
-type BillingResolutionTarget =
-    | { kind: "single"; order: BillingOrder; action: BillingResolutionAction }
-    | { kind: "batch"; orderIds: string[]; amountMicrocredits: number; action: BillingResolutionAction };
+type BillingResolutionTarget = { kind: "single"; order: BillingOrder; action: BillingResolutionAction } | { kind: "batch"; orderIds: string[]; amountMicrocredits: number; action: BillingResolutionAction };
 
 export default function CreditOperationsPanel({ users }: { users: AdminReferenceData["users"] }) {
     const { message } = App.useApp();
@@ -199,12 +197,17 @@ export default function CreditOperationsPanel({ users }: { users: AdminReference
         {
             title: "实际结算 / 用量",
             width: 190,
-            render: (_, order) => order.billingMode === "token" ? (
-                <div className="text-xs leading-5">
-                    <div className="font-medium tabular-nums">{order.status === "settled" ? `${formatCredits(order.actualAmountMicrocredits)} 积分` : "待 usage 结算"}</div>
-                    <div className="text-foreground/50">输入 {order.inputTokens} · 输出 {order.outputTokens} · 缓存 {order.cachedTokens}</div>
-                </div>
-            ) : <span className="tabular-nums">{order.status === "settled" ? formatCredits(order.actualAmountMicrocredits || order.amountMicrocredits) : "--"}</span>,
+            render: (_, order) =>
+                order.billingMode === "token" ? (
+                    <div className="text-xs leading-5">
+                        <div className="font-medium tabular-nums">{order.status === "settled" ? `${formatCredits(order.actualAmountMicrocredits)} 积分` : "待 usage 结算"}</div>
+                        <div className="text-foreground/50">
+                            输入 {order.inputTokens} · 输出 {order.outputTokens} · 缓存 {order.cachedTokens}
+                        </div>
+                    </div>
+                ) : (
+                    <span className="tabular-nums">{order.status === "settled" ? formatCredits(order.actualAmountMicrocredits || order.amountMicrocredits) : "--"}</span>
+                ),
         },
         {
             title: "状态",
@@ -226,10 +229,7 @@ export default function CreditOperationsPanel({ users }: { users: AdminReference
                 !canResolveBillingOrder(order) ? (
                     <span className="text-xs text-foreground/40">处理完成</span>
                 ) : (
-                    <AdminRowActions
-                        primary={{ label: "确认扣费", onClick: () => openSingleResolution(order, "settle") }}
-                        actions={[{ key: "refund", label: "退回积分", danger: true, onClick: () => openSingleResolution(order, "refund") }]}
-                    />
+                    <AdminRowActions primary={{ label: "确认扣费", onClick: () => openSingleResolution(order, "settle") }} actions={[{ key: "refund", label: "退回积分", danger: true, onClick: () => openSingleResolution(order, "refund") }]} />
                 ),
         },
     ];
@@ -237,41 +237,77 @@ export default function CreditOperationsPanel({ users }: { users: AdminReference
     return (
         <div className="flex min-h-0 flex-1 flex-col gap-4">
             <div className="grid shrink-0 gap-4 xl:grid-cols-2">
-                <section className="rounded-lg bg-background p-4">
-                    <div className="flex items-start gap-3">
+                <section className="admin-operation-card">
+                    <div className="admin-operation-card-heading flex items-start gap-3">
                         <span className="grid size-8 shrink-0 place-items-center rounded-md bg-muted/40">
                             <Settings2 className="size-4" />
                         </span>
-                        <h2 className="pt-1 text-sm font-semibold">积分策略</h2>
+                        <div>
+                            <h2 className="text-sm font-semibold">积分策略</h2>
+                            <p>管理注册、签到赠送与模型计费倍率。</p>
+                        </div>
                     </div>
                     <Form form={policyForm} layout="vertical" requiredMark={false} className="mt-3">
                         <div className="grid gap-3 sm:grid-cols-3">
-                            <Form.Item name="signupBonus" label="注册积分" rules={[{ required: true, message: "请填写注册积分" }, { type: "number", min: 0 }]}>
+                            <Form.Item
+                                name="signupBonus"
+                                label="注册积分"
+                                rules={[
+                                    { required: true, message: "请填写注册积分" },
+                                    { type: "number", min: 0 },
+                                ]}
+                            >
                                 <InputNumber className="w-full" min={0} precision={6} />
                             </Form.Item>
-                            <Form.Item name="checkinBonus" label="签到积分" rules={[{ required: true, message: "请填写签到积分" }, { type: "number", min: 0 }]}>
+                            <Form.Item
+                                name="checkinBonus"
+                                label="签到积分"
+                                rules={[
+                                    { required: true, message: "请填写签到积分" },
+                                    { type: "number", min: 0 },
+                                ]}
+                            >
                                 <InputNumber className="w-full" min={0} precision={6} />
                             </Form.Item>
-                            <Form.Item name="defaultMultiplier" label="默认倍率" rules={[{ required: true, message: "请填写默认倍率" }, { type: "number", min: 0.0001, max: 100 }]}>
+                            <Form.Item
+                                name="defaultMultiplier"
+                                label="默认倍率"
+                                rules={[
+                                    { required: true, message: "请填写默认倍率" },
+                                    { type: "number", min: 0.0001, max: 100 },
+                                ]}
+                            >
                                 <InputNumber className="w-full" min={0.0001} max={100} precision={4} />
                             </Form.Item>
                         </div>
                         <Form.Item name="modelMultipliers" label="模型独立倍率" extra="每行使用 模型名=倍率">
                             <Input.TextArea rows={2} placeholder={"gpt-image-1=1.5\nseedance-1.0-pro=2"} />
                         </Form.Item>
-                        <Button type="primary" loading={savingPolicy} onClick={() => void savePolicy()}>保存积分策略</Button>
+                        <Button type="primary" loading={savingPolicy} onClick={() => void savePolicy()}>
+                            保存积分策略
+                        </Button>
                     </Form>
                 </section>
-                <section className="rounded-lg bg-background p-4">
-                    <div className="flex items-start gap-3">
+                <section className="admin-operation-card">
+                    <div className="admin-operation-card-heading flex items-start gap-3">
                         <span className="grid size-8 shrink-0 place-items-center rounded-md bg-muted/40">
                             <UserRoundCog className="size-4" />
                         </span>
-                        <h2 className="pt-1 text-sm font-semibold">人工调整积分</h2>
+                        <div>
+                            <h2 className="text-sm font-semibold">人工调整积分</h2>
+                            <p>针对单个用户增减积分，并保留处理依据。</p>
+                        </div>
                     </div>
                     <Form form={adjustmentForm} layout="vertical" requiredMark={false} className="mt-3">
                         <Form.Item name="userId" label="目标用户" rules={[{ required: true, message: "请选择用户" }]}>
-                            <Select showSearch filterOption={false} loading={searchingUsers} placeholder="搜索用户名或显示名称" onSearch={(value) => void searchUsers(value)} options={adjustmentUsers.map((user) => ({ label: `${user.displayName || user.username} · @${user.username}`, value: user.id }))} />
+                            <Select
+                                showSearch
+                                filterOption={false}
+                                loading={searchingUsers}
+                                placeholder="搜索用户名或显示名称"
+                                onSearch={(value) => void searchUsers(value)}
+                                options={adjustmentUsers.map((user) => ({ label: `${user.displayName || user.username} · @${user.username}`, value: user.id }))}
+                            />
                         </Form.Item>
                         <div className="grid gap-3 sm:grid-cols-2">
                             <Form.Item name="amount" label="积分变化" rules={[{ required: true, message: "请填写积分变化" }]}>
@@ -281,43 +317,124 @@ export default function CreditOperationsPanel({ users }: { users: AdminReference
                                 <Input maxLength={500} placeholder="工单号或处理依据" />
                             </Form.Item>
                         </div>
-                        <Button type="primary" loading={adjusting} onClick={() => void adjust()}>确认调整</Button>
+                        <Button type="primary" loading={adjusting} onClick={() => void adjust()}>
+                            确认调整
+                        </Button>
                     </Form>
                 </section>
             </div>
 
             <section className="flex min-h-0 flex-1">
                 <AdminDataTable
-                    toolbar={<Input
-                        allowClear
-                        className="app-list-search"
-                        prefix={<Search className="size-4 text-foreground/40" />}
-                        value={keyword}
-                        placeholder="搜索用户、模型、场景或请求号"
-                        onChange={(event) => {
-                            setKeyword(event.target.value);
-                            setPage(1);
-                        }}
-                    />}
-                    toolbarActiveFilters={<>{keyword ? <AdminFilterChip label={`搜索：${keyword}`} onRemove={() => { setKeyword(""); setPage(1); }} /> : null}{orderStatus !== "review" ? <AdminFilterChip label={`队列：${orderStatus === "all" ? "全部历史" : orderStatus}`} onRemove={() => { setOrderStatus("review"); setPage(1); }} /> : null}</>}
+                    toolbar={
+                        <Input
+                            allowClear
+                            className="app-list-search"
+                            prefix={<Search className="size-4 text-foreground/40" />}
+                            value={keyword}
+                            placeholder="搜索用户、模型、场景或请求号"
+                            onChange={(event) => {
+                                setKeyword(event.target.value);
+                                setPage(1);
+                            }}
+                        />
+                    }
+                    toolbarActiveFilters={
+                        <>
+                            {keyword ? (
+                                <AdminFilterChip
+                                    label={`搜索：${keyword}`}
+                                    onRemove={() => {
+                                        setKeyword("");
+                                        setPage(1);
+                                    }}
+                                />
+                            ) : null}
+                            {orderStatus !== "review" ? (
+                                <AdminFilterChip
+                                    label={`队列：${orderStatus === "all" ? "全部历史" : orderStatus}`}
+                                    onRemove={() => {
+                                        setOrderStatus("review");
+                                        setPage(1);
+                                    }}
+                                />
+                            ) : null}
+                        </>
+                    }
                     toolbarActive={Boolean(keyword || orderStatus !== "review")}
-                    toolbarFilters={<Select className="w-36" value={orderStatus} onChange={(value) => { setOrderStatus(value); setPage(1); }} options={[{ label: "待核对队列", value: "review" }, { label: "全部历史", value: "all" }, { label: "费用待核对", value: "uncertain" }, { label: "运行中", value: "running" }, { label: "已冻结", value: "reserved" }, { label: "已结算", value: "settled" }, { label: "已退款", value: "refunded" }]} />}
-                    onReset={() => { setKeyword(""); setOrderStatus("review"); setPage(1); }}
-                    trailing={<Button type="text" size="small" icon={<RefreshCw className="size-3.5" />} loading={loading} onClick={() => void reload()}>刷新</Button>}
-                    batchActions={<AdminBatchBar count={selectedOrderIds.length} onClear={() => setSelectedOrderIds([])}><Button size="small" type="primary" icon={<BadgeCheck className="size-3.5" />} onClick={() => openBatchResolution("settle")}>批量确认扣费</Button><Button size="small" danger icon={<Undo2 className="size-3.5" />} onClick={() => openBatchResolution("refund")}>批量退回积分</Button></AdminBatchBar>}
-                    table={{ className: "app-data-table", rowKey: "id", size: "small", loading, pagination: false, columns, dataSource: orders, rowSelection: {
+                    toolbarFilters={
+                        <Select
+                            className="w-36"
+                            value={orderStatus}
+                            onChange={(value) => {
+                                setOrderStatus(value);
+                                setPage(1);
+                            }}
+                            options={[
+                                { label: "待核对队列", value: "review" },
+                                { label: "全部历史", value: "all" },
+                                { label: "费用待核对", value: "uncertain" },
+                                { label: "运行中", value: "running" },
+                                { label: "已冻结", value: "reserved" },
+                                { label: "已结算", value: "settled" },
+                                { label: "已退款", value: "refunded" },
+                            ]}
+                        />
+                    }
+                    onReset={() => {
+                        setKeyword("");
+                        setOrderStatus("review");
+                        setPage(1);
+                    }}
+                    trailing={
+                        <Button type="text" size="small" icon={<RefreshCw className="size-3.5" />} loading={loading} onClick={() => void reload()}>
+                            刷新
+                        </Button>
+                    }
+                    batchActions={
+                        <AdminBatchBar count={selectedOrderIds.length} onClear={() => setSelectedOrderIds([])}>
+                            <Button size="small" type="primary" icon={<BadgeCheck className="size-3.5" />} onClick={() => openBatchResolution("settle")}>
+                                批量确认扣费
+                            </Button>
+                            <Button size="small" danger icon={<Undo2 className="size-3.5" />} onClick={() => openBatchResolution("refund")}>
+                                批量退回积分
+                            </Button>
+                        </AdminBatchBar>
+                    }
+                    table={{
+                        className: "app-data-table",
+                        rowKey: "id",
+                        size: "small",
+                        loading,
+                        pagination: false,
+                        columns,
+                        dataSource: orders,
+                        rowSelection: {
                             selectedRowKeys: selectedOrderIds,
                             preserveSelectedRowKeys: false,
                             onChange: (keys) => setSelectedOrderIds(keys.map(String)),
                             getCheckboxProps: (order) => ({ disabled: !canResolveBillingOrder(order), name: `${order.model} ${order.scene || order.capability}` }),
-                        }, scroll: { x: 1390 } }}
+                        },
+                        scroll: { x: 1390 },
+                    }}
                     empty={<AdminTableEmpty filtered={Boolean(keyword || orderStatus !== "review")} title="暂无计费订单" />}
-                    footer={<PaginationBar alwaysShow current={page} pageSize={pageSize} total={total} onChange={(nextPage, nextPageSize) => { setPage(nextPageSize !== pageSize ? 1 : nextPage); setPageSize(nextPageSize); }} />}
+                    footer={
+                        <PaginationBar
+                            alwaysShow
+                            current={page}
+                            pageSize={pageSize}
+                            total={total}
+                            onChange={(nextPage, nextPageSize) => {
+                                setPage(nextPageSize !== pageSize ? 1 : nextPage);
+                                setPageSize(nextPageSize);
+                            }}
+                        />
+                    }
                 />
             </section>
 
             <Modal
-                title={resolutionTarget?.action === "settle" ? (resolutionTarget.kind === "batch" ? "批量确认扣除冻结积分" : "确认扣除冻结积分") : (resolutionTarget?.kind === "batch" ? "批量确认退回冻结积分" : "确认退回冻结积分")}
+                title={resolutionTarget?.action === "settle" ? (resolutionTarget.kind === "batch" ? "批量确认扣除冻结积分" : "确认扣除冻结积分") : resolutionTarget?.kind === "batch" ? "批量确认退回冻结积分" : "确认退回冻结积分"}
                 open={Boolean(resolutionTarget)}
                 okText={resolutionTarget?.action === "settle" ? "确认扣费" : "退回积分"}
                 cancelText="取消"
@@ -333,7 +450,8 @@ export default function CreditOperationsPanel({ users }: { users: AdminReference
             >
                 {resolutionTarget?.kind === "batch" ? (
                     <div className="mb-4 rounded-md border border-border bg-muted/25 px-3 py-2.5 text-sm text-foreground/65">
-                        已选择 <span className="font-semibold text-foreground">{resolutionTarget.orderIds.length}</span> 条订单，涉及冻结积分 <span className="font-semibold tabular-nums text-foreground">{formatCredits(resolutionTarget.amountMicrocredits)}</span>。本次核对依据将写入每条订单的审计记录。
+                        已选择 <span className="font-semibold text-foreground">{resolutionTarget.orderIds.length}</span> 条订单，涉及冻结积分{" "}
+                        <span className="font-semibold tabular-nums text-foreground">{formatCredits(resolutionTarget.amountMicrocredits)}</span>。本次核对依据将写入每条订单的审计记录。
                     </div>
                 ) : null}
                 <Form form={resolutionForm} layout="vertical" requiredMark={false}>

--- a/web/src/pages/admin/components/feature-availability-panel.tsx
+++ b/web/src/pages/admin/components/feature-availability-panel.tsx
@@ -111,8 +111,15 @@ export default function FeatureAvailabilityPanel() {
                                     <h3 className="text-sm font-medium">{item.title}</h3>
                                     <span className="rounded border border-border/70 px-1.5 py-0.5 text-[var(--fs-micro)] text-foreground/45">{item.menu}</span>
                                 </div>
+                                <p className="mt-1 max-w-3xl text-xs leading-5 text-foreground/52">{item.description}</p>
                             </div>
-                            <Switch checked={features?.[item.key] === true} loading={!features || saving === item.key} disabled={Boolean(saving && saving !== item.key) || (item.key === "systemPluginsVisibleToUsers" && features?.pluginCenterEnabled !== true)} onChange={(checked) => toggle(item.key, checked)} aria-label={`开放${item.title}`} />
+                            <Switch
+                                checked={features?.[item.key] === true}
+                                loading={!features || saving === item.key}
+                                disabled={Boolean(saving && saving !== item.key) || (item.key === "systemPluginsVisibleToUsers" && features?.pluginCenterEnabled !== true)}
+                                onChange={(checked) => toggle(item.key, checked)}
+                                aria-label={`开放${item.title}`}
+                            />
                         </div>
                     ))}
                 </div>
@@ -132,6 +139,7 @@ export default function FeatureAvailabilityPanel() {
                                     <h3 className="text-sm font-medium">{item.title}</h3>
                                     <span className="rounded border border-border/70 px-1.5 py-0.5 text-[var(--fs-micro)] text-foreground/45">{item.menu}</span>
                                 </div>
+                                <p className="mt-1 max-w-3xl text-xs leading-5 text-foreground/52">{item.description}</p>
                             </div>
                             <Switch checked={features?.[item.key] === true} loading={!features || saving === item.key} disabled={Boolean(saving && saving !== item.key)} onChange={(checked) => toggle(item.key, checked)} aria-label={`开放${item.title}`} />
                         </div>

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -9587,10 +9587,18 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 .admin-secondary-drawer,
 .admin-modal-root,
 .admin-channel-modal-root {
-    --admin-layer-0: #f7f7f5;
+    --admin-layer-0: #eef1f4;
     --admin-layer-1: #ffffff;
-    --admin-layer-2: #f5f4f2;
-    --admin-sidebar: #f0efe9;
+    --admin-layer-2: #f5f7f9;
+    --admin-sidebar: #e9ebef;
+    --admin-text-primary: #1f2328;
+    --admin-text-secondary: #3f4854;
+    --admin-text-muted: #5d6878;
+    --admin-text-placeholder: #6f7b8b;
+    --admin-control-border: color-mix(in srgb, var(--foreground) 27%, transparent);
+    --admin-divider: color-mix(in srgb, var(--foreground) 16%, transparent);
+    --admin-card-border: color-mix(in srgb, var(--foreground) 15%, transparent);
+    --admin-card-shadow: 0 12px 30px color-mix(in srgb, #1f2937 8%, transparent);
     --admin-status-success: oklch(0.52 0.14 155);
     --admin-status-warning: oklch(0.62 0.14 78);
     --admin-status-error: var(--destructive);
@@ -9605,10 +9613,18 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 .dark .admin-secondary-drawer,
 .dark .admin-modal-root,
 .dark .admin-channel-modal-root {
-    --admin-layer-0: #0d0d0d;
-    --admin-layer-1: #111111;
-    --admin-layer-2: #1a1a1a;
-    --admin-sidebar: #0a0a0a;
+    --admin-layer-0: #0b0d10;
+    --admin-layer-1: #14171b;
+    --admin-layer-2: #1b1f25;
+    --admin-sidebar: #0f1216;
+    --admin-text-primary: #f2f4f7;
+    --admin-text-secondary: #c3c8d0;
+    --admin-text-muted: #99a2ae;
+    --admin-text-placeholder: #858f9d;
+    --admin-control-border: color-mix(in srgb, var(--foreground) 24%, transparent);
+    --admin-divider: color-mix(in srgb, var(--foreground) 16%, transparent);
+    --admin-card-border: color-mix(in srgb, var(--foreground) 13%, transparent);
+    --admin-card-shadow: 0 16px 34px rgb(0 0 0 / 0.2);
     --admin-status-success: oklch(0.72 0.14 155);
     --admin-status-warning: oklch(0.78 0.14 78);
     --admin-status-info: oklch(0.76 0.13 250);
@@ -9617,20 +9633,21 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 }
 
 .admin-shell .admin-nav-group-label {
-    position: relative;
     display: flex;
     align-items: center;
     gap: 8px;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
+    margin-bottom: 5px !important;
+    padding-inline: 10px;
+    color: color-mix(in srgb, var(--admin-text-secondary) 84%, transparent) !important;
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 18px;
 }
 
 .admin-shell .admin-nav-group-label::before,
 .admin-shell .admin-nav-group-label::after {
-    height: 1px;
-    flex: 1 1 auto;
-    background: color-mix(in srgb, var(--foreground) 12%, transparent);
-    content: "";
+    display: none;
 }
 
 .admin-shell .admin-nav-group-label span {
@@ -9639,7 +9656,9 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 
 .admin-shell .app-workspace-nav-link {
     position: relative;
-    color: color-mix(in srgb, var(--foreground) 62%, transparent);
+    height: 34px !important;
+    border-radius: 8px;
+    color: var(--admin-text-secondary);
 }
 
 .admin-shell .app-workspace-brand-link {
@@ -9647,8 +9666,9 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 }
 
 .admin-shell .app-workspace-nav-link.is-active {
-    background: color-mix(in srgb, var(--foreground) 5%, transparent);
-    color: var(--foreground);
+    background: color-mix(in srgb, var(--admin-status-info) 11%, var(--admin-layer-2));
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--admin-status-info) 16%, transparent);
+    color: var(--admin-text-primary);
     font-weight: 600;
 }
 
@@ -9657,13 +9677,19 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 }
 
 .admin-shell .app-workspace-nav-link:hover:not(.is-active) {
-    background: var(--surface-hover);
-    color: var(--foreground);
+    background: var(--admin-layer-2);
+    color: var(--admin-text-primary);
 }
 
 .admin-shell .app-workspace-nav-link > svg {
-    width: 14px;
-    height: 14px;
+    width: 15px;
+    height: 15px;
+    color: var(--admin-text-muted);
+    stroke-width: 1.8;
+}
+
+.admin-shell .app-workspace-nav-link.is-active > svg {
+    color: var(--admin-status-info);
 }
 
 .admin-shell .app-workspace-nav-link:focus-visible,
@@ -9676,17 +9702,102 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 .admin-shell .app-workspace-sidebar,
 .admin-shell .admin-sidebar {
     background: var(--admin-sidebar);
+    border-radius: 0 !important;
+    border-right: 1px solid var(--admin-divider);
+    box-shadow: none;
 }
 
 /* 管理后台侧栏不复用通用 Tailwind 宽度：通用 sidebar 规则在后面会覆盖 w-*，导致视觉收缩但布局仍占展开宽度。 */
 .admin-shell .admin-sidebar {
-    width: 212px;
-    flex-basis: 212px;
+    width: 224px;
+    flex-basis: 224px;
 }
 
 .admin-shell .admin-sidebar.is-collapsed {
-    width: var(--workspace-sidebar-collapsed-width, 56px);
-    flex-basis: var(--workspace-sidebar-collapsed-width, 56px);
+    width: 64px;
+    flex-basis: 64px;
+}
+
+.admin-shell .admin-sidebar-header {
+    height: 68px;
+    border-bottom: 1px solid var(--admin-divider);
+    background: linear-gradient(160deg, color-mix(in srgb, var(--foreground) 3%, var(--admin-sidebar)), var(--admin-sidebar));
+}
+
+.admin-shell .admin-sidebar-brand-mark {
+    width: 32px;
+    height: 32px;
+    border-radius: 9px;
+    box-shadow: 0 6px 16px color-mix(in srgb, var(--foreground) 12%, transparent);
+}
+
+.admin-shell .admin-sidebar-brand-copy > span:first-child {
+    color: var(--admin-text-primary);
+    font-size: 14px;
+    line-height: 18px;
+}
+
+.admin-shell .admin-sidebar-brand-copy > span:last-child {
+    margin-top: 1px;
+    color: var(--admin-text-muted);
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    line-height: 15px;
+}
+
+.admin-shell .admin-sidebar-toggle {
+    width: 30px;
+    height: 30px;
+    border: 1px solid transparent;
+    border-radius: 8px;
+    color: var(--admin-text-muted);
+}
+
+.admin-shell .admin-sidebar-toggle:hover {
+    border-color: var(--admin-card-border);
+    background: var(--admin-layer-2);
+    color: var(--admin-text-primary);
+}
+
+.admin-shell .admin-sidebar-nav {
+    padding: 6px 10px;
+}
+
+.admin-shell .admin-nav-group {
+    margin-bottom: 0;
+}
+
+.admin-shell .admin-nav-group + .admin-nav-group {
+    margin-top: 12px;
+}
+
+.admin-shell .admin-nav-collapsed-separator {
+    width: 28px;
+    height: 1px;
+    margin: 8px auto;
+    background: var(--admin-divider);
+}
+
+.admin-shell .admin-sidebar-footer {
+    border-top: 1px solid var(--admin-divider);
+    background: linear-gradient(0deg, color-mix(in srgb, var(--foreground) 2%, var(--admin-sidebar)), var(--admin-sidebar));
+    padding: 9px 10px 10px;
+}
+
+.admin-shell .admin-sidebar-footer :is(button, a) {
+    min-height: 34px;
+    border-radius: 8px;
+    color: var(--admin-text-muted);
+}
+
+.admin-shell .admin-sidebar-footer :is(button, a):hover {
+    background: var(--admin-layer-2);
+    color: var(--admin-text-primary);
+}
+
+.admin-shell .admin-sidebar.is-collapsed .admin-sidebar-nav,
+.admin-shell .admin-sidebar.is-collapsed .admin-sidebar-footer {
+    padding-inline: 8px;
 }
 
 .admin-shell .app-user-content,
@@ -9735,7 +9846,23 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 }
 
 .admin-page-header {
-    min-height: 44px;
+    min-height: 58px;
+    border-bottom: 1px solid var(--admin-divider);
+    padding-bottom: 14px;
+}
+
+.admin-page-title {
+    color: var(--admin-text-primary);
+    font-size: 20px;
+    letter-spacing: -0.02em;
+    line-height: 1.35;
+}
+
+.admin-page-description {
+    margin-top: 3px;
+    color: var(--admin-text-muted);
+    font-size: 12px;
+    line-height: 1.55;
 }
 
 .admin-data-table {
@@ -9748,14 +9875,15 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 
 .admin-list-toolbar {
     flex: 0 0 auto;
-    padding-top: 8px;
-    padding-bottom: 8px;
+    padding-top: 10px;
+    padding-bottom: 10px;
 }
 
 .admin-list-toolbar-main .app-list-search {
     min-width: 180px;
-    width: auto !important;
-    flex: 1 1 280px;
+    width: min(360px, 100%) !important;
+    max-width: 360px;
+    flex: 0 1 360px;
 }
 
 .admin-filter-toggle {
@@ -9818,11 +9946,23 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
     background: var(--foreground);
 }
 
+.admin-table-frame {
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+    overflow: hidden;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 10px;
+    background: var(--admin-layer-1);
+    box-shadow: var(--admin-card-shadow);
+}
+
 .admin-table-surface {
     min-height: 0;
     flex: 1 1 auto;
     overflow: hidden;
-    border-radius: 8px;
+    border-radius: 0;
 }
 
 .admin-table-scroll {
@@ -9835,7 +9975,7 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 .admin-table-pagination {
     flex: 0 0 auto;
     min-height: 44px;
-    border-top: 1px solid color-mix(in srgb, var(--foreground) 9%, transparent);
+    border-top: 1px solid var(--admin-divider);
     background: color-mix(in srgb, var(--admin-layer-1) 92%, transparent);
     backdrop-filter: blur(10px);
 }
@@ -9853,22 +9993,30 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
     position: sticky;
     top: 0;
     z-index: 3;
-    height: 38px;
-    padding: 8px 16px !important;
-    background: var(--admin-layer-1) !important;
+    height: 42px;
+    padding: 9px 16px !important;
+    background: var(--admin-layer-2) !important;
     color: color-mix(in srgb, var(--foreground) 52%, transparent) !important;
     font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: 0.035em;
 }
 
 .admin-shell .admin-table-surface .ant-table-tbody > tr > td,
 .admin-modal-root .admin-table-surface .ant-table-tbody > tr > td {
-    height: 48px;
-    padding: 10px 16px !important;
+    height: 52px;
+    padding: 11px 16px !important;
     font-size: 13px;
     font-variant-numeric: tabular-nums;
+}
+
+.admin-shell .admin-table-surface .ant-table-tbody > tr.ant-table-measure-row > td,
+.admin-modal-root .admin-table-surface .ant-table-tbody > tr.ant-table-measure-row > td {
+    height: 0 !important;
+    padding: 0 !important;
+    border: 0 !important;
+    font-size: 0;
+    line-height: 0;
 }
 
 .admin-shell .admin-table-surface .ant-table-tbody > tr:hover > td,
@@ -9988,47 +10136,70 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
     display: inline-flex;
     align-items: center;
     justify-content: flex-end;
-    gap: 8px;
+    gap: 6px;
     white-space: nowrap;
 }
 
 .admin-row-action.ant-btn {
-    height: 24px;
-    min-height: 24px;
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent !important;
+    height: 30px;
+    min-height: 30px;
+    padding: 0 9px;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 6px;
+    background: var(--admin-layer-1) !important;
     box-shadow: none !important;
-    color: color-mix(in srgb, var(--foreground) 58%, transparent);
+    color: var(--admin-text-secondary);
     font-size: 12px;
-    font-weight: 500;
+    font-weight: 550;
     line-height: 1;
-    transition: none !important;
+    transition: border-color 140ms ease, background-color 140ms ease, color 140ms ease !important;
+}
+
+.admin-row-action.ant-btn .ant-btn-icon {
+    display: grid;
+    margin-inline-end: 0;
+}
+
+.admin-row-action.ant-btn .ant-btn-icon > svg {
+    width: 13px;
+    height: 13px;
 }
 
 .admin-row-action.ant-btn:hover:not(:disabled),
 .admin-row-action.ant-btn:active:not(:disabled),
 .admin-row-action.ant-btn:focus:not(:disabled),
 .admin-row-action.ant-btn.ant-dropdown-open {
-    background: transparent !important;
-    color: var(--foreground);
+    border-color: var(--admin-control-border);
+    background: var(--admin-layer-2) !important;
+    color: var(--admin-text-primary);
 }
 
 .admin-row-action-primary.ant-btn {
-    color: color-mix(in srgb, var(--foreground) 88%, transparent);
-    font-weight: 600;
+    border-color: color-mix(in srgb, var(--admin-status-info) 30%, var(--admin-card-border));
+    background: color-mix(in srgb, var(--admin-status-info) 8%, var(--admin-layer-1)) !important;
+    color: color-mix(in srgb, var(--admin-status-info) 68%, var(--admin-text-primary));
+    font-weight: 650;
+}
+
+.admin-row-action-primary.ant-btn:hover:not(:disabled),
+.admin-row-action-primary.ant-btn:focus:not(:disabled) {
+    border-color: color-mix(in srgb, var(--admin-status-info) 52%, var(--admin-card-border));
+    background: color-mix(in srgb, var(--admin-status-info) 13%, var(--admin-layer-1)) !important;
+    color: var(--admin-text-primary);
 }
 
 .admin-row-action-danger.ant-btn {
+    border-color: color-mix(in srgb, var(--destructive) 24%, var(--admin-card-border));
+    background: color-mix(in srgb, var(--destructive) 6%, var(--admin-layer-1)) !important;
     color: var(--destructive);
 }
 
 .admin-row-action-more.ant-btn {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
-    color: color-mix(in srgb, var(--foreground) 54%, transparent);
+    gap: 3px;
+    min-width: 54px;
+    color: var(--admin-text-secondary);
 }
 
 .admin-row-action-chevron {
@@ -10109,8 +10280,9 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 
 .admin-stat-tile {
     min-width: 0;
-    padding: var(--space-3);
-    background: linear-gradient(135deg, color-mix(in srgb, var(--foreground) 7%, var(--admin-layer-1)), var(--admin-layer-1) 72%);
+    min-height: 112px;
+    padding: 18px;
+    background: linear-gradient(145deg, color-mix(in srgb, var(--foreground) 6%, var(--admin-layer-1)), var(--admin-layer-1) 70%);
 }
 
 .admin-stat-tile + .admin-stat-tile {
@@ -10119,33 +10291,107 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 
 .admin-stat-tile-label {
     color: color-mix(in srgb, var(--foreground) 55%, transparent);
-    font-size: 11px;
+    font-size: 12px;
+    font-weight: 500;
 }
 
 .admin-stat-tile-value {
-    margin-top: var(--space-1);
+    margin-top: 7px;
     color: var(--foreground);
-    font-size: 16px;
+    font-size: 22px;
     font-variant-numeric: tabular-nums;
     font-weight: 650;
     line-height: 1.25;
 }
 
 .admin-stat-tile-detail {
-    margin-top: var(--space-1);
+    margin-top: 8px;
     color: color-mix(in srgb, var(--foreground) 45%, transparent);
     font-size: 11px;
 }
 
 .admin-settings-section {
-    margin-top: 12px;
+    width: 100%;
     overflow: hidden;
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--foreground) 3%, var(--admin-layer-1));
+    border: 1px solid var(--admin-card-border);
+    border-radius: 12px;
+    background: var(--admin-layer-1);
+    box-shadow: var(--admin-card-shadow);
 }
 
 .admin-settings-section > :last-child {
     min-width: 0;
+}
+
+.admin-settings-section-summary {
+    background: linear-gradient(145deg, color-mix(in srgb, var(--foreground) 4%, var(--admin-layer-1)), var(--admin-layer-1) 72%);
+}
+
+.admin-settings-section-content {
+    background: color-mix(in srgb, var(--admin-layer-1) 96%, var(--admin-layer-2));
+}
+
+.admin-settings-section-footer {
+    border-top: 1px solid var(--admin-divider);
+    background: color-mix(in srgb, var(--admin-layer-2) 56%, var(--admin-layer-1));
+}
+
+.admin-operation-card {
+    overflow: hidden;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 12px;
+    background: var(--admin-layer-1);
+    padding: 18px 20px 20px;
+    box-shadow: var(--admin-card-shadow);
+}
+
+.admin-operation-card-heading {
+    padding-bottom: 13px;
+    border-bottom: 1px solid var(--admin-divider);
+}
+
+.admin-operation-card-heading p {
+    margin-top: 3px;
+    color: var(--admin-text-muted);
+    font-size: 11px;
+    line-height: 1.55;
+}
+
+.admin-analytics-trend-section {
+    overflow: hidden;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 12px;
+    background: var(--admin-layer-1);
+    padding: 18px 20px;
+    box-shadow: var(--admin-card-shadow);
+}
+
+.admin-analytics-empty-chart {
+    display: flex;
+    min-height: 220px;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    color: var(--admin-text-secondary);
+    text-align: center;
+}
+
+.admin-analytics-empty-chart > span {
+    display: grid;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 12px;
+    place-items: center;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 10px;
+    background: var(--admin-layer-2);
+    color: var(--admin-text-muted);
+}
+
+.admin-analytics-empty-chart p {
+    margin-top: 5px;
+    color: var(--admin-text-muted);
+    font-size: 12px;
 }
 
 .admin-drawer .ant-drawer-body,
@@ -10185,9 +10431,679 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
     overflow-y: auto;
 }
 
+/* 系统渠道模型编辑器：恢复已确认的信息层级、协议参数与价格档布局。 */
+.admin-model-editor-drawer .ant-drawer-header {
+    min-height: 52px;
+    padding-inline: 24px;
+}
+
+.admin-model-editor-drawer .ant-drawer-body {
+    padding: 20px 24px 24px;
+}
+
+.admin-model-editor-form {
+    width: 100%;
+    max-width: 1120px;
+    margin-inline: auto;
+}
+
+.admin-model-editor-section {
+    display: grid;
+    grid-template-columns: minmax(140px, 176px) minmax(0, 1fr);
+    gap: 24px;
+    padding: 20px 22px;
+}
+
+.admin-model-editor-section-heading,
+.admin-model-editor-section-content {
+    min-width: 0;
+}
+
+.admin-model-editor-section-heading h2 {
+    color: var(--foreground);
+    font-size: 15px;
+    font-weight: 650;
+    line-height: 1.4;
+}
+
+.admin-model-editor-section-heading p {
+    margin-top: 6px;
+    color: color-mix(in srgb, var(--foreground) 46%, transparent);
+    font-size: 11px;
+    line-height: 1.65;
+}
+
+.admin-model-editor-section-content > .ant-form-item:last-child,
+.admin-model-editor-section-content > .ant-form-item-row:last-child {
+    margin-bottom: 0;
+}
+
+.admin-model-editor-parameters .admin-model-editor-section-content {
+    overflow: hidden;
+}
+
+.admin-model-identity-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.admin-model-editor-drawer .admin-capability-editor {
+    border-radius: 0;
+    background: transparent;
+    padding: 0;
+}
+
+.admin-model-editor-drawer .admin-capability-editor-heading {
+    padding: 0 2px 2px;
+}
+
+.admin-model-editor-drawer .admin-capability-group {
+    border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+    background: color-mix(in srgb, var(--foreground) 2.5%, var(--admin-layer-1));
+    padding: 14px;
+}
+
+.admin-model-editor-drawer .admin-capability-group > summary {
+    position: relative;
+    padding-right: 20px;
+}
+
+.admin-model-editor-drawer .admin-capability-group > summary::after {
+    position: absolute;
+    top: 5px;
+    right: 2px;
+    width: 7px;
+    height: 7px;
+    border-right: 1px solid currentColor;
+    border-bottom: 1px solid currentColor;
+    content: "";
+    transform: rotate(45deg);
+    transition: transform 140ms ease;
+}
+
+.admin-model-editor-drawer .admin-capability-group:not([open]) > summary::after {
+    transform: rotate(-45deg);
+}
+
+.admin-model-editor-drawer .admin-capability-group-description {
+    color: var(--admin-text-muted) !important;
+    line-height: 1.5;
+}
+
+.admin-model-editor-drawer .admin-capability-block + .admin-capability-block {
+    margin-top: 14px;
+    padding-top: 14px;
+    border-top: 1px solid var(--admin-divider);
+}
+
+.admin-model-editor-drawer .admin-capability-block-title {
+    margin-bottom: 9px;
+    color: var(--admin-text-secondary);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+}
+
+.admin-model-editor-drawer .admin-capability-number-field,
+.admin-model-editor-drawer .admin-capability-boolean-field,
+.admin-model-editor-drawer .admin-capability-parameter-field {
+    min-width: 0;
+}
+
+.admin-model-editor-drawer .admin-capability-number-field .ant-input-number {
+    width: 100% !important;
+    min-width: 0;
+}
+
+.admin-capability-reference-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.admin-capability-reference-grid.is-three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.admin-capability-reference-grid.is-two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.admin-capability-reference-card,
+.admin-capability-protocol-card {
+    min-width: 0;
+    border: 1px solid color-mix(in srgb, var(--foreground) 10%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--foreground) 2.5%, var(--admin-layer-1));
+    padding: 14px;
+}
+
+.admin-capability-reference-card-heading {
+    min-height: 38px;
+    margin-bottom: 8px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--admin-divider);
+}
+
+.admin-capability-reference-card-heading h3,
+.admin-capability-protocol-card-heading h3 {
+    color: var(--admin-text-primary);
+    font-size: 12px;
+    font-weight: 650;
+    line-height: 1.4;
+}
+
+.admin-capability-reference-card-heading p,
+.admin-capability-protocol-card-heading p {
+    margin-top: 3px;
+    color: var(--admin-text-muted);
+    font-size: 10px;
+    line-height: 1.5;
+}
+
+.admin-capability-reference-fields {
+    display: grid;
+    gap: 4px;
+}
+
+.admin-capability-reference-fields .admin-capability-number-field {
+    display: grid;
+    min-height: 62px;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: end;
+    gap: 5px;
+    border-bottom: 1px solid color-mix(in srgb, var(--foreground) 7%, transparent);
+    padding-block: 4px;
+}
+
+.admin-capability-reference-fields .admin-capability-number-field:last-child {
+    border-bottom: 0;
+}
+
+.admin-capability-reference-fields .admin-capability-field-label {
+    margin-bottom: 0;
+    line-height: 1.4;
+}
+
+.admin-capability-reference-fields .admin-capability-boolean-field {
+    min-height: 48px;
+    margin-top: 4px;
+    padding-block: 6px;
+}
+
+.admin-capability-reference-fields .admin-capability-boolean-field > div:first-child > div:last-child {
+    display: none;
+}
+
+.admin-capability-protocol-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.admin-capability-protocol-card-heading {
+    display: flex;
+    min-height: 46px;
+    align-items: flex-start;
+    gap: 9px;
+    margin-bottom: 12px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--admin-divider);
+}
+
+.admin-capability-protocol-card-heading > span {
+    display: grid;
+    width: 24px;
+    height: 24px;
+    flex: 0 0 auto;
+    place-items: center;
+    border-radius: 6px;
+    background: var(--admin-layer-3);
+    color: var(--admin-text-muted);
+    font-size: 9px;
+    font-weight: 700;
+}
+
+.admin-capability-protocol-card-heading p {
+    margin-top: 2px;
+    line-height: 1.45;
+}
+
+.admin-capability-protocol-fields,
+.admin-capability-spec-grid {
+    display: grid;
+    gap: 10px;
+}
+
+.admin-capability-duration-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.admin-price-tier-card {
+    overflow: hidden;
+    border: 1px solid color-mix(in srgb, var(--foreground) 12%, transparent);
+    border-radius: 8px;
+    background: color-mix(in srgb, var(--foreground) 2%, var(--admin-layer-1));
+}
+
+.admin-price-tier-card-header {
+    display: flex;
+    min-width: 0;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    border-bottom: 1px solid color-mix(in srgb, var(--foreground) 9%, transparent);
+    padding: 12px 14px;
+}
+
+.admin-price-tier-card-body {
+    display: grid;
+    grid-template-columns: minmax(0, 1.08fr) minmax(0, 0.92fr);
+}
+
+.admin-price-tier-block {
+    padding: 14px;
+}
+
+.admin-price-tier-block + .admin-price-tier-block {
+    border-left: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
+.admin-price-tier-block-title {
+    margin-bottom: 10px;
+    color: color-mix(in srgb, var(--foreground) 48%, transparent);
+    font-size: 10px;
+    font-weight: 650;
+    letter-spacing: 0.08em;
+}
+
+.admin-price-tier-block-title > span {
+    margin-right: 5px;
+    color: var(--admin-text-muted);
+}
+
+.admin-price-tier-match-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+}
+
+.admin-price-tier-upstream {
+    grid-column: 1 / -1;
+}
+
+.admin-price-tier-billing-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    align-items: end;
+    gap: 12px;
+}
+
+.admin-price-tier-billing-mode,
+.admin-price-tier-unit-price,
+.admin-price-tier-token-grid,
+.admin-price-tier-controls {
+    grid-column: 1 / -1;
+}
+
+.admin-price-tier-token-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 10px;
+}
+
+.admin-price-tier-billing-mode .ant-segmented {
+    border: 1px solid var(--admin-card-border);
+    background: var(--admin-layer-2);
+    padding: 3px;
+}
+
+.admin-price-tier-billing-mode .ant-segmented-item {
+    min-height: 32px;
+    border-radius: 5px;
+}
+
+.admin-price-tier-billing-mode .ant-segmented-item-label {
+    min-height: 32px;
+    padding-inline: 12px;
+    line-height: 32px;
+}
+
+.admin-price-tier-billing-mode .ant-segmented-item-selected {
+    background: var(--admin-layer-1);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--foreground) 14%, transparent);
+}
+
+.admin-price-tier-unit-price .ant-input-number {
+    width: 100% !important;
+}
+
+.admin-price-tier-controls {
+    display: grid !important;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 10px !important;
+}
+
+.admin-price-tier-toggle {
+    display: flex;
+    min-width: 0;
+    min-height: 58px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 7px;
+    background: var(--admin-layer-2);
+    padding: 8px 10px;
+}
+
+.admin-price-tier-toggle > div {
+    display: grid;
+    min-width: 0;
+    gap: 2px;
+}
+
+.admin-price-tier-toggle strong {
+    color: var(--admin-text-primary);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.35;
+}
+
+.admin-price-tier-toggle span {
+    overflow: hidden;
+    color: var(--admin-text-muted);
+    font-size: 9px;
+    line-height: 1.4;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.admin-model-editor-add-tier.ant-btn {
+    min-height: 38px;
+}
+
+.admin-drawer.admin-model-editor-drawer .ant-drawer-footer {
+    border-top: 0;
+    background: var(--admin-layer-0);
+    padding: 8px 24px 12px;
+    backdrop-filter: none;
+}
+
+.admin-model-editor-footer-actions {
+    width: 100%;
+    max-width: 1120px;
+    min-height: 52px;
+    margin-inline: auto;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 10px;
+    background: var(--admin-layer-1);
+    padding: 8px 10px;
+    box-shadow: 0 8px 24px color-mix(in srgb, var(--foreground) 8%, transparent);
+}
+
+.admin-model-editor-footer-primary {
+    min-width: 0;
+}
+
+.admin-model-editor-footer-status {
+    display: flex;
+    min-height: 34px;
+    align-items: center;
+    gap: 8px;
+    margin-right: 4px;
+    border: 1px solid var(--admin-card-border);
+    border-radius: 6px;
+    background: var(--admin-layer-2);
+    padding: 4px 8px;
+}
+
+.admin-model-editor-footer-status > span {
+    width: 6px;
+    height: 6px;
+    flex: 0 0 auto;
+    border-radius: 50%;
+    background: var(--admin-text-muted);
+}
+
+.admin-model-editor-footer-status > span.is-enabled {
+    background: #10a36a;
+}
+
+.admin-model-editor-footer-status > div {
+    display: grid;
+    min-width: 0;
+    margin-right: 4px;
+}
+
+.admin-model-editor-footer-status strong {
+    color: var(--admin-text-primary);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1.25;
+}
+
+.admin-model-editor-footer-status small {
+    color: var(--admin-text-muted);
+    font-size: 9px;
+    line-height: 1.2;
+}
+
+:root:not(.dark) .admin-model-editor-drawer .ant-drawer-header,
+:root:not(.dark) .admin-model-editor-drawer .ant-drawer-footer {
+    border-color: #d4dae2;
+    background: #ffffff;
+}
+
+:root:not(.dark) .admin-model-editor-drawer .ant-drawer-body,
+:root:not(.dark) .admin-drawer.admin-model-editor-drawer .ant-drawer-footer {
+    background: #edf1f5;
+}
+
+:root:not(.dark) .admin-model-editor-section {
+    border: 1px solid #d4dae2;
+    background: #ffffff;
+    box-shadow: 0 1px 3px rgb(15 23 42 / 0.055);
+}
+
+:root:not(.dark) .admin-model-editor-drawer :is(.admin-capability-group, .admin-capability-boolean-field, .admin-capability-parameter-field),
+:root:not(.dark) .admin-model-editor-drawer .admin-capability-reference-card,
+:root:not(.dark) .admin-model-editor-drawer .admin-capability-protocol-card,
+:root:not(.dark) .admin-price-tier-toggle,
+:root:not(.dark) .admin-price-tier-billing-mode .ant-segmented {
+    border-color: #cbd3dd;
+    background: #ffffff;
+}
+
+:root:not(.dark) .admin-price-tier-card {
+    border-color: #cbd3dd;
+    background: #f5f7fa;
+}
+
+:root:not(.dark) .admin-model-editor-drawer .admin-capability-reference-card,
+:root:not(.dark) .admin-model-editor-drawer .admin-capability-protocol-card {
+    border-color: #cbd3dd;
+    background: #f5f7fa;
+}
+
+:root:not(.dark) .admin-model-editor-drawer [role="radio"] {
+    border-color: #c3ccd7;
+    background: #ffffff;
+}
+
+:root:not(.dark) .admin-model-editor-drawer [role="radio"]:hover {
+    border-color: #929eac;
+    background: #f8fafc;
+}
+
+:root:not(.dark) .admin-model-editor-drawer [role="radio"][aria-checked="true"] {
+    border-color: #657180;
+    background: #eef3f7;
+    box-shadow: inset 0 0 0 1px rgb(31 41 55 / 0.08);
+}
+
+:root:not(.dark) .admin-model-editor-drawer
+    :is(.ant-input, .ant-input-affix-wrapper, .ant-input-number, .ant-select-selector, .ant-segmented) {
+    background: #ffffff;
+}
+
+:root:not(.dark) .admin-model-editor-section-heading h2 {
+    color: #20262e;
+}
+
+:root:not(.dark) .admin-model-editor-drawer .ant-form-item-label > label {
+    color: #364152;
+    font-weight: 550;
+}
+
+:root:not(.dark) .admin-model-editor-footer-actions {
+    border-color: #d4dae2;
+    background: #ffffff;
+    box-shadow: 0 6px 20px rgb(15 23 42 / 0.08);
+}
+
+:root:not(.dark) .admin-price-tier-billing-mode .ant-segmented-item-selected {
+    background: #e8edf2;
+    box-shadow: inset 0 0 0 1px rgb(31 41 55 / 0.12);
+}
+
+@media (max-width: 899px) {
+    .admin-model-editor-section,
+    .admin-capability-protocol-grid,
+    .admin-price-tier-card-body,
+    .admin-model-identity-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .admin-model-editor-section {
+        gap: 16px;
+    }
+
+    .admin-model-editor-section-heading {
+        padding-bottom: 12px;
+        border-bottom: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+    }
+
+    .admin-price-tier-block + .admin-price-tier-block {
+        border-top: 1px solid color-mix(in srgb, var(--foreground) 8%, transparent);
+        border-left: 0;
+    }
+}
+
+/* 管理后台可读性基线：收敛历史页面中过低的文字透明度，并统一表单层级。 */
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root) {
+    color: var(--admin-text-primary);
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.text-foreground\/30, .text-foreground\/35, .text-foreground\/38, .text-foreground\/40, .text-foreground\/42, .text-foreground\/45) {
+    color: var(--admin-text-muted) !important;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.text-foreground\/48, .text-foreground\/50, .text-foreground\/52, .text-foreground\/55) {
+    color: var(--admin-text-secondary) !important;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.ant-form-item-label > label, .ant-checkbox-wrapper, .ant-radio-wrapper, .ant-segmented-item-label) {
+    color: var(--admin-text-secondary);
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.ant-input, .ant-input-affix-wrapper, .ant-input-number, .ant-picker, .ant-select-selector) {
+    border-color: var(--admin-control-border) !important;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.ant-input, .ant-input-affix-wrapper input, .ant-input-number-input, .ant-picker-input > input, .ant-select-selection-item) {
+    color: var(--admin-text-primary) !important;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(input, textarea)::placeholder {
+    color: var(--admin-text-placeholder) !important;
+    opacity: 1;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    .ant-select-selection-placeholder,
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    .ant-input-number-input::placeholder {
+    color: var(--admin-text-placeholder) !important;
+    opacity: 1;
+}
+
+:is(.admin-shell, .admin-drawer, .admin-secondary-drawer, .admin-modal-root, .admin-channel-modal-root)
+    :is(.ant-input-disabled, .ant-input-number-disabled, .ant-picker-disabled, .ant-select-disabled .ant-select-selector) {
+    color: var(--admin-text-muted) !important;
+    opacity: 0.82;
+}
+
+.admin-shell .app-workspace-nav-link,
+.admin-shell .admin-sidebar :is(button, a) {
+    color: var(--admin-text-secondary);
+}
+
+.admin-shell .admin-nav-group-label {
+    color: color-mix(in srgb, var(--admin-text-secondary) 84%, transparent) !important;
+}
+
+.admin-shell .admin-table-surface .ant-table-thead > tr > th,
+.admin-modal-root .admin-table-surface .ant-table-thead > tr > th {
+    color: var(--admin-text-muted) !important;
+}
+
+.admin-shell .admin-table-surface .ant-table-tbody > tr > td,
+.admin-modal-root .admin-table-surface .ant-table-tbody > tr > td,
+.admin-shell .admin-pagination-total {
+    color: var(--admin-text-primary);
+}
+
+.admin-shell .admin-table-surface .ant-table-tbody > tr > td,
+.admin-modal-root .admin-table-surface .ant-table-tbody > tr > td,
+.admin-table-pagination,
+.admin-drawer .ant-drawer-footer,
+.admin-secondary-drawer .ant-drawer-footer {
+    border-color: var(--admin-divider);
+}
+
+.admin-model-editor-section-heading p,
+.admin-model-editor-subsection-heading p,
+.admin-price-tier-block-title {
+    color: var(--admin-text-muted);
+}
+
 .admin-channel-modal .ant-modal-body {
     max-height: min(70vh, 620px);
     overflow-y: auto;
+}
+
+@media (min-width: 1024px) {
+    .admin-page-frame {
+        padding: 18px 24px 0;
+    }
+
+    .admin-page-frame-scrollable {
+        padding-bottom: 28px;
+    }
+
+    .admin-page-frame-scrollable > :not(.admin-page-header) {
+        width: 100%;
+        max-width: 1120px;
+        margin-inline: auto;
+    }
+
+    .admin-settings-section:not(.is-stacked) .admin-settings-section-content {
+        border-left: 1px solid var(--admin-divider);
+    }
+
+    .admin-settings-section.is-stacked .admin-settings-section-summary {
+        border-bottom: 1px solid var(--admin-divider);
+    }
 }
 
 .admin-shell .admin-monospace {
@@ -10221,6 +11137,8 @@ html:not(.dark) .creation-media-preview-modal .ant-modal-container { background:
 
     .admin-list-toolbar-main .app-list-search {
         min-width: 0;
+        width: 100% !important;
+        max-width: none;
         flex-basis: 100%;
     }
 


### PR DESCRIPTION
## 背景

管理后台不同页面的信息层级、表格操作和表单密度不够统一；系统渠道的模型编辑器内容较长，图片、视频、文本能力与协议、参数、价格配置不易快速定位。本次仅做管理后台视觉与交互收口，不改变后端接口或模型协议。

## 主要改动

- 统一管理后台侧栏、顶部区域、内容容器、卡片和明暗主题视觉层级。
- 整理列表工具栏、表格容器、分页和行内操作按钮：后台筛选项默认常驻，主要操作直接展示，低频操作收进“更多”菜单。
- 优化数据分析、额度操作和功能开关页面的分区、空状态、说明文案与操作布局。
- 重排系统渠道模型编辑器：按基础信息、图片/视频/文本能力、协议参数、参考素材、价格档等分区，明确启用状态与保存操作。
- 优化能力卡片、协议选择、价格档与长表单在桌面宽度下的扫描效率。
- 为公共列表工具栏增加默认关闭的 `filtersAlwaysVisible` 可选能力；现有用户端调用保持原行为，仅管理后台启用。

## 验证

- `Prettier --check`：通过（本 PR 涉及的 9 个 TSX 文件）。
- `git diff --check`：通过。
- TypeScript 类型检查与生产构建：通过。
- 主测试：469 项通过，0 失败。
- 跨运行时测试：1 项通过，0 失败。
- 桌面视觉检查：覆盖 1440px / 1280px，检查管理后台首页、表格、设置页、系统渠道模型编辑器及明暗主题。

## 用户可见变化

- 管理后台列表筛选常驻显示，减少一次展开操作。
- 表格操作列更紧凑，低频或危险操作通过“更多”菜单访问。
- 系统渠道模型编辑页按能力和配置语义重新分组，保存入口更清晰。

## 范围与风险

- 不包含 Go 后端改动、可美协议、其他用户前端改造、数据库迁移、环境变量、部署步骤或依赖锁文件变化。
- 公共能力编辑组件保留默认的完整渲染行为；本次不修改保存数据结构、接口合同或协议枚举。
- 交互变化主要集中在筛选展示方式和操作入口层级，建议评审时重点确认后台各表格“更多”菜单中的低频操作仍符合使用习惯。

## 截图 / 视觉验证

- 已完成本地桌面端明暗主题视觉验证；本 PR 暂未附截图，合并前可按项目习惯补充代表性页面截图。

## 回滚

- 如出现样式覆盖或后台交互回归，可直接回滚本 PR 的单个提交，不涉及数据迁移或服务端回滚。
