### PR TITLE
fix(video): 支持 MiniMax 异步任务恢复

### DIFF
--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -2428,51 +2428,51 @@ func runMiniMaxVideoTask(ctx context.Context, input canvasGenerationInput) (map[
 	if strings.TrimSpace(input.Prompt) == "" {
 		return nil, errors.New("MiniMax 视频提示词不能为空")
 	}
-	if len(input.ReferenceImages) > 9 || len(input.ReferenceVideos) > 3 || len(input.ReferenceAudios) > 3 {
-		return nil, errors.New("MiniMax 视频最多支持 9 张参考图、3 个参考视频和 3 个参考音频")
-	}
-	content := []miniMaxVideoContent{{Type: "text", Text: strings.TrimSpace(input.Prompt)}}
-	for index, image := range input.ReferenceImages {
-		url, err := miniMaxMediaURLValue(image)
-		if err != nil {
-			return nil, fmt.Errorf("MiniMax 参考图无效：%w", err)
-		}
-		role := "reference_image"
-		if len(input.ReferenceVideos) == 0 && len(input.ReferenceAudios) == 0 && len(input.ReferenceImages) <= 2 {
-			if index == 0 {
-				role = "first_frame"
-			} else if index == 1 {
-				role = "last_frame"
-			}
-		}
-		content = append(content, miniMaxVideoContent{Type: "image_url", ImageURL: &miniMaxMediaURL{URL: url}, Role: role})
-	}
-	for _, video := range input.ReferenceVideos {
-		url, err := miniMaxMediaURLValue(video)
-		if err != nil {
-			return nil, fmt.Errorf("MiniMax 参考视频无效：%w", err)
-		}
-		content = append(content, miniMaxVideoContent{Type: "video_url", VideoURL: &miniMaxMediaURL{URL: url}, Role: "reference_video"})
-	}
-	for _, audio := range input.ReferenceAudios {
-		url, err := miniMaxMediaURLValue(audio)
-		if err != nil {
-			return nil, fmt.Errorf("MiniMax 参考音频无效：%w", err)
-		}
-		content = append(content, miniMaxVideoContent{Type: "audio_url", AudioURL: &miniMaxMediaURL{URL: url}, Role: "reference_audio"})
-	}
-	watermark := parseBool(input.Config.VideoWatermark, false)
-	frameMode := len(input.ReferenceImages) > 0 && len(input.ReferenceImages) <= 2 && len(input.ReferenceVideos) == 0 && len(input.ReferenceAudios) == 0
-	body := miniMaxVideoRequest{
-		Model:         input.Config.Model,
-		Content:       content,
-		Resolution:    normalizeMiniMaxResolution(input.Config.VQuality),
-		Duration:      normalizeMiniMaxDuration(input.Config.VideoSeconds),
-		Ratio:         normalizeMiniMaxRatio(input.Config.Size, frameMode),
-		AIGCWatermark: &watermark,
-	}
 	id := resumedProviderRequestID(ctx)
 	if id == "" {
+		if len(input.ReferenceImages) > 9 || len(input.ReferenceVideos) > 3 || len(input.ReferenceAudios) > 3 {
+			return nil, errors.New("MiniMax 视频最多支持 9 张参考图、3 个参考视频和 3 个参考音频")
+		}
+		content := []miniMaxVideoContent{{Type: "text", Text: strings.TrimSpace(input.Prompt)}}
+		for index, image := range input.ReferenceImages {
+			url, err := miniMaxMediaURLValue(image)
+			if err != nil {
+				return nil, fmt.Errorf("MiniMax 参考图无效：%w", err)
+			}
+			role := "reference_image"
+			if len(input.ReferenceVideos) == 0 && len(input.ReferenceAudios) == 0 && len(input.ReferenceImages) <= 2 {
+				if index == 0 {
+					role = "first_frame"
+				} else if index == 1 {
+					role = "last_frame"
+				}
+			}
+			content = append(content, miniMaxVideoContent{Type: "image_url", ImageURL: &miniMaxMediaURL{URL: url}, Role: role})
+		}
+		for _, video := range input.ReferenceVideos {
+			url, err := miniMaxMediaURLValue(video)
+			if err != nil {
+				return nil, fmt.Errorf("MiniMax 参考视频无效：%w", err)
+			}
+			content = append(content, miniMaxVideoContent{Type: "video_url", VideoURL: &miniMaxMediaURL{URL: url}, Role: "reference_video"})
+		}
+		for _, audio := range input.ReferenceAudios {
+			url, err := miniMaxMediaURLValue(audio)
+			if err != nil {
+				return nil, fmt.Errorf("MiniMax 参考音频无效：%w", err)
+			}
+			content = append(content, miniMaxVideoContent{Type: "audio_url", AudioURL: &miniMaxMediaURL{URL: url}, Role: "reference_audio"})
+		}
+		watermark := parseBool(input.Config.VideoWatermark, false)
+		frameMode := len(input.ReferenceImages) > 0 && len(input.ReferenceImages) <= 2 && len(input.ReferenceVideos) == 0 && len(input.ReferenceAudios) == 0
+		body := miniMaxVideoRequest{
+			Model:         input.Config.Model,
+			Content:       content,
+			Resolution:    normalizeMiniMaxResolution(input.Config.VQuality),
+			Duration:      normalizeMiniMaxDuration(input.Config.VideoSeconds),
+			Ratio:         normalizeMiniMaxRatio(input.Config.Size, frameMode),
+			AIGCWatermark: &watermark,
+		}
 		var created map[string]interface{}
 		if err := postJSON(ctx, input.Config, "/v2/video_generation", body, &created); err != nil {
 			return nil, err
@@ -2486,36 +2486,52 @@ func runMiniMaxVideoTask(ctx context.Context, input canvasGenerationInput) (map[
 		return nil, errors.New("MiniMax 视频接口没有返回任务 ID")
 	}
 	for deadline := providerPollingDeadline(ctx); time.Now().Before(deadline); {
-		var response map[string]interface{}
-		if err := getJSON(ctx, input.Config, "/v2/query/video_generation/"+url.PathEscape(id), &response); err != nil {
+		result, _, err := queryMiniMaxVideoTask(withProviderRequestKind(ctx, "poll"), input, id)
+		if err != nil {
 			return nil, err
 		}
-		task, _ := response["task"].(map[string]interface{})
-		if task == nil {
-			task = response
-		}
-		status := strings.ToLower(stringField(task, "status"))
-		if status == "succeeded" || status == "completed" {
-			contentValue, _ := task["content"].(map[string]interface{})
-			videoURL := stringField(contentValue, "url")
-			if videoURL == "" {
-				return nil, fmt.Errorf("MiniMax 视频任务 %s 已完成但没有返回视频 URL", id)
-			}
-			data, mimeType, err := getProviderExternalBinary(withProviderRequestKind(ctx, "download"), input.Config, videoURL)
-			if err != nil {
-				return nil, fmt.Errorf("MiniMax 视频结果下载失败（任务 %s）：%w", id, err)
-			}
-			mimeType = normalizedMediaMimeType(mimeType, data)
-			return map[string]interface{}{"mode": "video", "video": map[string]interface{}{"dataUrl": dataURL(mimeType, data), "mimeType": mimeType}}, nil
-		}
-		if status == "failed" || status == "cancelled" {
-			return nil, fmt.Errorf("MiniMax 视频生成失败（任务 %s）：%s", id, miniMaxTaskError(task))
+		if result != nil {
+			return result, nil
 		}
 		if err := sleepContext(ctx, 2500*time.Millisecond); err != nil {
 			return nil, err
 		}
 	}
-	return nil, fmt.Errorf("MiniMax 视频生成超时（任务 %s）", id)
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, context.DeadlineExceeded
+}
+
+// 单次查询只读取已有 MiniMax 任务，自动续查和人工恢复共用这条路径。
+func queryMiniMaxVideoTask(ctx context.Context, input canvasGenerationInput, id string) (map[string]interface{}, string, error) {
+	var response map[string]interface{}
+	if err := getJSON(ctx, input.Config, "/v2/query/video_generation/"+url.PathEscape(id), &response); err != nil {
+		return nil, "", err
+	}
+	task, _ := response["task"].(map[string]interface{})
+	if task == nil {
+		task = response
+	}
+	status := strings.ToLower(strings.TrimSpace(stringField(task, "status")))
+	switch status {
+	case "succeeded", "completed":
+		contentValue, _ := task["content"].(map[string]interface{})
+		videoURL := stringField(contentValue, "url")
+		if videoURL == "" {
+			return nil, status, fmt.Errorf("MiniMax 视频任务 %s 已完成但没有返回视频 URL", id)
+		}
+		data, mimeType, err := getProviderExternalBinary(withProviderRequestKind(ctx, "download"), input.Config, videoURL)
+		if err != nil {
+			return nil, status, fmt.Errorf("MiniMax 视频结果下载失败（任务 %s）：%w", id, err)
+		}
+		mimeType = normalizedMediaMimeType(mimeType, data)
+		return map[string]interface{}{"mode": "video", "video": map[string]interface{}{"dataUrl": dataURL(mimeType, data), "mimeType": mimeType}}, status, nil
+	case "failed", "cancelled":
+		return nil, status, fmt.Errorf("MiniMax 视频生成失败（任务 %s）：%s", id, miniMaxTaskError(task))
+	default:
+		return nil, status, nil
+	}
 }
 
 func miniMaxMediaURLValue(media providerMedia) (string, error) {

--- a/backend/internal/service/provider_task_recovery.go
+++ b/backend/internal/service/provider_task_recovery.go
@@ -104,8 +104,9 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 	if err != nil {
 		return nil, err
 	}
-	if config.InterfaceType != string(model.ChannelInterfaceNewAPIChannel2) {
-		return nil, BadAuthRequest("该任务不使用 NewAPI Video Generations 协议")
+	protocol := model.ChannelInterfaceType(config.InterfaceType)
+	if protocol != model.ChannelInterfaceNewAPIChannel2 && protocol != model.ChannelInterfaceMiniMaxVideo {
+		return nil, BadAuthRequest("该视频协议不支持上游任务恢复")
 	}
 	input.Config = config
 	task.InputJSON = decryptedInput
@@ -130,7 +131,14 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 
 	queryCtx := withProviderAnalytics(ctx, s, *task)
 	queryCtx = withProviderOutboundPolicy(queryCtx, input.Config)
-	result, providerStatus, err := queryNewAPIChannel2VideoTask(queryCtx, input, providerRequestID)
+	var result map[string]interface{}
+	var providerStatus string
+	switch protocol {
+	case model.ChannelInterfaceNewAPIChannel2:
+		result, providerStatus, err = queryNewAPIChannel2VideoTask(queryCtx, input, providerRequestID)
+	case model.ChannelInterfaceMiniMaxVideo:
+		result, providerStatus, err = queryMiniMaxVideoTask(queryCtx, input, providerRequestID)
+	}
 	if err != nil {
 		_ = s.log(task.UserID, task.ID, "error", "人工查询上游视频任务失败", err.Error())
 		return nil, err

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -1719,6 +1719,61 @@ func TestRunNewAPIChannel2VideoTaskReturnsTypedDeadlineWhenPollingWindowEnds(t *
 	}
 }
 
+func TestRunMiniMaxVideoTaskResumesOriginalProviderTaskWithoutAnotherPostOrReferenceValidation(t *testing.T) {
+	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "true")
+	paths := make([]string, 0, 2)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.Method+" "+r.URL.Path)
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v2/query/video_generation/existing-minimax-task":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"task":{"status":"succeeded","content":{"url":"` + server.URL + `/video.mp4"}}}`))
+		case "GET /video.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	input := canvasGenerationInput{
+		Mode:            "video",
+		Prompt:          "test",
+		Config:          providerConfig{BaseURL: server.URL, APIKey: "test-key", Model: "MiniMax-H3", InterfaceType: string(model.ChannelInterfaceMiniMaxVideo)},
+		ReferenceImages: []providerMedia{{ID: "stored-reference"}},
+	}
+	inputJSON, err := json.Marshal(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := withProviderAnalytics(context.Background(), nil, model.Task{
+		ID: "task-1", Type: "canvas_video", ProviderRequestID: "existing-minimax-task", InputJSON: string(inputJSON),
+	})
+	result, err := runMiniMaxVideoTask(ctx, input)
+	if err != nil {
+		t.Fatalf("runMiniMaxVideoTask() error = %v", err)
+	}
+	if result["video"] == nil {
+		t.Fatalf("result = %#v", result)
+	}
+	want := "GET /v2/query/video_generation/existing-minimax-task,GET /video.mp4"
+	if got := strings.Join(paths, ","); got != want {
+		t.Fatalf("paths = %q, want %q", got, want)
+	}
+}
+
+func TestRunMiniMaxVideoTaskReturnsTypedDeadlineWhenPollingWindowEnds(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	ctx = withProviderAnalytics(ctx, nil, model.Task{ID: "task-1", Type: "canvas_video", ProviderRequestID: "existing-minimax-task"})
+	_, err := runMiniMaxVideoTask(ctx, canvasGenerationInput{Prompt: "test"})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("runMiniMaxVideoTask() error = %v, want context deadline exceeded", err)
+	}
+}
+
 func TestRunGeminiVeoVideoTaskUsesLongRunningOperation(t *testing.T) {
 	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "true")
 	paths := make([]string, 0, 3)

--- a/backend/internal/service/runtime_policy_test.go
+++ b/backend/internal/service/runtime_policy_test.go
@@ -25,7 +25,7 @@ func TestVideoTaskTimeoutHasFiveMinuteSafetyFloor(t *testing.T) {
 	}
 }
 
-func TestOnlyResumableNewAPIChannel2VideoDeadlinesStayRunning(t *testing.T) {
+func TestOnlyResumableVideoDeadlinesStayRunning(t *testing.T) {
 	svc := &Service{}
 	input, err := json.Marshal(canvasGenerationInput{Mode: "video", Config: providerConfig{BaseURL: "https://example.com", InterfaceType: string(model.ChannelInterfaceNewAPIChannel2)}})
 	if err != nil {
@@ -40,6 +40,13 @@ func TestOnlyResumableNewAPIChannel2VideoDeadlinesStayRunning(t *testing.T) {
 	}
 	if svc.shouldDeferVideoProviderTask(base, string(input), context.Canceled) {
 		t.Fatal("explicit cancellation must not be deferred")
+	}
+	miniMax, err := json.Marshal(canvasGenerationInput{Mode: "video", Config: providerConfig{BaseURL: "https://example.com", InterfaceType: string(model.ChannelInterfaceMiniMaxVideo)}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !svc.shouldDeferVideoProviderTask(base, string(miniMax), context.DeadlineExceeded) {
+		t.Fatal("resumable MiniMax video deadline should remain running")
 	}
 	other, err := json.Marshal(canvasGenerationInput{Mode: "video", Config: providerConfig{BaseURL: "https://example.com", InterfaceType: string(model.ChannelInterfaceNewAPIVideo)}})
 	if err != nil {

--- a/backend/internal/service/task_worker.go
+++ b/backend/internal/service/task_worker.go
@@ -216,7 +216,15 @@ func (s *Service) shouldDeferVideoProviderTask(task model.Task, decryptedInput s
 		return false
 	}
 	resolved, resolveErr := s.resolveProviderConfig(input.Config)
-	return resolveErr == nil && resolved.InterfaceType == string(model.ChannelInterfaceNewAPIChannel2)
+	if resolveErr != nil {
+		return false
+	}
+	switch model.ChannelInterfaceType(resolved.InterfaceType) {
+	case model.ChannelInterfaceNewAPIChannel2, model.ChannelInterfaceMiniMaxVideo:
+		return true
+	default:
+		return false
+	}
 }
 
 func taskTimeoutMessage(taskType string) string {


### PR DESCRIPTION
## 说明

- MiniMax 视频超时后保留原任务 ID 并继续回查
- 支持在任务中心手动恢复失败任务
- 恢复时不重复提交任务或重新校验参考素材

## 测试

- `cd backend && go test ./...`