### PR TITLE
fix(home): 对齐首页两种开始方式的操作入口

### DIFF
--- a/web/src/pages/home/index.tsx
+++ b/web/src/pages/home/index.tsx
@@ -259,7 +259,7 @@ function RecentProjectRow({ summary, divided }: { summary: ProjectSummary; divid
 
 function StartMode({ icon, title, description, action, href, onClick }: { icon: ReactNode; title: string; description: string; action: string; href?: string; onClick?: () => void }) {
     const content = <><span className="mt-0.5 text-foreground/45">{icon}</span><span className="min-w-0"><span className="block text-sm font-semibold">{title}</span><span className="mt-1 block text-xs leading-5 text-foreground/48">{description}</span></span><span className="self-center text-xs font-medium text-foreground/50">{action} →</span></>;
-    const className = "grid grid-cols-[20px_minmax(0,1fr)_auto] gap-3 py-4 text-left hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20";
+    const className = "grid w-full grid-cols-[20px_minmax(0,1fr)_auto] gap-3 py-4 text-left hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground/20";
     return href ? <Link to={href} className={className}>{content}</Link> : <button type="button" className={className} onClick={onClick}>{content}</button>;
 }
 


### PR DESCRIPTION
## 变更说明

- 修复 `/home` 页面“两种开始方式”区域中，“打开画布”与“创建项目”操作入口未对齐的问题。
- 为 `StartMode` 的行级网格容器补充 `w-full`，统一 `Link` 与原生 `button` 的占用宽度，使右侧操作文字保持对齐。

## 问题原因

“创建项目”使用 `Link`，而“打开画布”使用原生 `button`。两者在自动宽度下的布局行为不同，导致按钮按内容宽度收缩，右侧操作文字随描述长度向左偏移。

## 验证

- `git diff --check` 通过。
- 已核对相对上游 `main` 的变更，仅包含上述首页布局修复。
- 当前环境未安装 Bun，因此未运行完整前端类型检查或构建。