### PR TITLE
fix(create): 统一创作页侧边栏配色

### DIFF
--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -10012,13 +10012,11 @@ html:not(.dark) .creation-model-picker-menu .canvas-model-picker-option > span:f
     color: #ffffff;
 }
 .app-workspace-shell.is-creation-workspace,
-.app-workspace-shell.is-creation-workspace .app-workspace-sidebar,
 .app-workspace-shell.is-creation-workspace .app-workspace-stage {
     background: var(--workspace-page) !important;
 }
 
 html:not(.dark) .app-workspace-shell.is-creation-workspace,
-html:not(.dark) .app-workspace-shell.is-creation-workspace .app-workspace-sidebar,
 html:not(.dark) .app-workspace-shell.is-creation-workspace .app-workspace-stage {
     background: var(--workspace-page) !important;
 }

--- a/web/test/create-sidebar-theme.test.ts
+++ b/web/test/create-sidebar-theme.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("create page sidebar theme", () => {
+    test("keeps the shared workspace sidebar surface", () => {
+        const styles = readFileSync(resolve(import.meta.dir, "../src/styles/globals.css"), "utf8");
+
+        expect(styles).not.toContain(".app-workspace-shell.is-creation-workspace .app-workspace-sidebar");
+        expect(styles).toContain(".app-workspace-shell.is-creation-workspace .app-workspace-stage");
+        expect(styles).toContain("background: color-mix(in srgb, var(--workspace-sidebar) 96%, var(--foreground) 4%);");
+    });
+});


### PR DESCRIPTION
## 问题

`/create` 的创作工作区样式把侧边栏背景强制覆盖为 `--workspace-page`。深色主题下该值接近纯黑，导致创作页侧边栏与首页、短剧、画布、任务、素材、技能库、插件中心和积分中心的统一侧边栏表面色不一致。

## 修复

- 移除创作工作区对 `.app-workspace-sidebar` 的专用背景覆盖
- 保留创作页外壳与内容舞台使用 `--workspace-page` 的现有设计
- 让侧边栏重新继承全站通用的 `--workspace-sidebar` 表面规则
- 新增静态回归测试，防止创作页再次覆盖侧边栏主题

## 验证

- 创作页侧边栏主题静态检查通过
- 新增测试文件通过 Prettier 格式检查
- `git diff --check` 通过
- 完整前端构建未重复执行；当前仓库的 `package.json` 与 `pnpm-lock.yaml` 存在既有 TipTap 3.28/3.30 版本不一致问题