### PR TITLE
feat(admin): 管理后台 - 新增系统信息、存储管理与公告增强

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -85,6 +85,8 @@ func main() {
 	handler.RegisterAdminRoutes(api, svc)
 	handler.RegisterAdminAnalyticsRoutes(api, svc)
 	handler.RegisterAnnouncementRoutes(api, svc)
+	handler.RegisterSystemInfoRoutes(api, svc, env("CANVAS_GIT_COMMIT", "local"), env("CANVAS_BUILD_TIME", "dev"))
+	handler.RegisterStorageAdminRoutes(api, svc)
 	handler.RegisterFinanceRoutes(api, svc)
 	handler.RegisterLibTVRoutes(api, svc)
 	handler.RegisterTapNowRoutes(api, svc)

--- a/backend/internal/handler/admin_system.go
+++ b/backend/internal/handler/admin_system.go
@@ -1,0 +1,22 @@
+package handler
+
+import (
+	"infinite-canvas/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterSystemInfoRoutes(r *gin.RouterGroup, svc *service.Service, commit string, buildTime string) {
+	r.GET("/admin/system/instances", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		if err := svc.RequireAdmin(user); err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"instances": service.CollectSystemInstances(commit, buildTime), "intervalSeconds": 30})
+	})
+}

--- a/backend/internal/handler/announcement.go
+++ b/backend/internal/handler/announcement.go
@@ -23,6 +23,31 @@ func RegisterAnnouncementRoutes(r *gin.RouterGroup, svc *service.Service) {
 		}
 		ok(c, feed)
 	})
+	r.GET("/announcements/:id/image", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		stream, err := svc.OpenAnnouncementImage(user, c.Param("id"), c.GetHeader("Range"))
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		defer stream.Body.Close()
+		mimeType := stream.Resource.MimeType
+		if mimeType == "" {
+			mimeType = "image/jpeg"
+		}
+		c.Header("Cache-Control", "private, max-age=3600")
+		c.Header("Referrer-Policy", "no-referrer")
+		c.Header("Accept-Ranges", stream.AcceptRanges)
+		c.Header("X-Content-Type-Options", "nosniff")
+		if stream.ContentRange != "" {
+			c.Header("Content-Range", stream.ContentRange)
+		}
+		c.DataFromReader(stream.StatusCode, stream.ContentLength, mimeType, stream.Body, nil)
+	})
 
 	r.POST("/announcements/read", func(c *gin.Context) {
 		user, err := currentUser(c, svc)

--- a/backend/internal/handler/storage_admin.go
+++ b/backend/internal/handler/storage_admin.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"infinite-canvas/backend/internal/service"
+
+	"github.com/gin-gonic/gin"
+)
+
+func RegisterStorageAdminRoutes(r *gin.RouterGroup, svc *service.Service) {
+	r.GET("/admin/storage/stats", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		stats, err := svc.AdminStorageStats(user)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"stats": stats})
+	})
+
+	r.GET("/admin/resources", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+		limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+		result, err := svc.AdminResourcePage(user, service.AdminResourceQuery{
+			Keyword: c.Query("keyword"), Kind: c.Query("kind"), Status: c.Query("status"), Provider: c.Query("provider"),
+			UserID: c.Query("userId"), From: c.Query("from"), To: c.Query("to"), Page: page, Limit: limit,
+		})
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, result)
+	})
+
+	r.GET("/admin/resources/:id/file", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		stream, err := svc.OpenResourceRangeAsAdmin(user, c.Param("id"), c.GetHeader("Range"))
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		defer stream.Body.Close()
+		mimeType := stream.Resource.MimeType
+		if mimeType == "" {
+			mimeType = "application/octet-stream"
+		}
+		c.Header("Cache-Control", "private, no-cache")
+		c.Header("Accept-Ranges", stream.AcceptRanges)
+		c.Header("X-Content-Type-Options", "nosniff")
+		if stream.ContentRange != "" {
+			c.Header("Content-Range", stream.ContentRange)
+		}
+		if c.Query("download") == "1" {
+			c.Header("Content-Disposition", "attachment")
+		}
+		c.DataFromReader(stream.StatusCode, stream.ContentLength, mimeType, stream.Body, nil)
+	})
+
+	r.DELETE("/admin/resources/:id", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		if err := svc.AdminDeleteResource(user, c.Param("id")); err != nil {
+			failService(c, err)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"code": 0, "data": gin.H{"ok": true}, "msg": "ok"})
+	})
+}

--- a/backend/internal/model/models_project.go
+++ b/backend/internal/model/models_project.go
@@ -316,16 +316,19 @@ type UserPromptCustomization struct {
 }
 
 type Announcement struct {
-	ID          string             `json:"id" gorm:"primaryKey;size:36"`
-	Title       string             `json:"title" gorm:"size:120"`
-	Content     string             `json:"content" gorm:"type:text"`
-	Level       AnnouncementLevel  `json:"level" gorm:"index;size:24"`
-	Status      AnnouncementStatus `json:"status" gorm:"index;size:24;index:idx_announcements_status_published,priority:1"`
-	CreatedBy   string             `json:"createdBy" gorm:"index;size:36"`
-	PublishedAt time.Time          `json:"publishedAt" gorm:"index:idx_announcements_status_published,priority:2"`
-	ClosedAt    *time.Time         `json:"closedAt"`
-	CreatedAt   time.Time          `json:"createdAt"`
-	UpdatedAt   time.Time          `json:"updatedAt"`
+	ID              string             `json:"id" gorm:"primaryKey;size:36"`
+	Title           string             `json:"title" gorm:"size:120"`
+	Content         string             `json:"content" gorm:"type:text"`
+	ImageResourceID string             `json:"imageResourceId,omitempty" gorm:"index;size:36"`
+	ImageURL        string             `json:"imageUrl,omitempty" gorm:"-"`
+	Level           AnnouncementLevel  `json:"level" gorm:"index;size:24"`
+	Pinned          bool               `json:"pinned" gorm:"index"`
+	Status          AnnouncementStatus `json:"status" gorm:"index;size:24;index:idx_announcements_status_published,priority:1"`
+	CreatedBy       string             `json:"createdBy" gorm:"index;size:36"`
+	PublishedAt     time.Time          `json:"publishedAt" gorm:"index:idx_announcements_status_published,priority:2"`
+	ClosedAt        *time.Time         `json:"closedAt"`
+	CreatedAt       time.Time          `json:"createdAt"`
+	UpdatedAt       time.Time          `json:"updatedAt"`
 }
 
 type UserAnnouncementRead struct {

--- a/backend/internal/repository/announcement.go
+++ b/backend/internal/repository/announcement.go
@@ -24,7 +24,7 @@ func (r *Repository) AdminAnnouncements(keyword string, status model.Announcemen
 	if err := query.Count(&total).Error; err != nil {
 		return nil, 0, err
 	}
-	if err := query.Order("published_at desc").Limit(limit).Offset(offset).Find(&announcements).Error; err != nil {
+	if err := query.Order("pinned desc, published_at desc").Limit(limit).Offset(offset).Find(&announcements).Error; err != nil {
 		return nil, 0, err
 	}
 	return announcements, total, nil
@@ -34,7 +34,7 @@ func (r *Repository) AnnouncementFeed(userID string) ([]model.Announcement, int6
 	var announcements []model.Announcement
 	var unreadCount int64
 	err := r.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Where("status = ?", model.AnnouncementStatusActive).Order("published_at desc").Find(&announcements).Error; err != nil {
+		if err := tx.Where("status = ?", model.AnnouncementStatusActive).Order("pinned desc, published_at desc").Find(&announcements).Error; err != nil {
 			return err
 		}
 		return tx.Model(&model.Announcement{}).
@@ -65,7 +65,9 @@ func (r *Repository) UpdateAnnouncement(announcement *model.Announcement) error 
 		result := tx.Model(&model.Announcement{}).Where("id = ?", announcement.ID).Updates(map[string]any{
 			"title":        announcement.Title,
 			"content":      announcement.Content,
+			"image_resource_id": announcement.ImageResourceID,
 			"level":        announcement.Level,
+			"pinned":      announcement.Pinned,
 			"status":       announcement.Status,
 			"published_at": announcement.PublishedAt,
 			"closed_at":    announcement.ClosedAt,

--- a/backend/internal/repository/repository.go
+++ b/backend/internal/repository/repository.go
@@ -180,6 +180,22 @@ func (r *Repository) User(id string) (*model.User, error) {
 	return &user, nil
 }
 
+// UsersByIDs 批量读取后台资源列表需要展示的用户信息，避免逐条查询造成 N+1。
+func (r *Repository) UsersByIDs(ids []string) (map[string]model.User, error) {
+	if len(ids) == 0 {
+		return map[string]model.User{}, nil
+	}
+	var users []model.User
+	if err := r.db.Where("id IN ?", ids).Find(&users).Error; err != nil {
+		return nil, err
+	}
+	result := make(map[string]model.User, len(users))
+	for _, user := range users {
+		result[user.ID] = user
+	}
+	return result, nil
+}
+
 func (r *Repository) UserByAccount(account string) (*model.User, error) {
 	var user model.User
 	if err := r.db.Where("lower(username) = lower(?) OR lower(email) = lower(?)", account, account).First(&user).Error; err != nil {
@@ -975,6 +991,109 @@ func (r *Repository) Resources(userID string, limit int) ([]model.Resource, erro
 	}
 	err := r.db.Order("created_at desc").Limit(limit).Find(&resources, "user_id = ?", userID).Error
 	return resources, err
+}
+
+type AdminResourceFilter struct {
+	Kind     string
+	Status   string
+	Provider string
+	UserID   string
+	Keyword  string
+	From     *time.Time
+	To       *time.Time
+	Limit    int
+	Offset   int
+}
+
+func resourceProviderExpression() string {
+	return "COALESCE(NULLIF(provider, ''), 'local')"
+}
+
+func (r *Repository) AdminResources(filter AdminResourceFilter) ([]model.Resource, int64, error) {
+	var resources []model.Resource
+	var total int64
+	query := r.db.Model(&model.Resource{})
+	if value := strings.TrimSpace(filter.Kind); value != "" {
+		query = query.Where("kind = ?", value)
+	}
+	if value := strings.TrimSpace(filter.Status); value != "" {
+		query = query.Where("status = ?", value)
+	}
+	if value := strings.TrimSpace(filter.Provider); value != "" {
+		query = query.Where(resourceProviderExpression()+" = ?", value)
+	}
+	if value := strings.TrimSpace(filter.UserID); value != "" {
+		query = query.Where("user_id = ?", value)
+	}
+	if value := strings.TrimSpace(filter.Keyword); value != "" {
+		pattern := "%" + strings.ToLower(value) + "%"
+		query = query.Where("lower(id) LIKE ? OR lower(object_key) LIKE ?", pattern, pattern)
+	}
+	if filter.From != nil {
+		query = query.Where("created_at >= ?", *filter.From)
+	}
+	if filter.To != nil {
+		query = query.Where("created_at <= ?", *filter.To)
+	}
+	if err := query.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if filter.Limit <= 0 || filter.Limit > 200 {
+		filter.Limit = 20
+	}
+	if filter.Offset < 0 {
+		filter.Offset = 0
+	}
+	if err := query.Order("created_at desc").Limit(filter.Limit).Offset(filter.Offset).Find(&resources).Error; err != nil {
+		return nil, 0, err
+	}
+	return resources, total, nil
+}
+
+type ResourceKindStat struct {
+	Kind  string `json:"kind" gorm:"column:kind"`
+	Count int64  `json:"count" gorm:"column:count"`
+	Bytes int64  `json:"bytes" gorm:"column:bytes"`
+}
+
+type ResourceProviderStat struct {
+	Provider      string `json:"provider" gorm:"column:provider"`
+	Count         int64  `json:"count" gorm:"column:count"`
+	LogicalBytes  int64  `json:"logicalBytes" gorm:"column:logical_bytes"`
+	PhysicalBytes int64  `json:"physicalBytes" gorm:"column:physical_bytes"`
+}
+
+func (r *Repository) ResourceKindStats() ([]ResourceKindStat, error) {
+	var stats []ResourceKindStat
+	err := r.db.Model(&model.Resource{}).
+		Select("kind, COUNT(*) AS count, COALESCE(SUM(size), 0) AS bytes").
+		Group("kind").
+		Order("bytes desc").
+		Scan(&stats).Error
+	return stats, err
+}
+
+func (r *Repository) ResourceProviderStats() ([]ResourceProviderStat, error) {
+	var stats []ResourceProviderStat
+	provider := resourceProviderExpression()
+	err := r.db.Model(&model.Resource{}).
+		Select(provider+" AS provider, COUNT(*) AS count, COALESCE(SUM(size), 0) AS logical_bytes, COALESCE(SUM(CASE WHEN status = 'ready' THEN size ELSE 0 END), 0) AS physical_bytes").
+		Group(provider).
+		Order("logical_bytes desc").
+		Scan(&stats).Error
+	return stats, err
+}
+
+func (r *Repository) ResourceCount() (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Resource{}).Count(&count).Error
+	return count, err
+}
+
+func (r *Repository) ResourceAnnouncementCount(resourceID string) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Announcement{}).Where("image_resource_id = ?", resourceID).Count(&count).Error
+	return count, err
 }
 
 func (r *Repository) Assets(userID string) ([]model.Asset, error) {

--- a/backend/internal/repository/resource_reference.go
+++ b/backend/internal/repository/resource_reference.go
@@ -265,3 +265,23 @@ func (r *Repository) DeleteAssetAndResources(userID string, assetID string, reso
 		return tx.Where("user_id = ? AND id IN ?", userID, resourceIDs).Delete(&model.Resource{}).Error
 	})
 }
+
+func (r *Repository) DeleteResourceAndEnqueueDeletion(resource *model.Resource, job model.ResourceDeletionJob) error {
+	if resource == nil {
+		return gorm.ErrRecordNotFound
+	}
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		result := tx.Where("resource_id = ?", resource.ID).Delete(&model.ArkPrivateAssetBinding{})
+		if result.Error != nil {
+			return result.Error
+		}
+		result = tx.Where("id = ? AND user_id = ?", resource.ID, resource.UserID).Delete(&model.Resource{})
+		if result.Error != nil {
+			return result.Error
+		}
+		if result.RowsAffected != 1 {
+			return gorm.ErrRecordNotFound
+		}
+		return tx.Create(&job).Error
+	})
+}

--- a/backend/internal/service/announcement.go
+++ b/backend/internal/service/announcement.go
@@ -12,9 +12,11 @@ import (
 )
 
 type CreateAnnouncementRequest struct {
-	Title   string                  `json:"title"`
-	Content string                  `json:"content"`
-	Level   model.AnnouncementLevel `json:"level"`
+	Title           string                  `json:"title"`
+	Content         string                  `json:"content"`
+	ImageResourceID string                  `json:"imageResourceId"`
+	Level           model.AnnouncementLevel `json:"level"`
+	Pinned          bool                    `json:"pinned"`
 }
 
 type UpdateAnnouncementRequest = CreateAnnouncementRequest
@@ -40,6 +42,9 @@ func (s *Service) AdminAnnouncementPage(actor *model.User, query AdminListQuery)
 	if err != nil {
 		return nil, err
 	}
+	for index := range announcements {
+		decorateAnnouncement(&announcements[index])
+	}
 	return &AnnouncementPage{Announcements: announcements, Total: total, Page: page, Limit: limit}, nil
 }
 
@@ -51,21 +56,19 @@ func (s *Service) CreateAnnouncement(actor *model.User, req CreateAnnouncementRe
 	if err != nil {
 		return nil, err
 	}
+	imageResourceID, err := s.validateAnnouncementImage(actor, req.ImageResourceID)
+	if err != nil {
+		return nil, err
+	}
 	now := time.Now()
 	announcement := &model.Announcement{
-		ID:          newID(),
-		Title:       title,
-		Content:     content,
-		Level:       level,
-		Status:      model.AnnouncementStatusActive,
-		CreatedBy:   actor.ID,
-		PublishedAt: now,
-		CreatedAt:   now,
-		UpdatedAt:   now,
+		ID: newID(), Title: title, Content: content, ImageResourceID: imageResourceID, Level: level, Pinned: req.Pinned,
+		Status: model.AnnouncementStatusActive, CreatedBy: actor.ID, PublishedAt: now, CreatedAt: now, UpdatedAt: now,
 	}
 	if err := s.repo.Create(announcement); err != nil {
 		return nil, err
 	}
+	decorateAnnouncement(announcement)
 	return announcement, nil
 }
 
@@ -84,10 +87,16 @@ func (s *Service) UpdateAnnouncement(actor *model.User, id string, req UpdateAnn
 	if err != nil {
 		return nil, err
 	}
+	imageResourceID, err := s.validateAnnouncementImage(actor, req.ImageResourceID)
+	if err != nil {
+		return nil, err
+	}
 	now := time.Now()
 	announcement.Title = title
 	announcement.Content = content
+	announcement.ImageResourceID = imageResourceID
 	announcement.Level = level
+	announcement.Pinned = req.Pinned
 	announcement.Status = model.AnnouncementStatusActive
 	announcement.ClosedAt = nil
 	announcement.PublishedAt = now
@@ -98,7 +107,12 @@ func (s *Service) UpdateAnnouncement(actor *model.User, id string, req UpdateAnn
 		}
 		return nil, err
 	}
-	return s.repo.Announcement(announcement.ID)
+	updated, err := s.repo.Announcement(announcement.ID)
+	if err != nil {
+		return nil, err
+	}
+	decorateAnnouncement(updated)
+	return updated, nil
 }
 
 func (s *Service) CloseAnnouncement(actor *model.User, id string) (*model.Announcement, error) {
@@ -122,7 +136,12 @@ func (s *Service) CloseAnnouncement(actor *model.User, id string) (*model.Announ
 	if !updated {
 		return nil, BadAuthRequest("公告状态已变化，请刷新后重试")
 	}
-	return s.repo.Announcement(announcement.ID)
+	updated, err := s.repo.Announcement(announcement.ID)
+	if err != nil {
+		return nil, err
+	}
+	decorateAnnouncement(updated)
+	return updated, nil
 }
 
 func (s *Service) UserAnnouncements(user *model.User) (*UserAnnouncementFeed, error) {
@@ -133,7 +152,48 @@ func (s *Service) UserAnnouncements(user *model.User) (*UserAnnouncementFeed, er
 	if err != nil {
 		return nil, err
 	}
+	for index := range announcements {
+		decorateAnnouncement(&announcements[index])
+	}
 	return &UserAnnouncementFeed{Announcements: announcements, UnreadCount: unreadCount}, nil
+}
+
+func (s *Service) OpenAnnouncementImage(actor *model.User, announcementID string, rangeHeader string) (*ResourceStream, error) {
+	resource, err := s.announcementImageResource(actor, announcementID)
+	if err != nil {
+		return nil, err
+	}
+	return s.openResourceRange(resource.UserID, resource, rangeHeader)
+}
+
+func (s *Service) announcementImageResource(actor *model.User, announcementID string) (*model.Resource, error) {
+	if actor == nil {
+		return nil, Unauthorized("请先登录")
+	}
+	announcement, err := s.repo.Announcement(strings.TrimSpace(announcementID))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, NotFound("公告不存在")
+		}
+		return nil, err
+	}
+	if actor.Role != model.UserRoleAdmin && announcement.Status != model.AnnouncementStatusActive {
+		return nil, Forbidden("公告不可访问")
+	}
+	if strings.TrimSpace(announcement.ImageResourceID) == "" {
+		return nil, BadAuthRequest("该公告没有配图")
+	}
+	resource, err := s.repo.Resource(announcement.ImageResourceID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, NotFound("公告配图不存在")
+		}
+		return nil, err
+	}
+	if resource.Kind != "image" || resource.Status != model.ResourceStatusReady {
+		return nil, BadAuthRequest("公告配图资源不可用")
+	}
+	return resource, nil
 }
 
 func (s *Service) MarkAnnouncementsRead(user *model.User, announcementIDs []string) (int64, error) {
@@ -175,5 +235,33 @@ func normalizeAnnouncementInput(req CreateAnnouncementRequest) (string, string, 
 	if !validAnnouncementLevel(req.Level) {
 		return "", "", "", BadAuthRequest("公告级别无效")
 	}
+	if strings.TrimSpace(req.ImageResourceID) != "" && len(strings.TrimSpace(req.ImageResourceID)) > 64 {
+		return "", "", "", BadAuthRequest("公告配图资源 ID 无效")
+	}
 	return title, content, req.Level, nil
+}
+
+func (s *Service) validateAnnouncementImage(actor *model.User, id string) (string, error) {
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return "", nil
+	}
+	if actor == nil {
+		return "", Unauthorized("请先登录")
+	}
+	resource, err := s.repo.ResourceForUser(actor.ID, id)
+	if err != nil {
+		return "", BadAuthRequest("公告配图不存在或不属于当前管理员")
+	}
+	if resource.Kind != "image" || resource.Status != model.ResourceStatusReady {
+		return "", BadAuthRequest("公告配图必须是已上传完成的图片")
+	}
+	return id, nil
+}
+
+func decorateAnnouncement(announcement *model.Announcement) {
+	if announcement == nil || strings.TrimSpace(announcement.ImageResourceID) == "" {
+		return
+	}
+	announcement.ImageURL = "/api/announcements/" + announcement.ID + "/image"
 }

--- a/backend/internal/service/announcement_test.go
+++ b/backend/internal/service/announcement_test.go
@@ -113,6 +113,39 @@ func TestAnnouncementUpdateRepublishesAndResetsReads(t *testing.T) {
 	}
 }
 
+func TestPinnedAnnouncementsAreReturnedFirst(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sqlDB.SetMaxOpenConns(1)
+	if err := db.AutoMigrate(&model.User{}, &model.Announcement{}, &model.UserAnnouncementRead{}); err != nil {
+		t.Fatal(err)
+	}
+	svc := New(repository.New(db), t.TempDir())
+	admin := &model.User{ID: "admin", Role: model.UserRoleAdmin, Status: model.UserStatusActive}
+	user := &model.User{ID: "user", Role: model.UserRoleUser, Status: model.UserStatusActive}
+
+	if _, err := svc.CreateAnnouncement(admin, CreateAnnouncementRequest{Title: "普通", Content: "普通公告", Level: model.AnnouncementLevelInfo}); err != nil {
+		t.Fatal(err)
+	}
+	pinned, err := svc.CreateAnnouncement(admin, CreateAnnouncementRequest{Title: "置顶", Content: "置顶公告", Level: model.AnnouncementLevelWarning, Pinned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed, err := svc.UserAnnouncements(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(feed.Announcements) != 2 || feed.Announcements[0].ID != pinned.ID || !feed.Announcements[0].Pinned {
+		t.Fatalf("feed = %+v, want pinned announcement first", feed)
+	}
+}
+
 func TestAnnouncementPublishRejectsInvalidInput(t *testing.T) {
 	svc := &Service{}
 	admin := &model.User{ID: "admin", Role: model.UserRoleAdmin, Status: model.UserStatusActive}

--- a/backend/internal/service/storage_admin.go
+++ b/backend/internal/service/storage_admin.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"infinite-canvas/backend/internal/model"
+	"infinite-canvas/backend/internal/repository"
+
+	"gorm.io/gorm"
+)
+
+type AdminResourceQuery struct {
+	Keyword  string
+	Kind     string
+	Status   string
+	Provider string
+	UserID   string
+	From     string
+	To       string
+	Page     int
+	Limit    int
+}
+
+type AdminStorageResourceView struct {
+	ID              string             `json:"id"`
+	UserID          string             `json:"userId"`
+	UserName        string             `json:"userName"`
+	Kind            string             `json:"kind"`
+	Status          model.ResourceStatus `json:"status"`
+	Provider        string             `json:"provider"`
+	Endpoint        string             `json:"endpoint,omitempty"`
+	Bucket          string             `json:"bucket,omitempty"`
+	ObjectKey       string             `json:"objectKey"`
+	MimeType        string             `json:"mimeType"`
+	Size            int64              `json:"size"`
+	Width           int                `json:"width"`
+	Height          int                `json:"height"`
+	DurationMs      int64              `json:"durationMs"`
+	Error           string             `json:"error,omitempty"`
+	StorageLocation string             `json:"storageLocation"`
+	StorageBytes    int64              `json:"storageBytes"`
+	FileURL         string             `json:"fileUrl"`
+	CreatedAt       time.Time          `json:"createdAt"`
+	UpdatedAt       time.Time          `json:"updatedAt"`
+}
+
+type AdminResourcePage struct {
+	Items []AdminStorageResourceView `json:"items"`
+	Total int64                      `json:"total"`
+	Page  int                        `json:"page"`
+	Limit int                        `json:"limit"`
+}
+
+type AdminStorageStats struct {
+	ResourceCount int64                             `json:"resourceCount"`
+	ByKind        []repository.ResourceKindStat     `json:"byKind"`
+	ByProvider    []repository.ResourceProviderStat `json:"byProvider"`
+	TotalBytes    int64                             `json:"totalBytes"`
+	LocalBytes    int64                             `json:"localBytes"`
+	RemoteBytes   int64                             `json:"remoteBytes"`
+}
+
+func (s *Service) AdminResourcePage(actor *model.User, query AdminResourceQuery) (*AdminResourcePage, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	page, limit := normalizeAdminPage(query.Page, query.Limit)
+	filter := repository.AdminResourceFilter{Keyword: query.Keyword, Kind: query.Kind, Status: query.Status, Provider: query.Provider, UserID: query.UserID, Limit: limit, Offset: (page - 1) * limit}
+	filter.From = parseAdminResourceTime(query.From)
+	filter.To = parseAdminResourceTime(query.To)
+	resources, total, err := s.repo.AdminResources(filter)
+	if err != nil {
+		return nil, err
+	}
+	userIDs := make([]string, 0, len(resources))
+	seen := map[string]struct{}{}
+	for _, resource := range resources {
+		if _, exists := seen[resource.UserID]; !exists {
+			seen[resource.UserID] = struct{}{}
+			userIDs = append(userIDs, resource.UserID)
+		}
+	}
+	users, err := s.repo.UsersByIDs(userIDs)
+	if err != nil {
+		return nil, err
+	}
+	items := make([]AdminStorageResourceView, 0, len(resources))
+	for _, resource := range resources {
+		provider := normalizedResourceProvider(resource.Provider)
+		user := users[resource.UserID]
+		items = append(items, AdminStorageResourceView{
+			ID: resource.ID, UserID: resource.UserID, UserName: pickAdminUserName(user), Kind: resource.Kind, Status: resource.Status,
+			Provider: provider, Endpoint: resource.Endpoint, Bucket: resource.Bucket, ObjectKey: resource.ObjectKey, MimeType: resource.MimeType,
+			Size: resource.Size, Width: resource.Width, Height: resource.Height, DurationMs: resource.DurationMs, Error: resource.Error,
+			StorageLocation: provider, StorageBytes: resourcePhysicalBytesForAdmin(resource), FileURL: "/api/admin/resources/" + resource.ID + "/file",
+			CreatedAt: resource.CreatedAt, UpdatedAt: resource.UpdatedAt,
+		})
+	}
+	return &AdminResourcePage{Items: items, Total: total, Page: page, Limit: limit}, nil
+}
+
+func (s *Service) AdminStorageStats(actor *model.User) (*AdminStorageStats, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	count, err := s.repo.ResourceCount()
+	if err != nil {
+		return nil, err
+	}
+	byKind, err := s.repo.ResourceKindStats()
+	if err != nil {
+		return nil, err
+	}
+	byProvider, err := s.repo.ResourceProviderStats()
+	if err != nil {
+		return nil, err
+	}
+	var total, local, remote int64
+	for _, stat := range byKind {
+		total += stat.Bytes
+	}
+	for _, stat := range byProvider {
+		if stat.Provider == "local" {
+			local += stat.PhysicalBytes
+		} else {
+			remote += stat.PhysicalBytes
+		}
+	}
+	return &AdminStorageStats{ResourceCount: count, ByKind: byKind, ByProvider: byProvider, TotalBytes: total, LocalBytes: local, RemoteBytes: remote}, nil
+}
+
+func (s *Service) ResourceAsAdmin(actor *model.User, id string) (*model.Resource, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	resource, err := s.repo.Resource(strings.TrimSpace(id))
+	if resource != nil {
+		resource.PublicURL = ""
+	}
+	return resource, err
+}
+
+func (s *Service) OpenResourceRangeAsAdmin(actor *model.User, id string, rangeHeader string) (*ResourceStream, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	resource, err := s.repo.Resource(strings.TrimSpace(id))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, NotFound("资源不存在")
+		}
+		return nil, err
+	}
+	return s.openResourceRange(resource.UserID, resource, rangeHeader)
+}
+
+func (s *Service) AdminDeleteResource(actor *model.User, id string) error {
+	if err := s.RequireAdmin(actor); err != nil {
+		return err
+	}
+	s.storageMu.Lock()
+	defer s.storageMu.Unlock()
+	resource, err := s.repo.Resource(strings.TrimSpace(id))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return NotFound("资源不存在")
+		}
+		return err
+	}
+	if err := s.ensureAdminResourceIsUnreferenced(resource); err != nil {
+		return err
+	}
+	jobs := resourceDeletionJobs(resource.UserID, map[string]*model.Resource{resourceStorageIdentity(resource): resource})
+	if len(jobs) != 1 {
+		return errors.New("无法创建资源删除任务")
+	}
+	if err := s.repo.DeleteResourceAndEnqueueDeletion(resource, jobs[0]); err != nil {
+		return err
+	}
+	if err := s.appendAdminAudit(actor, "resource.delete", "resource", resource.ID, "管理员删除资源", map[string]any{"userId": resource.UserID, "kind": resource.Kind, "provider": normalizedResourceProvider(resource.Provider), "size": resource.Size}); err != nil {
+		return err
+	}
+	go s.drainResourceDeletionJobs(1)
+	return nil
+}
+
+func (s *Service) ensureAdminResourceIsUnreferenced(resource *model.Resource) error {
+	if resource == nil {
+		return NotFound("资源不存在")
+	}
+	if count, err := s.repo.ResourceAnnouncementCount(resource.ID); err != nil {
+		return err
+	} else if count > 0 {
+		return BadAuthRequest("资源仍被系统公告使用，请先移除公告配图")
+	}
+	snapshot, err := s.repo.ResourceReferenceSnapshot(resource.UserID, "", []string{resource.ID})
+	if err != nil {
+		return err
+	}
+	ids := map[string]struct{}{resource.ID: {}}
+	for _, document := range snapshot.Documents {
+		if documentReferencesResources(document.PrimaryJSON, ids) || documentReferencesResources(document.SecondaryJSON, ids) {
+			return BadAuthRequest("资源仍被业务数据引用，请先解除引用")
+		}
+	}
+	if len(snapshot.Direct) > 0 {
+		return BadAuthRequest("资源仍被业务数据引用，请先解除引用")
+	}
+	if count, err := s.repo.ResourceStorageReferenceCount(resource, []string{resource.ID}); err != nil {
+		return err
+	} else if count > 0 {
+		return BadAuthRequest("资源仍与其他记录共享存储对象，暂不能删除")
+	}
+	return nil
+}
+
+func normalizedResourceProvider(provider string) string {
+	provider = strings.ToLower(strings.TrimSpace(provider))
+	if provider == "" {
+		return "local"
+	}
+	return provider
+}
+
+func resourcePhysicalBytesForAdmin(resource model.Resource) int64 {
+	if resource.Status != model.ResourceStatusReady {
+		return 0
+	}
+	return resource.Size
+}
+
+func pickAdminUserName(user model.User) string {
+	if strings.TrimSpace(user.DisplayName) != "" {
+		return user.DisplayName
+	}
+	if strings.TrimSpace(user.Username) != "" {
+		return user.Username
+	}
+	return user.ID
+}
+
+func parseAdminResourceTime(raw string) *time.Time {
+	for _, layout := range []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"} {
+		if parsed, err := time.Parse(layout, strings.TrimSpace(raw)); err == nil {
+			return &parsed
+		}
+	}
+	return nil
+}

--- a/backend/internal/service/storage_admin_test.go
+++ b/backend/internal/service/storage_admin_test.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"testing"
+
+	"infinite-canvas/backend/internal/model"
+)
+
+func TestNormalizedResourceProvider(t *testing.T) {
+	for input, want := range map[string]string{"": "local", " LOCAL ": "local", "aliyun": "aliyun", "S3": "s3"} {
+		if got := normalizedResourceProvider(input); got != want {
+			t.Fatalf("normalizedResourceProvider(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestResourcePhysicalBytesForAdmin(t *testing.T) {
+	if got := resourcePhysicalBytesForAdmin(model.Resource{Status: model.ResourceStatusPending, Size: 100}); got != 0 {
+		t.Fatalf("pending resource bytes = %d, want 0", got)
+	}
+	if got := resourcePhysicalBytesForAdmin(model.Resource{Status: model.ResourceStatusReady, Size: 100}); got != 100 {
+		t.Fatalf("ready resource bytes = %d, want 100", got)
+	}
+}

--- a/backend/internal/service/system_info.go
+++ b/backend/internal/service/system_info.go
@@ -1,0 +1,230 @@
+package service
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type SystemInstance struct {
+	ID            string  `json:"id"`
+	Name          string  `json:"name"`
+	Role          string  `json:"role"`
+	IP            string  `json:"ip"`
+	Status        string  `json:"status"`
+	Online        bool    `json:"online"`
+	CPUPercent    float64 `json:"cpuPercent"`
+	MemoryPercent float64 `json:"memoryPercent"`
+	MemoryUsedGB  float64 `json:"memoryUsedGb"`
+	MemoryTotalGB float64 `json:"memoryTotalGb"`
+	DiskPercent   float64 `json:"diskPercent"`
+	DiskUsedGB    float64 `json:"diskUsedGb"`
+	DiskTotalGB   float64 `json:"diskTotalGb"`
+	Version       string  `json:"version"`
+	Platform      string  `json:"platform"`
+	BootedAt      string  `json:"bootedAt"`
+	ReportedAt    string  `json:"reportedAt"`
+}
+
+func CollectSystemInstances(commit string, buildTime string) []SystemInstance {
+	memTotalKB, memAvailableKB := readMemInfo()
+	memTotalGB := roundTo(float64(memTotalKB)/1024/1024, 2)
+	memAvailableGB := roundTo(float64(memAvailableKB)/1024/1024, 2)
+	memUsedGB := roundTo(maxFloat(memTotalGB-memAvailableGB, 0), 2)
+	memPercent := 0.0
+	if memTotalGB > 0 {
+		memPercent = roundTo(memUsedGB/memTotalGB*100, 1)
+	}
+	diskTotalGB, diskUsedGB, diskPercent := readDiskUsage("/")
+	hostname, _ := os.Hostname()
+	hostname = pickNonEmpty(os.Getenv("CANVAS_INSTANCE_NAME"), hostname)
+	if hostname == "" {
+		hostname = "canvas-node"
+	}
+	now := time.Now().UTC()
+	return []SystemInstance{{
+		ID: hostname, Name: hostname, Role: "master", IP: readPrimaryIPv4(), Status: "online", Online: true,
+		CPUPercent: readCPUPercent(), MemoryPercent: memPercent, MemoryUsedGB: memUsedGB, MemoryTotalGB: memTotalGB,
+		DiskPercent: diskPercent, DiskUsedGB: diskUsedGB, DiskTotalGB: diskTotalGB,
+		Version: fmt.Sprintf("%s · %s", trimTo(strings.TrimSpace(commit), 7), strings.TrimSpace(buildTime)),
+		Platform: fmt.Sprintf("%s · %s · %s", runtime.GOOS, runtime.GOARCH, readKernelVersion()),
+		BootedAt: readBootTime(), ReportedAt: now.Format(time.RFC3339),
+	}}
+}
+
+func readMemInfo() (totalKB int64, availableKB int64) {
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		value, parseErr := strconv.ParseInt(fields[1], 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		switch fields[0] {
+		case "MemTotal:":
+			totalKB = value
+		case "MemAvailable:":
+			availableKB = value
+		}
+	}
+	return totalKB, availableKB
+}
+
+func readCPUPercent() float64 {
+	busy1, total1 := readProcStatBusyTotal()
+	if total1 == 0 {
+		return 0
+	}
+	time.Sleep(100 * time.Millisecond)
+	busy2, total2 := readProcStatBusyTotal()
+	if total2 <= total1 {
+		return 0
+	}
+	return roundTo(float64(busy2-busy1)/float64(total2-total1)*100, 1)
+}
+
+func readProcStatBusyTotal() (busy, total uint64) {
+	f, err := os.Open("/proc/stat")
+	if err != nil {
+		return 0, 0
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 5 || fields[0] != "cpu" {
+			continue
+		}
+		var values [8]uint64
+		for index := 0; index < len(values) && index+1 < len(fields); index++ {
+			values[index], _ = strconv.ParseUint(fields[index+1], 10, 64)
+		}
+		busy = values[0] + values[1] + values[2] + values[5] + values[6] + values[7]
+		for _, value := range values {
+			total += value
+		}
+		return busy, total
+	}
+	return 0, 0
+}
+
+func readDiskUsage(path string) (totalGB, usedGB, percent float64) {
+	out, err := exec.Command("df", "-B1", path).Output()
+	if err != nil {
+		return 0, 0, 0
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return 0, 0, 0
+	}
+	fields := strings.Fields(lines[len(lines)-1])
+	if len(fields) < 5 {
+		return 0, 0, 0
+	}
+	total, _ := strconv.ParseInt(fields[1], 10, 64)
+	used, _ := strconv.ParseInt(fields[2], 10, 64)
+	totalGB = roundTo(float64(total)/1024/1024/1024, 2)
+	usedGB = roundTo(float64(used)/1024/1024/1024, 2)
+	if total > 0 {
+		percent = roundTo(float64(used)/float64(total)*100, 1)
+	}
+	return totalGB, usedGB, percent
+}
+
+func readBootTime() string {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || fields[0] != "btime" {
+			continue
+		}
+		seconds, _ := strconv.ParseInt(fields[1], 10, 64)
+		if seconds > 0 {
+			return time.Unix(seconds, 0).UTC().Format(time.RFC3339)
+		}
+	}
+	return ""
+}
+
+func readKernelVersion() string {
+	data, err := os.ReadFile("/proc/version")
+	if err != nil {
+		return ""
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) >= 3 {
+		return fields[2]
+	}
+	return ""
+}
+
+func readPrimaryIPv4() string {
+	interfaces, err := net.Interfaces()
+	if err != nil {
+		return ""
+	}
+	for _, iface := range interfaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addresses, addressErr := iface.Addrs()
+		if addressErr != nil {
+			continue
+		}
+		for _, address := range addresses {
+			ip, _, splitErr := net.ParseCIDR(address.String())
+			if splitErr == nil && ip.To4() != nil {
+				return ip.String()
+			}
+		}
+	}
+	return ""
+}
+
+func roundTo(value float64, digits int) float64 {
+	pow := 1.0
+	for index := 0; index < digits; index++ {
+		pow *= 10
+	}
+	return float64(int64(value*pow+0.5)) / pow
+}
+
+func trimTo(value string, maxLength int) string {
+	if len(value) <= maxLength {
+		return value
+	}
+	return value[:maxLength]
+}
+
+func pickNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func maxFloat(value float64, minimum float64) float64 {
+	if value < minimum {
+		return minimum
+	}
+	return value
+}

--- a/backend/internal/service/system_info_test.go
+++ b/backend/internal/service/system_info_test.go
@@ -1,0 +1,29 @@
+package service
+
+import "testing"
+
+func TestSystemInfoHelpers(t *testing.T) {
+	if got := roundTo(12.345, 2); got != 12.35 {
+		t.Fatalf("roundTo() = %v, want 12.35", got)
+	}
+	if got := trimTo("abcdef", 4); got != "abcd" {
+		t.Fatalf("trimTo() = %q, want abcd", got)
+	}
+	if got := pickNonEmpty("", "  ", "canvas"); got != "canvas" {
+		t.Fatalf("pickNonEmpty() = %q, want canvas", got)
+	}
+}
+
+func TestCollectSystemInstancesReturnsAdminSafeSnapshot(t *testing.T) {
+	instances := CollectSystemInstances("abcdef123", "test")
+	if len(instances) != 1 {
+		t.Fatalf("instances = %d, want one instance", len(instances))
+	}
+	instance := instances[0]
+	if !instance.Online || instance.Status != "online" || instance.Role != "master" {
+		t.Fatalf("instance status = %+v, want online master", instance)
+	}
+	if instance.Version != "abcdef1 · test" {
+		t.Fatalf("version = %q, want abbreviated commit and build time", instance.Version)
+	}
+}

--- a/docs/content/docs/backend/backend-database.mdx
+++ b/docs/content/docs/backend/backend-database.mdx
@@ -45,3 +45,11 @@ description: 影策后端核心持久化表与状态边界
 | `resource_deletion_jobs` | 在业务记录删除后可靠清理物理对象 | 固化资源的存储位置与对象键；删除失败保留任务并重试，S3 404 按幂等成功处理 |
 
 `storage_locations.value_json` 中的 Secret Key 和 Session Token 使用后端设置密钥加密。启用 S3 前，关键位置字段和凭据摘要必须与最近一次 Put、Range Get、Delete 连接测试结果一致；历史资源继续按绑定的位置读取和删除，不随当前配置切换。
+
+## 管理后台资源与公告
+
+管理员可以通过 `/api/admin/system/instances` 查看当前实例的 CPU、内存、磁盘和构建信息；该接口仅允许管理员访问，指标在服务端按请求实时采样。
+
+后台存储管理通过 `/api/admin/resources` 分页查询资源，并通过 `/api/admin/storage/stats` 返回按类型和存储位置聚合的统计。删除资源前会复用资源引用检查；数据库记录与 `resource_deletion_jobs` 在同一事务中提交，物理对象由后台 worker 清理，失败时保留任务重试。
+
+系统公告通过 `/api/admin/announcements` 管理，用户通过 `/api/announcements` 获取当前公告和未读数量。公告可置顶并关联已上传的图片资源，图片读取使用公告鉴权接口，不把对象存储地址直接下发给浏览器。

--- a/web/src/components/ui/aceternity/announcement-timeline-modal.tsx
+++ b/web/src/components/ui/aceternity/announcement-timeline-modal.tsx
@@ -1,10 +1,10 @@
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
-import { Modal } from "antd";
-import { Bell, BellOff, CircleAlert, Info, ShieldAlert, Wrench } from "lucide-react";
+import { Image as AntImage, Modal } from "antd";
+import { Bell, BellOff, CircleAlert, Info, Pin, ShieldAlert, Wrench } from "lucide-react";
 
 import { aceternityMotion } from "@/lib/aceternity-motion";
 import { AnnouncementContent } from "@/components/ui/announcement-content";
-import type { AnnouncementLevel, SystemAnnouncement } from "@/services/api/announcements";
+import { announcementImageUrl, type AnnouncementLevel, type SystemAnnouncement } from "@/services/api/announcements";
 
 type AnnouncementTimelineModalProps = {
     open: boolean;
@@ -45,11 +45,7 @@ export function AnnouncementTimelineModal({ open, announcements, loading = false
             }
             styles={{ body: { paddingTop: 8, maxHeight: "min(72vh, 720px)", overflowY: "auto", overscrollBehavior: "contain" } }}
             modalRender={(node) => (
-                <motion.div
-                    initial={reducedMotion ? false : { opacity: 0, y: 14, scale: 0.975 }}
-                    animate={{ opacity: 1, y: 0, scale: 1 }}
-                    transition={{ duration: aceternityMotion.duration.panel, ease: aceternityMotion.easing.enter }}
-                >
+                <motion.div initial={reducedMotion ? false : { opacity: 0, y: 14, scale: 0.975 }} animate={{ opacity: 1, y: 0, scale: 1 }} transition={{ duration: aceternityMotion.duration.panel, ease: aceternityMotion.easing.enter }}>
                     {node}
                 </motion.div>
             )}
@@ -58,7 +54,12 @@ export function AnnouncementTimelineModal({ open, announcements, loading = false
                 {loading ? (
                     <motion.div key="loading" role="status" className="grid min-h-60 place-items-center" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
                         <div className="flex flex-col items-center gap-3 text-sm text-foreground/50">
-                            <motion.span aria-hidden className="size-7 rounded-full border-2 border-foreground/15 border-t-foreground/70" animate={reducedMotion ? undefined : { rotate: 360 }} transition={{ duration: 0.8, repeat: Infinity, ease: "linear" }} />
+                            <motion.span
+                                aria-hidden
+                                className="size-7 rounded-full border-2 border-foreground/15 border-t-foreground/70"
+                                animate={reducedMotion ? undefined : { rotate: 360 }}
+                                transition={{ duration: 0.8, repeat: Infinity, ease: "linear" }}
+                            />
                             正在读取公告
                         </div>
                     </motion.div>
@@ -68,7 +69,15 @@ export function AnnouncementTimelineModal({ open, announcements, loading = false
                             <CircleAlert className="mx-auto size-7 text-red-500" />
                             <p className="mt-3 text-sm font-medium text-foreground">公告读取失败</p>
                             <p className="mt-1 max-w-sm text-xs leading-5 text-foreground/50">{error}</p>
-                            {onRetry ? <button type="button" className="mt-4 h-8 rounded-md border border-border px-3 text-xs font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" onClick={onRetry}>重新加载</button> : null}
+                            {onRetry ? (
+                                <button
+                                    type="button"
+                                    className="mt-4 h-8 rounded-md border border-border px-3 text-xs font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                    onClick={onRetry}
+                                >
+                                    重新加载
+                                </button>
+                            ) : null}
                         </div>
                     </motion.div>
                 ) : announcements.length ? (
@@ -80,7 +89,9 @@ export function AnnouncementTimelineModal({ open, announcements, loading = false
                 ) : (
                     <motion.div key="empty" className="grid min-h-60 place-items-center text-center" initial={reducedMotion ? false : { opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}>
                         <div>
-                            <span className="mx-auto grid size-12 place-items-center rounded-full border border-border bg-muted/40 text-foreground/45"><BellOff className="size-5" /></span>
+                            <span className="mx-auto grid size-12 place-items-center rounded-full border border-border bg-muted/40 text-foreground/45">
+                                <BellOff className="size-5" />
+                            </span>
                             <p className="mt-3 text-sm font-medium text-foreground">暂无系统公告</p>
                             <p className="mt-1 text-xs text-foreground/45">有新的服务动态时会在这里展示</p>
                         </div>
@@ -107,10 +118,22 @@ function AnnouncementTimelineItem({ announcement, last, reducedMotion }: { annou
             <div className="min-w-0">
                 <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
                     <h3 className="text-[var(--fs-body-lg)] font-semibold leading-6 tracking-normal text-foreground sm:text-base">{announcement.title}</h3>
-                    <span className="inline-flex items-center gap-1 text-[var(--fs-label)] font-medium text-foreground/45"><Icon className="size-3" />{meta.label}</span>
+                    <span className="inline-flex items-center gap-1 text-[var(--fs-label)] font-medium text-foreground/45">
+                        <Icon className="size-3" />
+                        {meta.label}
+                    </span>
+                    {announcement.pinned ? (
+                        <span className="inline-flex items-center gap-1 text-[var(--fs-label)] font-medium text-amber-500">
+                            <Pin className="size-3" />
+                            置顶
+                        </span>
+                    ) : null}
                 </div>
+                {announcement.imageUrl ? <AntImage src={announcementImageUrl(announcement)} alt={`${announcement.title} 配图`} preview className="mt-3 max-h-36 w-56 max-w-full rounded-lg border border-border/70 bg-muted/20 object-contain p-1" /> : null}
                 <AnnouncementContent content={announcement.content} className="mt-1 text-sm leading-6 text-foreground/75 sm:text-[var(--fs-body-lg)]" />
-                <time dateTime={announcement.publishedAt} className="mt-2 block text-xs tabular-nums text-foreground/40">{relativeTime(announcement.publishedAt)} · {formatDateTime(announcement.publishedAt)}</time>
+                <time dateTime={announcement.publishedAt} className="mt-2 block text-xs tabular-nums text-foreground/40">
+                    {relativeTime(announcement.publishedAt)} · {formatDateTime(announcement.publishedAt)}
+                </time>
             </div>
         </motion.article>
     );

--- a/web/src/pages/admin/admin-route-pages.tsx
+++ b/web/src/pages/admin/admin-route-pages.tsx
@@ -9,6 +9,8 @@ const CreditOperationsPanel = lazy(() => import("./components/credit-operations-
 const AccessSettingsPanel = lazy(() => import("./components/access-settings-panel"));
 const EmailSettingsPanel = lazy(() => import("./components/email-settings-panel"));
 const FeatureAvailabilityPanel = lazy(() => import("./components/feature-availability-panel"));
+const SystemInfoPanel = lazy(() => import("./components/system-info-panel"));
+const StorageResourcesPanel = lazy(() => import("./components/storage-resources-panel"));
 
 function PageFallback({ label }: { label: string }) {
     return <div className="py-16 text-center text-sm text-foreground/50">正在读取{label}...</div>;
@@ -16,26 +18,84 @@ function PageFallback({ label }: { label: string }) {
 
 export function AnalyticsPage() {
     const { references } = useAdminContext();
-    return <AdminPageFrame title="数据概览" description="活跃、调用与成本趋势"><Suspense fallback={<PageFallback label="统计数据" />}><AnalyticsPanel users={references.users} channels={references.channels} /></Suspense></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="数据概览" description="活跃、调用与成本趋势">
+            <Suspense fallback={<PageFallback label="统计数据" />}>
+                <AnalyticsPanel users={references.users} channels={references.channels} />
+            </Suspense>
+        </AdminPageFrame>
+    );
+}
+
+export function SystemInfoPage() {
+    return (
+        <AdminPageFrame title="系统信息" description="服务器实例与核心资源实时状态">
+            <Suspense fallback={<PageFallback label="系统信息" />}>
+                <SystemInfoPanel />
+            </Suspense>
+        </AdminPageFrame>
+    );
+}
+
+export function StorageResourcesPage() {
+    return (
+        <AdminPageFrame title="存储管理" description="跨用户查看、预览和清理资源对象" scroll>
+            <Suspense fallback={<PageFallback label="存储资源" />}>
+                <StorageResourcesPanel />
+            </Suspense>
+        </AdminPageFrame>
+    );
 }
 
 export function AnnouncementsPage() {
-    return <AdminPageFrame title="系统公告" description="发布、关闭与历史公告"><Suspense fallback={<PageFallback label="系统公告" />}><AdminAnnouncementsPanel /></Suspense></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="系统公告" description="发布、关闭与历史公告">
+            <Suspense fallback={<PageFallback label="系统公告" />}>
+                <AdminAnnouncementsPanel />
+            </Suspense>
+        </AdminPageFrame>
+    );
 }
 
 export function CreditOperationsPage() {
     const { references } = useAdminContext();
-    return <AdminPageFrame title="积分运营" description="人工调账与异常计费"><Suspense fallback={<PageFallback label="积分运营数据" />}><CreditOperationsPanel users={references.users} /></Suspense></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="积分运营" description="人工调账与异常计费">
+            <Suspense fallback={<PageFallback label="积分运营数据" />}>
+                <CreditOperationsPanel users={references.users} />
+            </Suspense>
+        </AdminPageFrame>
+    );
 }
 
 export function AccessSettingsPage() {
-    return <AdminPageFrame title="登录与注册" description="注册策略与 Linux.do" scroll><Suspense fallback={<PageFallback label="登录与注册配置" />}><AccessSettingsPanel /></Suspense></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="登录与注册" description="注册策略与 Linux.do" scroll>
+            <Suspense fallback={<PageFallback label="登录与注册配置" />}>
+                <AccessSettingsPanel />
+            </Suspense>
+        </AdminPageFrame>
+    );
 }
 
 export function EmailSettingsPage() {
-    return <AdminPageFrame title="邮件服务" description="注册验证码 SMTP" scroll><div className="pt-4"><Suspense fallback={<PageFallback label="邮件配置" />}><EmailSettingsPanel /></Suspense></div></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="邮件服务" description="注册验证码 SMTP" scroll>
+            <div className="pt-4">
+                <Suspense fallback={<PageFallback label="邮件配置" />}>
+                    <EmailSettingsPanel />
+                </Suspense>
+            </div>
+        </AdminPageFrame>
+    );
 }
 
 export function FeatureAvailabilityPage() {
-    return <AdminPageFrame title="功能开放" description="控制用户工作台入口、渠道、插件与计费模式" scroll><Suspense fallback={<PageFallback label="功能开放配置" />}><FeatureAvailabilityPanel /></Suspense></AdminPageFrame>;
+    return (
+        <AdminPageFrame title="功能开放" description="控制用户工作台入口、渠道、插件与计费模式" scroll>
+            <Suspense fallback={<PageFallback label="功能开放配置" />}>
+                <FeatureAvailabilityPanel />
+            </Suspense>
+        </AdminPageFrame>
+    );
 }

--- a/web/src/pages/admin/components/admin-announcements-panel.tsx
+++ b/web/src/pages/admin/components/admin-announcements-panel.tsx
@@ -1,25 +1,20 @@
-import { App, Button, Form, Input, Modal, Select } from "antd";
+import { App, Button, Form, Input, Modal, Select, Switch, Tag } from "antd";
 import type { ColumnsType } from "antd/es/table";
-import { Plus, Search } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { Pin, Plus, Search, Upload, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type ChangeEvent } from "react";
 
 import { PaginationBar } from "@/components/layout/workspace-page";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import {
-    closeAdminAnnouncement,
-    createAdminAnnouncement,
-    listAdminAnnouncements,
-    updateAdminAnnouncement,
-    type AnnouncementLevel,
-    type AnnouncementStatus,
-    type SystemAnnouncement,
-} from "@/services/api/announcements";
+import { announcementImageUrl, closeAdminAnnouncement, createAdminAnnouncement, listAdminAnnouncements, updateAdminAnnouncement, type AnnouncementLevel, type AnnouncementStatus, type SystemAnnouncement } from "@/services/api/announcements";
+import { resourceFileUrl, uploadResourceFile } from "@/services/api/resources";
 import { AdminDataTable, AdminFilterChip, AdminRowActions, AdminStatusBadge, AdminTableEmpty } from "./admin-ui";
 
 type AnnouncementFormValues = {
     title: string;
     content: string;
+    imageResourceId?: string;
     level: AnnouncementLevel;
+    pinned: boolean;
 };
 
 const levelOptions: Array<{ value: AnnouncementLevel; label: string }> = [
@@ -51,6 +46,9 @@ export default function AdminAnnouncementsPanel() {
     const [editingAnnouncement, setEditingAnnouncement] = useState<SystemAnnouncement | null>(null);
     const [publishing, setPublishing] = useState(false);
     const [closingId, setClosingId] = useState("");
+    const [imagePreviewUrl, setImagePreviewUrl] = useState("");
+    const [imageUploading, setImageUploading] = useState(false);
+    const imageInputRef = useRef<HTMLInputElement | null>(null);
 
     const reload = useCallback(async () => {
         setLoading(true);
@@ -71,21 +69,53 @@ export default function AdminAnnouncementsPanel() {
 
     const openPublishModal = () => {
         setEditingAnnouncement(null);
-        form.setFieldsValue({ title: "", content: "", level: "info" });
+        form.setFieldsValue({ title: "", content: "", imageResourceId: "", level: "info", pinned: false });
+        setImagePreviewUrl("");
         setModalOpen(true);
     };
 
     const openEditModal = (announcement: SystemAnnouncement) => {
         setEditingAnnouncement(announcement);
-        form.setFieldsValue({ title: announcement.title, content: announcement.content, level: announcement.level });
+        form.setFieldsValue({ title: announcement.title, content: announcement.content, imageResourceId: announcement.imageResourceId || "", level: announcement.level, pinned: announcement.pinned });
+        setImagePreviewUrl(announcementImageUrl(announcement) || (announcement.imageResourceId ? resourceFileUrl(announcement.imageResourceId) : ""));
         setModalOpen(true);
+    };
+
+    const uploadAnnouncementImage = async (event: ChangeEvent<HTMLInputElement>) => {
+        const file = event.target.files?.[0];
+        event.target.value = "";
+        if (!file) return;
+        if (!file.type.startsWith("image/")) {
+            message.warning("公告配图必须是图片文件");
+            return;
+        }
+        if (file.size > 10 * 1024 * 1024) {
+            message.warning("公告配图不能超过 10MB");
+            return;
+        }
+        setImageUploading(true);
+        try {
+            const resource = await uploadResourceFile(file, "image", { fileName: file.name });
+            form.setFieldValue("imageResourceId", resource.id);
+            setImagePreviewUrl(resourceFileUrl(resource.id));
+            message.success("公告配图已上传");
+        } catch (error) {
+            message.error(error instanceof Error ? error.message : "公告配图上传失败");
+        } finally {
+            setImageUploading(false);
+        }
+    };
+
+    const clearAnnouncementImage = () => {
+        form.setFieldValue("imageResourceId", "");
+        setImagePreviewUrl("");
     };
 
     const publish = async () => {
         const values = await form.validateFields();
         setPublishing(true);
         try {
-            const input = { title: values.title.trim(), content: values.content.trim(), level: values.level };
+            const input = { title: values.title.trim(), content: values.content.trim(), imageResourceId: values.imageResourceId?.trim() || "", level: values.level, pinned: Boolean(values.pinned) };
             if (editingAnnouncement) await updateAdminAnnouncement(editingAnnouncement.id, input);
             else await createAdminAnnouncement(input);
             setModalOpen(false);
@@ -119,11 +149,29 @@ export default function AdminAnnouncementsPanel() {
             dataIndex: "title",
             minWidth: 360,
             render: (_, announcement) => (
-                <div className="min-w-0 py-0.5">
-                    <div className="truncate text-sm font-medium text-foreground" title={announcement.title}>{announcement.title}</div>
-                    <div className="mt-1 line-clamp-2 whitespace-pre-wrap text-xs leading-5 text-foreground/50">{announcement.content}</div>
+                <div className="flex min-w-0 items-center gap-3 py-0.5">
+                    {announcement.imageUrl ? <img src={announcementImageUrl(announcement)} alt="" loading="lazy" decoding="async" className="size-14 shrink-0 rounded-md border border-border/70 bg-muted/20 object-contain p-0.5" /> : null}
+                    <div className="min-w-0">
+                        <div className="truncate text-sm font-medium text-foreground" title={announcement.title}>
+                            {announcement.title}
+                        </div>
+                        <div className="mt-1 line-clamp-2 whitespace-pre-wrap text-xs leading-5 text-foreground/50">{announcement.content}</div>
+                    </div>
                 </div>
             ),
+        },
+        {
+            title: "置顶",
+            dataIndex: "pinned",
+            width: 90,
+            render: (pinned: boolean) =>
+                pinned ? (
+                    <Tag color="gold" icon={<Pin className="size-3" />}>
+                        置顶
+                    </Tag>
+                ) : (
+                    <span className="text-foreground/35">--</span>
+                ),
         },
         {
             title: "级别",
@@ -150,39 +198,173 @@ export default function AdminAnnouncementsPanel() {
             title: "关闭时间",
             dataIndex: "closedAt",
             width: 170,
-            render: (value?: string) => value ? formatDateTime(value) : "--",
+            render: (value?: string) => (value ? formatDateTime(value) : "--"),
         },
         {
             title: "操作",
             key: "actions",
             width: 160,
-            render: (_, announcement) => <AdminRowActions primary={{ label: "编辑", onClick: () => openEditModal(announcement) }} actions={announcement.status === "active" ? [{ key: "close", label: "关闭", danger: true, disabled: closingId === announcement.id, onClick: () => void closeAnnouncement(announcement), confirm: { title: "关闭这条公告？", description: "关闭后用户公告中心将不再展示，历史记录会保留。", okText: "关闭公告" } }] : []} />,
+            render: (_, announcement) => (
+                <AdminRowActions
+                    primary={{ label: "编辑", onClick: () => openEditModal(announcement) }}
+                    actions={
+                        announcement.status === "active"
+                            ? [
+                                  {
+                                      key: "close",
+                                      label: "关闭",
+                                      danger: true,
+                                      disabled: closingId === announcement.id,
+                                      onClick: () => void closeAnnouncement(announcement),
+                                      confirm: { title: "关闭这条公告？", description: "关闭后用户公告中心将不再展示，历史记录会保留。", okText: "关闭公告" },
+                                  },
+                              ]
+                            : []
+                    }
+                />
+            ),
         },
     ];
 
     return (
         <>
             <AdminDataTable
-                toolbar={<Input allowClear className="app-list-search" prefix={<Search className="size-4 text-foreground/40" />} value={keyword} placeholder="搜索公告标题或正文" onChange={(event) => { setKeyword(event.target.value); setPage(1); }} />}
-                toolbarActiveFilters={<>{keyword ? <AdminFilterChip label={`搜索：${keyword}`} onRemove={() => { setKeyword(""); setPage(1); }} /> : null}{status !== "all" ? <AdminFilterChip label={`状态：${status === "active" ? "发布中" : "已关闭"}`} onRemove={() => { setStatus("all"); setPage(1); }} /> : null}</>}
+                toolbar={
+                    <Input
+                        allowClear
+                        className="app-list-search"
+                        prefix={<Search className="size-4 text-foreground/40" />}
+                        value={keyword}
+                        placeholder="搜索公告标题或正文"
+                        onChange={(event) => {
+                            setKeyword(event.target.value);
+                            setPage(1);
+                        }}
+                    />
+                }
+                toolbarActiveFilters={
+                    <>
+                        {keyword ? (
+                            <AdminFilterChip
+                                label={`搜索：${keyword}`}
+                                onRemove={() => {
+                                    setKeyword("");
+                                    setPage(1);
+                                }}
+                            />
+                        ) : null}
+                        {status !== "all" ? (
+                            <AdminFilterChip
+                                label={`状态：${status === "active" ? "发布中" : "已关闭"}`}
+                                onRemove={() => {
+                                    setStatus("all");
+                                    setPage(1);
+                                }}
+                            />
+                        ) : null}
+                    </>
+                }
                 toolbarActive={Boolean(keyword || status !== "all")}
-                toolbarFilters={<Select className="w-32" value={status} onChange={(value) => { setStatus(value); setPage(1); }} options={[{ label: "全部状态", value: "all" }, { label: "发布中", value: "active" }, { label: "已关闭", value: "closed" }]} />}
-                onReset={() => { setKeyword(""); setStatus("all"); setPage(1); }}
-                trailing={<Button type="primary" size="small" icon={<Plus className="size-4" />} onClick={openPublishModal}>发布公告</Button>}
+                toolbarFilters={
+                    <Select
+                        className="w-32"
+                        value={status}
+                        onChange={(value) => {
+                            setStatus(value);
+                            setPage(1);
+                        }}
+                        options={[
+                            { label: "全部状态", value: "all" },
+                            { label: "发布中", value: "active" },
+                            { label: "已关闭", value: "closed" },
+                        ]}
+                    />
+                }
+                onReset={() => {
+                    setKeyword("");
+                    setStatus("all");
+                    setPage(1);
+                }}
+                trailing={
+                    <Button type="primary" size="small" icon={<Plus className="size-4" />} onClick={openPublishModal}>
+                        发布公告
+                    </Button>
+                }
                 table={{ rowKey: "id", size: "small", loading, pagination: false, columns, dataSource: announcements, scroll: { x: 1020 } }}
                 empty={<AdminTableEmpty filtered={Boolean(keyword || status !== "all")} title="暂无公告" />}
-                footer={<PaginationBar alwaysShow current={page} pageSize={pageSize} total={total} onChange={(nextPage, nextPageSize) => { setPage(nextPageSize !== pageSize ? 1 : nextPage); setPageSize(nextPageSize); }} />}
+                footer={
+                    <PaginationBar
+                        alwaysShow
+                        current={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onChange={(nextPage, nextPageSize) => {
+                            setPage(nextPageSize !== pageSize ? 1 : nextPage);
+                            setPageSize(nextPageSize);
+                        }}
+                    />
+                }
             />
 
-            <Modal title={editingAnnouncement ? "编辑并重新发布公告" : "发布系统公告"} open={modalOpen} width={760} centered okText={editingAnnouncement ? "保存并重新发布" : "立即发布"} cancelText="取消" confirmLoading={publishing} onOk={() => void publish()} onCancel={() => { setModalOpen(false); setEditingAnnouncement(null); }} destroyOnHidden>
+            <Modal
+                title={editingAnnouncement ? "编辑并重新发布公告" : "发布系统公告"}
+                open={modalOpen}
+                width={760}
+                centered
+                okText={editingAnnouncement ? "保存并重新发布" : "立即发布"}
+                cancelText="取消"
+                confirmLoading={publishing}
+                onOk={() => void publish()}
+                onCancel={() => {
+                    setModalOpen(false);
+                    setEditingAnnouncement(null);
+                }}
+                destroyOnHidden
+            >
                 <Form form={form} layout="vertical" className="pt-3" requiredMark={false}>
-                    <Form.Item name="title" label="公告标题" rules={[{ required: true, whitespace: true, message: "请填写公告标题" }, { max: 120, message: "标题不能超过 120 个字符" }]}>
+                    <Form.Item
+                        name="title"
+                        label="公告标题"
+                        rules={[
+                            { required: true, whitespace: true, message: "请填写公告标题" },
+                            { max: 120, message: "标题不能超过 120 个字符" },
+                        ]}
+                    >
                         <Input maxLength={120} showCount placeholder="例如：视频模型已恢复正常使用" />
                     </Form.Item>
                     <Form.Item name="level" label="公告级别" rules={[{ required: true, message: "请选择公告级别" }]}>
                         <Select options={levelOptions} />
                     </Form.Item>
-                    <Form.Item name="content" label="公告正文" rules={[{ required: true, whitespace: true, message: "请填写公告正文" }, { max: 4000, message: "正文不能超过 4000 个字符" }]}>
+                    <Form.Item name="pinned" label="展示方式" valuePropName="checked" extra="置顶公告会优先展示。">
+                        <Switch checkedChildren="置顶" unCheckedChildren="普通" />
+                    </Form.Item>
+                    <Form.Item name="imageResourceId" hidden>
+                        <Input />
+                    </Form.Item>
+                    <Form.Item label="公告配图" extra="可选，图片文件不超过 10MB。">
+                        <div className="space-y-2">
+                            {imagePreviewUrl ? (
+                                <div className="relative flex min-h-28 items-center justify-center overflow-hidden rounded-md border border-border/70 bg-muted/20 p-2">
+                                    <img src={imagePreviewUrl} alt="公告配图预览" className="max-h-44 w-full object-contain" />
+                                    <Button type="text" size="small" danger icon={<X className="size-3.5" />} className="!absolute right-1 top-1 !size-7 !min-w-7 !p-0" onClick={clearAnnouncementImage} aria-label="移除公告配图" title="移除公告配图" />
+                                </div>
+                            ) : (
+                                <div className="flex min-h-24 items-center justify-center rounded-md border border-dashed border-border/80 bg-muted/10 text-xs text-foreground/45">暂未添加配图</div>
+                            )}
+                            <input ref={imageInputRef} type="file" accept="image/*" className="hidden" onChange={(event) => void uploadAnnouncementImage(event)} />
+                            <Button icon={<Upload className="size-3.5" />} loading={imageUploading} onClick={() => imageInputRef.current?.click()}>
+                                {imagePreviewUrl ? "更换配图" : "上传配图"}
+                            </Button>
+                        </div>
+                    </Form.Item>
+                    <Form.Item
+                        name="content"
+                        label="公告正文"
+                        rules={[
+                            { required: true, whitespace: true, message: "请填写公告正文" },
+                            { max: 4000, message: "正文不能超过 4000 个字符" },
+                        ]}
+                    >
                         <Input.TextArea maxLength={4000} showCount autoSize={{ minRows: 6, maxRows: 12 }} placeholder="填写服务状态、影响范围和用户需要采取的操作" />
                     </Form.Item>
                 </Form>

--- a/web/src/pages/admin/components/admin-shell.tsx
+++ b/web/src/pages/admin/components/admin-shell.tsx
@@ -5,6 +5,7 @@ import {
     BellRing,
     CloudUpload,
     Coins,
+    Database,
     FileClock,
     HardDrive,
     Home,
@@ -19,6 +20,7 @@ import {
     PanelLeftOpen,
     RadioTower,
     Settings2,
+    Server,
     ShieldAlert,
     ShieldCheck,
     TicketCheck,
@@ -47,11 +49,15 @@ type AdminNavigationItem = {
 const adminNavigation: Array<{ label: string; items: AdminNavigationItem[] }> = [
     {
         label: "概览",
-        items: [{ path: "/admin", label: "数据概览", description: "活跃、调用与成本趋势", icon: <BarChart3 className="size-4" /> }],
+        items: [
+            { path: "/admin/system-info", label: "系统信息", description: "服务器实例与核心资源状态", icon: <Server className="size-4" /> },
+            { path: "/admin", label: "数据概览", description: "活跃、调用与成本趋势", icon: <BarChart3 className="size-4" /> },
+        ],
     },
     {
         label: "平台资源",
         items: [
+            { path: "/admin/resources", label: "存储管理", description: "全部用户资源与物理对象", icon: <Database className="size-4" /> },
             { path: "/admin/users", label: "用户管理", description: "账号、角色与状态", icon: <UsersRound className="size-4" /> },
             { path: "/admin/channels", label: "系统渠道", description: "渠道、模型与售价", icon: <RadioTower className="size-4" /> },
             { path: "/admin/models", label: "前台模型", description: "展示、线路与用户价格", icon: <Layers3 className="size-4" />, requireFeature: "frontendModelsEnabled" },

--- a/web/src/pages/admin/components/storage-resources-panel.tsx
+++ b/web/src/pages/admin/components/storage-resources-panel.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { App, Button, Image as AntImage, Input, Modal, Select, Tag } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { AudioLines, Database, FileText, Film, Image as ImageIcon, RefreshCw, Search, Trash2 } from "lucide-react";
+
+import { PaginationBar, ListToolbar } from "@/components/layout/workspace-page";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { adminResourceFileUrl, deleteAdminResource, getAdminStorageStats, listAdminResources, type AdminResourceItem, type AdminStorageStats } from "@/services/api/admin-storage";
+import { useAdminContext } from "@/pages/admin/admin-context";
+import { AdminDataTable, AdminFilterChip, AdminRowActions, AdminStatTile, AdminStatusBadge, AdminTableEmpty } from "./admin-ui";
+
+const kindOptions = [
+    { label: "全部类型", value: "all" },
+    { label: "图片", value: "image" },
+    { label: "视频", value: "video" },
+    { label: "音频", value: "audio" },
+    { label: "文件", value: "file" },
+];
+const statusOptions = [
+    { label: "全部状态", value: "all" },
+    { label: "就绪", value: "ready" },
+    { label: "处理中", value: "pending" },
+    { label: "失败", value: "failed" },
+];
+const providerOptions = [
+    { label: "全部位置", value: "all" },
+    { label: "服务器本地", value: "local" },
+    { label: "阿里云 OSS", value: "aliyun" },
+    { label: "腾讯云 COS", value: "tencent" },
+    { label: "七牛云 Kodo", value: "qiniu" },
+    { label: "通用 S3", value: "s3" },
+];
+
+export default function StorageResourcesPanel() {
+    const { message, modal } = App.useApp();
+    const { references } = useAdminContext();
+    const [keyword, setKeyword] = useState("");
+    const debouncedKeyword = useDebouncedValue(keyword);
+    const [kind, setKind] = useState("all");
+    const [status, setStatus] = useState("all");
+    const [provider, setProvider] = useState("all");
+    const [userId, setUserId] = useState("");
+    const [page, setPage] = useState(1);
+    const [pageSize, setPageSize] = useState(20);
+    const [items, setItems] = useState<AdminResourceItem[]>([]);
+    const [total, setTotal] = useState(0);
+    const [stats, setStats] = useState<AdminStorageStats | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [selectedRowKeys, setSelectedRowKeys] = useState<React.Key[]>([]);
+    const [preview, setPreview] = useState<AdminResourceItem | null>(null);
+    const requestVersion = useRef(0);
+
+    const reload = useCallback(async () => {
+        const version = ++requestVersion.current;
+        setLoading(true);
+        try {
+            const result = await listAdminResources({
+                keyword: debouncedKeyword || undefined,
+                kind: kind === "all" ? undefined : kind,
+                status: status === "all" ? undefined : status,
+                provider: provider === "all" ? undefined : provider,
+                userId: userId || undefined,
+                page,
+                limit: pageSize,
+            });
+            if (version !== requestVersion.current) return;
+            setItems(result.items || []);
+            setTotal(result.total || 0);
+        } catch (error) {
+            if (version === requestVersion.current) message.error(error instanceof Error ? error.message : "读取存储资源失败");
+        } finally {
+            if (version === requestVersion.current) setLoading(false);
+        }
+    }, [debouncedKeyword, kind, message, page, pageSize, provider, status, userId]);
+
+    const reloadStats = useCallback(async () => {
+        try {
+            setStats((await getAdminStorageStats()).stats);
+        } catch (error) {
+            message.error(error instanceof Error ? error.message : "读取存储统计失败");
+        }
+    }, [message]);
+
+    useEffect(() => {
+        void reload();
+    }, [reload]);
+    useEffect(() => {
+        void reloadStats();
+    }, [reloadStats]);
+
+    const remove = useCallback(
+        async (id: string) => {
+            try {
+                await deleteAdminResource(id);
+                message.success("资源已删除，物理对象将由后台清理");
+                setSelectedRowKeys((keys) => keys.filter((key) => String(key) !== id));
+                await Promise.all([reload(), reloadStats()]);
+            } catch (error) {
+                message.error(error instanceof Error ? error.message : "删除资源失败");
+            }
+        },
+        [message, reload, reloadStats],
+    );
+
+    const removeSelected = useCallback(() => {
+        if (!selectedRowKeys.length) return;
+        modal.confirm({
+            title: `删除选中的 ${selectedRowKeys.length} 个资源？`,
+            content: "删除前会检查业务引用；删除成功后文件由后台队列清理。",
+            okText: "删除",
+            okButtonProps: { danger: true },
+            cancelText: "取消",
+            onOk: async () => {
+                for (const key of selectedRowKeys) await remove(String(key));
+            },
+        });
+    }, [modal, remove, selectedRowKeys]);
+
+    const columns = useMemo<ColumnsType<AdminResourceItem>>(
+        () => [
+            {
+                title: "资源",
+                dataIndex: "id",
+                width: 300,
+                render: (_, record) => (
+                    <div className="flex min-w-0 items-center gap-2">
+                        <span className="grid size-8 shrink-0 place-items-center rounded-md bg-foreground/[.05] text-foreground/60">
+                            <ResourceIcon kind={record.kind} />
+                        </span>
+                        <div className="min-w-0">
+                            <div className="truncate font-mono text-xs" title={record.id}>
+                                {record.id}
+                            </div>
+                            <div className="mt-1 truncate text-xs text-foreground/45" title={record.mimeType}>
+                                {record.mimeType || record.kind}
+                            </div>
+                        </div>
+                    </div>
+                ),
+            },
+            { title: "用户", dataIndex: "userName", width: 150, ellipsis: true, render: (value: string, record) => <span title={record.userId}>{value || record.userId}</span> },
+            { title: "位置", dataIndex: "storageLocation", width: 130, render: (value: string) => <Tag>{storageLabel(value)}</Tag> },
+            { title: "状态", dataIndex: "status", width: 100, render: (value: string) => <AdminStatusBadge label={statusLabel(value)} tone={value === "ready" ? "success" : value === "failed" ? "error" : "warning"} /> },
+            { title: "大小", dataIndex: "storageBytes", width: 120, align: "right", render: (value: number) => <span className="tabular-nums">{formatBytes(value)}</span> },
+            { title: "创建时间", dataIndex: "createdAt", width: 170, render: (value: string) => <span className="text-xs tabular-nums text-foreground/55">{formatDateTime(value)}</span> },
+            {
+                title: "操作",
+                key: "actions",
+                width: 150,
+                fixed: "right",
+                render: (_, record) => (
+                    <AdminRowActions
+                        primary={{ label: "预览", icon: <Search className="size-3.5" />, onClick: () => setPreview(record) }}
+                        actions={[
+                            {
+                                key: "delete",
+                                label: "删除",
+                                icon: <Trash2 className="size-3.5" />,
+                                danger: true,
+                                onClick: () => void remove(record.id),
+                                confirm: { title: "删除这个资源？", description: "删除前会检查业务引用，删除成功后物理对象进入后台清理队列。", okText: "删除资源" },
+                            },
+                        ]}
+                    />
+                ),
+            },
+        ],
+        [remove],
+    );
+
+    const userOptions = references.users.map((user) => ({ label: user.displayName || user.username, value: user.id }));
+    const activeFilterCount = Boolean(keyword || kind !== "all" || status !== "all" || provider !== "all" || userId);
+
+    return (
+        <div>
+            <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                <AdminStatTile label="资源记录" value={stats?.resourceCount ?? "-"} detail="包含全部状态" />
+                <AdminStatTile label="逻辑大小" value={formatBytes(stats?.totalBytes || 0)} detail="资源记录声明大小" />
+                <AdminStatTile label="本地占用" value={formatBytes(stats?.localBytes || 0)} detail="就绪的服务器本地对象" />
+                <AdminStatTile label="远端占用" value={formatBytes(stats?.remoteBytes || 0)} detail="就绪的对象存储对象" />
+            </div>
+            <ListToolbar
+                active={activeFilterCount}
+                onReset={() => {
+                    setKeyword("");
+                    setKind("all");
+                    setStatus("all");
+                    setProvider("all");
+                    setUserId("");
+                    setPage(1);
+                }}
+                trailing={
+                    selectedRowKeys.length ? (
+                        <Button danger icon={<Trash2 className="size-3.5" />} onClick={removeSelected}>
+                            删除选中
+                        </Button>
+                    ) : (
+                        <Button icon={<RefreshCw className={loading ? "size-4 animate-spin" : "size-4"} />} onClick={() => void Promise.all([reload(), reloadStats()])}>
+                            刷新
+                        </Button>
+                    )
+                }
+            >
+                <Input
+                    allowClear
+                    className="app-list-search"
+                    prefix={<Search className="size-4 text-foreground/40" />}
+                    value={keyword}
+                    placeholder="搜索资源 ID 或对象路径"
+                    onChange={(event) => {
+                        setKeyword(event.target.value);
+                        setPage(1);
+                    }}
+                />
+                <Select
+                    className="w-28"
+                    value={kind}
+                    options={kindOptions}
+                    onChange={(value) => {
+                        setKind(value);
+                        setPage(1);
+                    }}
+                />
+                <Select
+                    className="w-28"
+                    value={status}
+                    options={statusOptions}
+                    onChange={(value) => {
+                        setStatus(value);
+                        setPage(1);
+                    }}
+                />
+                <Select
+                    className="w-32"
+                    value={provider}
+                    options={providerOptions}
+                    onChange={(value) => {
+                        setProvider(value);
+                        setPage(1);
+                    }}
+                />
+                <Select
+                    className="w-40"
+                    allowClear
+                    showSearch
+                    optionFilterProp="label"
+                    placeholder="全部用户"
+                    options={userOptions}
+                    value={userId || undefined}
+                    onChange={(value) => {
+                        setUserId(value || "");
+                        setPage(1);
+                    }}
+                />
+            </ListToolbar>
+            {activeFilterCount ? (
+                <div className="mb-3 flex flex-wrap gap-2">
+                    {keyword ? <AdminFilterChip label={`搜索：${keyword}`} onRemove={() => setKeyword("")} /> : null}
+                    {kind !== "all" ? <AdminFilterChip label={`类型：${kind}`} onRemove={() => setKind("all")} /> : null}
+                    {status !== "all" ? <AdminFilterChip label={`状态：${statusLabel(status)}`} onRemove={() => setStatus("all")} /> : null}
+                    {provider !== "all" ? <AdminFilterChip label={`位置：${storageLabel(provider)}`} onRemove={() => setProvider("all")} /> : null}
+                </div>
+            ) : null}
+            <AdminDataTable
+                table={{ rowKey: "id", size: "small", loading, dataSource: items, columns, pagination: false, scroll: { x: 1120 }, rowSelection: { selectedRowKeys, onChange: setSelectedRowKeys } }}
+                empty={<AdminTableEmpty filtered={activeFilterCount} title="没有匹配的资源" />}
+                footer={
+                    <PaginationBar
+                        alwaysShow
+                        current={page}
+                        pageSize={pageSize}
+                        total={total}
+                        onChange={(nextPage, nextSize) => {
+                            setPage(nextSize !== pageSize ? 1 : nextPage);
+                            setPageSize(nextSize);
+                        }}
+                    />
+                }
+            />
+            <Modal title="资源预览" open={Boolean(preview)} footer={null} width={760} onCancel={() => setPreview(null)}>
+                {preview ? (
+                    <div className="space-y-3">
+                        <div className="flex items-center justify-between gap-2">
+                            <span className="truncate font-mono text-xs text-foreground/55">{preview.id}</span>
+                            <Button size="small" icon={<FileText className="size-3.5" />} href={adminResourceFileUrl(preview.id, true)} target="_blank" rel="noopener noreferrer">
+                                下载
+                            </Button>
+                        </div>
+                        <div className="grid min-h-56 place-items-center overflow-hidden rounded-lg border border-border/60 bg-black/95 p-4">
+                            {preview.kind === "image" ? (
+                                <AntImage src={adminResourceFileUrl(preview.id)} alt={preview.id} className="max-h-[440px] max-w-full object-contain" />
+                            ) : preview.kind === "video" ? (
+                                <video src={adminResourceFileUrl(preview.id)} controls className="max-h-[440px] max-w-full" />
+                            ) : preview.kind === "audio" ? (
+                                <audio src={adminResourceFileUrl(preview.id)} controls />
+                            ) : (
+                                <FileText className="size-12 text-white/40" />
+                            )}
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-xs text-foreground/60 sm:grid-cols-3">
+                            <span>用户：{preview.userName || preview.userId}</span>
+                            <span>类型：{preview.mimeType || preview.kind}</span>
+                            <span>大小：{formatBytes(preview.size)}</span>
+                            <span>位置：{storageLabel(preview.storageLocation)}</span>
+                            <span>对象：{preview.objectKey}</span>
+                            <span>创建：{formatDateTime(preview.createdAt)}</span>
+                            {preview.error ? <span className="col-span-2 text-red-500 sm:col-span-3">错误：{preview.error}</span> : null}
+                        </div>
+                    </div>
+                ) : null}
+            </Modal>
+        </div>
+    );
+}
+
+function ResourceIcon({ kind }: { kind: string }) {
+    if (kind === "image") return <ImageIcon className="size-4" />;
+    if (kind === "video") return <Film className="size-4" />;
+    if (kind === "audio") return <AudioLines className="size-4" />;
+    return <Database className="size-4" />;
+}
+function formatBytes(value: number) {
+    if (!value) return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB"];
+    const index = Math.min(Math.floor(Math.log(value) / Math.log(1024)), units.length - 1);
+    return `${(value / 1024 ** index).toFixed(index ? 2 : 0)} ${units[index]}`;
+}
+function formatDateTime(value: string) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "--" : date.toLocaleString("zh-CN", { hour12: false }).replaceAll("/", "-");
+}
+function statusLabel(value: string) {
+    return value === "ready" ? "就绪" : value === "pending" ? "处理中" : value === "failed" ? "失败" : value;
+}
+function storageLabel(value: string) {
+    return value === "local" ? "服务器本地" : value === "aliyun" ? "阿里云 OSS" : value === "tencent" ? "腾讯云 COS" : value === "qiniu" ? "七牛云 Kodo" : value === "s3" ? "通用 S3" : value;
+}

--- a/web/src/pages/admin/components/system-info-panel.tsx
+++ b/web/src/pages/admin/components/system-info-panel.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { App, Button, Table, Tag } from "antd";
+import type { ColumnsType } from "antd/es/table";
+import { Activity, RefreshCw, Server } from "lucide-react";
+
+import { getAdminSystemInstances, type SystemInstance } from "@/services/api/admin-system";
+
+function formatPercent(value: number) {
+    return `${Math.max(0, Math.min(100, value)).toFixed(1)}%`;
+}
+
+function formatGb(used: number, total: number) {
+    return `${used.toFixed(2)} / ${total.toFixed(2)} GB`;
+}
+
+function Metric({ value }: { value: number }) {
+    return <span className="tabular-nums text-foreground/75">{formatPercent(value)}</span>;
+}
+
+export default function SystemInfoPanel() {
+    const { message } = App.useApp();
+    const [instances, setInstances] = useState<SystemInstance[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [intervalSeconds, setIntervalSeconds] = useState(30);
+    const requestVersion = useRef(0);
+
+    const refresh = useCallback(async () => {
+        const version = ++requestVersion.current;
+        try {
+            const result = await getAdminSystemInstances();
+            if (version !== requestVersion.current) return;
+            setInstances(result.instances || []);
+            setIntervalSeconds(result.intervalSeconds || 30);
+        } catch (error) {
+            if (version !== requestVersion.current) return;
+            message.error(error instanceof Error ? error.message : "读取系统信息失败");
+        } finally {
+            if (version === requestVersion.current) setLoading(false);
+        }
+    }, [message]);
+
+    useEffect(() => {
+        void refresh();
+        const timer = window.setInterval(() => void refresh(), intervalSeconds * 1000);
+        return () => window.clearInterval(timer);
+    }, [intervalSeconds, refresh]);
+
+    const columns: ColumnsType<SystemInstance> = [
+        {
+            title: "实例",
+            dataIndex: "name",
+            render: (_, record) => (
+                <div className="flex min-w-0 items-center gap-2">
+                    <span className="grid size-8 shrink-0 place-items-center rounded-md bg-foreground/[.06] text-foreground/65">
+                        <Server className="size-4" />
+                    </span>
+                    <div className="min-w-0">
+                        <div className="truncate text-sm font-medium">{record.name}</div>
+                        <div className="truncate text-xs text-foreground/45">{record.ip || record.id}</div>
+                    </div>
+                </div>
+            ),
+        },
+        { title: "状态", dataIndex: "status", render: (_, record) => <span className={record.online ? "text-emerald-600" : "text-foreground/45"}>{record.online ? "在线" : "离线"}</span> },
+        { title: "角色", dataIndex: "role", width: 100, render: (value: string) => <Tag color="blue">{value === "master" ? "主节点" : value}</Tag> },
+        { title: "CPU", dataIndex: "cpuPercent", width: 100, render: (value: number) => <Metric value={value} /> },
+        {
+            title: "内存",
+            dataIndex: "memoryPercent",
+            width: 190,
+            render: (value: number, record) => (
+                <span>
+                    <Metric value={value} /> <span className="ml-1 text-xs text-foreground/45">{formatGb(record.memoryUsedGb, record.memoryTotalGb)}</span>
+                </span>
+            ),
+        },
+        {
+            title: "磁盘",
+            dataIndex: "diskPercent",
+            width: 190,
+            render: (value: number, record) => (
+                <span>
+                    <Metric value={value} /> <span className="ml-1 text-xs text-foreground/45">{formatGb(record.diskUsedGb, record.diskTotalGb)}</span>
+                </span>
+            ),
+        },
+        { title: "版本", dataIndex: "version", width: 180, ellipsis: true },
+        { title: "运行环境", dataIndex: "platform", width: 230, ellipsis: true },
+        { title: "最后上报", dataIndex: "reportedAt", width: 170, render: (value: string) => <span className="text-xs tabular-nums text-foreground/55">{formatDateTime(value)}</span> },
+    ];
+
+    return (
+        <div className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-border/60 bg-background/40 px-4 py-3">
+                <div className="flex items-center gap-3">
+                    <span className="grid size-9 place-items-center rounded-md bg-foreground/[.05] text-foreground/65">
+                        <Activity className="size-4" />
+                    </span>
+                    <div>
+                        <div className="text-sm font-medium">服务器实例</div>
+                        <div className="text-xs text-foreground/50">CPU、内存和磁盘指标每 {intervalSeconds} 秒自动刷新。</div>
+                    </div>
+                </div>
+                <Button icon={<RefreshCw className={loading ? "size-4 animate-spin" : "size-4"} />} loading={loading} onClick={() => void refresh()}>
+                    刷新
+                </Button>
+            </div>
+            <Table<SystemInstance>
+                rowKey="id"
+                size="middle"
+                loading={loading && instances.length === 0}
+                pagination={false}
+                dataSource={instances}
+                columns={columns}
+                scroll={{ x: 1250 }}
+                locale={{ emptyText: loading ? "正在读取节点指标..." : "暂无实例数据" }}
+            />
+        </div>
+    );
+}
+
+function formatDateTime(value: string) {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? "--" : date.toLocaleString("zh-CN", { hour12: false }).replaceAll("/", "-");
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -11,6 +11,8 @@ import RouteErrorPage from "@/pages/route-error";
 
 const AdminPage = lazy(() => import("@/pages/admin"));
 const AnalyticsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AnalyticsPage })));
+const SystemInfoPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.SystemInfoPage })));
+const StorageResourcesPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.StorageResourcesPage })));
 const AnnouncementsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AnnouncementsPage })));
 const CreditOperationsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.CreditOperationsPage })));
 const AccessSettingsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AccessSettingsPage })));
@@ -105,8 +107,22 @@ export const router = createBrowserRouter([
             },
             { path: "/assets", element: <RequireAuth>{deferred(<AssetsPage />)}</RequireAuth> },
             { path: "/skills", element: <RequireAuth>{deferred(<SkillsPage />)}</RequireAuth> },
-            { path: "/plugins", element: <RequireAuth><RequireFeature feature="pluginCenterEnabled">{deferred(<PluginsPage />)}</RequireFeature></RequireAuth> },
-            { path: "/plugins/eagle", element: <RequireAuth><RequireFeature feature="pluginCenterEnabled">{deferred(<EagleLibraryPage />)}</RequireFeature></RequireAuth> },
+            {
+                path: "/plugins",
+                element: (
+                    <RequireAuth>
+                        <RequireFeature feature="pluginCenterEnabled">{deferred(<PluginsPage />)}</RequireFeature>
+                    </RequireAuth>
+                ),
+            },
+            {
+                path: "/plugins/eagle",
+                element: (
+                    <RequireAuth>
+                        <RequireFeature feature="pluginCenterEnabled">{deferred(<EagleLibraryPage />)}</RequireFeature>
+                    </RequireAuth>
+                ),
+            },
             {
                 path: "/wallet",
                 element: (
@@ -156,6 +172,8 @@ export const router = createBrowserRouter([
                 element: <RequireAuth>{deferred(<AdminPage />)}</RequireAuth>,
                 children: [
                     { index: true, element: deferred(<AnalyticsPage />) },
+                    { path: "system-info", element: deferred(<SystemInfoPage />) },
+                    { path: "resources", element: deferred(<StorageResourcesPage />) },
                     { path: "users", element: deferred(<UsersPage />) },
                     { path: "channels", element: deferred(<ChannelsPage />) },
                     { path: "models", element: <RequireFeature feature="frontendModelsEnabled">{deferred(<LogicalModelsPage />)}</RequireFeature> },

--- a/web/src/services/api/admin-storage.ts
+++ b/web/src/services/api/admin-storage.ts
@@ -1,0 +1,62 @@
+import { apiBaseURL, apiClient, request } from "@/services/api/request";
+
+export type AdminResourceFilter = {
+    keyword?: string;
+    kind?: string;
+    status?: string;
+    provider?: string;
+    userId?: string;
+    from?: string;
+    to?: string;
+    page?: number;
+    limit?: number;
+};
+
+export type AdminResourceItem = {
+    id: string;
+    userId: string;
+    userName: string;
+    kind: string;
+    status: string;
+    provider: string;
+    endpoint?: string;
+    bucket?: string;
+    objectKey: string;
+    mimeType: string;
+    size: number;
+    width: number;
+    height: number;
+    durationMs: number;
+    error?: string;
+    storageLocation: string;
+    storageBytes: number;
+    fileUrl: string;
+    createdAt: string;
+    updatedAt: string;
+};
+
+export type AdminStorageStats = {
+    resourceCount: number;
+    byKind: Array<{ kind: string; count: number; bytes: number }>;
+    byProvider: Array<{ provider: string; count: number; logicalBytes: number; physicalBytes: number }>;
+    totalBytes: number;
+    localBytes: number;
+    remoteBytes: number;
+};
+
+export function listAdminResources(params: AdminResourceFilter = {}) {
+    return request<{ items: AdminResourceItem[]; total: number; page: number; limit: number }>(apiClient.get("/admin/resources", { params }));
+}
+
+export function getAdminStorageStats() {
+    return request<{ stats: AdminStorageStats }>(apiClient.get("/admin/storage/stats"));
+}
+
+export function deleteAdminResource(id: string) {
+    return request<{ ok: boolean }>(apiClient.delete(`/admin/resources/${encodeURIComponent(id)}`));
+}
+
+export function adminResourceFileUrl(id: string, download = false) {
+    const base = String(apiBaseURL).replace(/\/+$/, "");
+    return `${base}/admin/resources/${encodeURIComponent(id)}/file${download ? "?download=1" : ""}`;
+}

--- a/web/src/services/api/admin-system.ts
+++ b/web/src/services/api/admin-system.ts
@@ -1,0 +1,25 @@
+import { apiClient, request } from "@/services/api/request";
+
+export type SystemInstance = {
+    id: string;
+    name: string;
+    role: string;
+    ip: string;
+    status: string;
+    online: boolean;
+    cpuPercent: number;
+    memoryPercent: number;
+    memoryUsedGb: number;
+    memoryTotalGb: number;
+    diskPercent: number;
+    diskUsedGb: number;
+    diskTotalGb: number;
+    version: string;
+    platform: string;
+    bootedAt: string;
+    reportedAt: string;
+};
+
+export function getAdminSystemInstances() {
+    return request<{ instances: SystemInstance[]; intervalSeconds: number }>(apiClient.get("/admin/system/instances"));
+}

--- a/web/src/services/api/announcements.ts
+++ b/web/src/services/api/announcements.ts
@@ -1,4 +1,4 @@
-import { apiClient, request } from "@/services/api/request";
+import { apiBaseURL, apiClient, request } from "@/services/api/request";
 
 export type AnnouncementLevel = "info" | "success" | "warning" | "critical";
 export type AnnouncementStatus = "active" | "closed";
@@ -7,7 +7,10 @@ export type SystemAnnouncement = {
     id: string;
     title: string;
     content: string;
+    imageResourceId?: string;
+    imageUrl?: string;
     level: AnnouncementLevel;
+    pinned?: boolean;
     status: AnnouncementStatus;
     createdBy: string;
     publishedAt: string;
@@ -34,6 +37,13 @@ export function getAnnouncementFeed() {
     return request<AnnouncementFeed>(api.get("/announcements"));
 }
 
+export function announcementImageUrl(announcement: Pick<SystemAnnouncement, "imageUrl">) {
+    const imageUrl = announcement.imageUrl;
+    if (!imageUrl || !imageUrl.startsWith("/api/")) return imageUrl || "";
+    const base = String(apiBaseURL).replace(/\/+$/, "");
+    return base === "/api" ? imageUrl : `${base}${imageUrl.slice("/api".length)}`;
+}
+
 export function markAnnouncementsRead(announcementIds: string[]) {
     return request<{ unreadCount: number }>(api.post("/announcements/read", { announcementIds }));
 }
@@ -42,11 +52,11 @@ export function listAdminAnnouncements(params: AdminAnnouncementListParams = {})
     return request<{ announcements: SystemAnnouncement[]; total: number; page: number; limit: number }>(api.get("/admin/announcements", { params }));
 }
 
-export function createAdminAnnouncement(input: { title: string; content: string; level: AnnouncementLevel }) {
+export function createAdminAnnouncement(input: { title: string; content: string; imageResourceId?: string; level: AnnouncementLevel; pinned?: boolean }) {
     return request<{ announcement: SystemAnnouncement }>(api.post("/admin/announcements", input));
 }
 
-export function updateAdminAnnouncement(id: string, input: { title: string; content: string; level: AnnouncementLevel }) {
+export function updateAdminAnnouncement(id: string, input: { title: string; content: string; imageResourceId?: string; level: AnnouncementLevel; pinned?: boolean }) {
     return request<{ announcement: SystemAnnouncement }>(api.patch(`/admin/announcements/${encodeURIComponent(id)}`, input));
 }
 


### PR DESCRIPTION
## 改动摘要

- 新增管理员系统信息页，展示实例状态、CPU、内存、磁盘、运行环境和构建版本，并提供自动刷新。
- 新增管理员存储管理页，支持跨用户资源分页、类型、状态、存储位置和用户筛选，提供统计概览、媒体预览、下载和批量删除。
- 扩展系统公告管理与前端公告中心，支持置顶公告、公告配图、应用内鉴权图片读取和用户端公告展示。
- 管理员资源删除复用业务引用检查和物理对象删除队列，新增数据库说明和针对性测试。

## 风险与兼容性

- 新增字段通过现有 GORM AutoMigrate 自动补齐，历史公告默认保持非置顶且无配图。
- 系统信息和存储管理接口均在 service 层校验管理员权限。
- 公告图片和后台资源预览通过应用内鉴权接口读取，不直接向浏览器暴露对象存储地址。
- 删除资源前会检查公告、素材、项目、画布、任务等业务引用；物理对象由后台删除队列清理。

## 验证

- bun node_modules/typescript/bin/tsc --noEmit
- Prettier changed-file check
- bun node_modules/vite/bin/vite.js build
- 前端完整测试：1046 项通过；2 项失败为仓库既有 Windows CRLF 字符串断言，与本次改动无关。
- 后端 go test ./... 和 gofmt -l 未在本机执行，原因是本机未安装 Go 工具链；新增后端测试已提交供 CI 执行。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义