### PR TITLE
fix(canvas): 调整亮光模式画布背景

### DIFF
--- a/web/src/components/canvas/infinite-canvas.tsx
+++ b/web/src/components/canvas/infinite-canvas.tsx
@@ -41,7 +41,9 @@ type PinchState = {
 };
 
 export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines", onViewportChange, onViewportPreviewChange, onCanvasMouseDown, boxSelectEnabled = false, onCanvasDoubleClick, onCanvasDeselect, onContextMenu, onDrop, onFileDragEnter, onFileDragLeave, onFileDragOver, graphicsLayer, children }: InfiniteCanvasProps) {
-    const theme = canvasThemes[useThemeStore((state) => state.theme)];
+    const colorTheme = useThemeStore((state) => state.theme);
+    const theme = canvasThemes[colorTheme];
+    const canvasBackground = colorTheme === "light" ? "#e6e6e6" : theme.canvas.background;
     const panState = useRef({
         isPanning: false,
         pointerId: -1,
@@ -372,7 +374,7 @@ export function InfiniteCanvas({ containerRef, viewport, backgroundMode = "lines
             ref={containerRef}
             className={`relative h-full w-full select-none overflow-hidden touch-none ${isPanning ? "cursor-grabbing" : boxSelectEnabled ? "cursor-crosshair" : "cursor-grab"}`}
             style={{
-                background: theme.canvas.background,
+                background: canvasBackground,
                 overscrollBehavior: "none",
                 "--canvas-live-x": `${viewport.x}px`,
                 "--canvas-live-y": `${viewport.y}px`,


### PR DESCRIPTION
## 变更内容
- 亮光模式下，InfiniteCanvas 内部背景使用 #E6E6E6。
- 暗色模式继续使用既有主题画布背景；不改变网格、节点或页面主界面。
- 创作页侧边栏已由上游现有规则保持与首页一致的灰色圆角样式，本 PR 不重复添加无效样式覆盖。

## 验证
- 已执行 git diff --check，无格式问题。
- 按约定，本次未重复执行构建；由本地开发环境手动验证。