### PR TITLE
fix(hostupdate): 拆分磁盘空间预检为平台实现，修复 Windows 编译失败

### DIFF
--- a/backend/internal/hostupdate/disk_unix.go
+++ b/backend/internal/hostupdate/disk_unix.go
@@ -1,0 +1,21 @@
+//go:build !windows
+
+package hostupdate
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// checkBackupDiskSpace 确保备份目录至少有 2 GiB 可用空间。
+func checkBackupDiskSpace(directory string) error {
+	var disk syscall.Statfs_t
+	if err := syscall.Statfs(directory, &disk); err != nil {
+		return fmt.Errorf("检查备份磁盘空间：%w", err)
+	}
+	available := int64(disk.Bavail) * int64(disk.Bsize)
+	if available < 2<<30 {
+		return fmt.Errorf("备份目录可用空间不足 2 GiB：当前 %d MiB", available>>20)
+	}
+	return nil
+}

--- a/backend/internal/hostupdate/disk_windows.go
+++ b/backend/internal/hostupdate/disk_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package hostupdate
+
+// checkBackupDiskSpace 在 Windows 本地开发环境跳过磁盘空间预检。
+// 磁盘预检仅服务 Linux 服务器部署时的在线更新器，Windows 本地开发用不到。
+func checkBackupDiskSpace(directory string) error {
+	return nil
+}

--- a/backend/internal/hostupdate/manager_ops.go
+++ b/backend/internal/hostupdate/manager_ops.go
@@ -17,7 +17,6 @@ import (
 	"runtime"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -131,13 +130,8 @@ func (m *Manager) preflight(composePath, targetVersion string) error {
 			return fmt.Errorf("检查 Host Updater 安装目录：%w", err)
 		}
 	}
-	var disk syscall.Statfs_t
-	if err := syscall.Statfs(m.config.BackupDir, &disk); err != nil {
-		return fmt.Errorf("检查备份磁盘空间：%w", err)
-	}
-	available := int64(disk.Bavail) * int64(disk.Bsize)
-	if available < 2<<30 {
-		return fmt.Errorf("备份目录可用空间不足 2 GiB：当前 %d MiB", available>>20)
+	if err := checkBackupDiskSpace(m.config.BackupDir); err != nil {
+		return err
 	}
 	if err := m.compose(composePath, targetVersion, 2*time.Minute, nil, "config", "--quiet"); err != nil {
 		return fmt.Errorf("目标 Compose 校验失败：%w", err)


### PR DESCRIPTION
## 背景

v1.2.3.1 新增的 Host Updater 在 `manager_ops.go` 中使用了 Linux 专属系统调用 `syscall.Statfs`，导致 **Windows 本地开发无法编译后端**。

## 修改

- `manager_ops.go`：删除内联 `syscall.Statfs`，改为调用 `checkBackupDiskSpace`
- 新增 `disk_unix.go`（`//go:build !windows`）：保留原磁盘空间检查
- 新增 `disk_windows.go`（`//go:build windows`）：Windows 跳过磁盘预检（仅服务 Linux 在线更新）

## 验证

- Windows 下 `go build` 通过
- Linux 行为不变