### PR TITLE
fix(create):修复数据概述界面模型价格筛选与创作页面布局重叠问题

### DIFF
--- a/web/src/pages/admin/components/analytics-panel.tsx
+++ b/web/src/pages/admin/components/analytics-panel.tsx
@@ -77,6 +77,7 @@ export default function AnalyticsPanel({ users, channels }: Props) {
     const [pricingWorkspaceOpen, setPricingWorkspaceOpen] = useState(false);
     const [pendingPricing, setPendingPricing] = useState<ModelPricing | null | undefined>(undefined);
     const [form] = Form.useForm<PricingFormValues>();
+    const pricingChannelId = Form.useWatch("channelId", form);
     const analyticsPageSize = 20;
 
     const filters = useMemo<AnalyticsFilters>(
@@ -148,11 +149,17 @@ export default function AnalyticsPanel({ users, channels }: Props) {
 
     const pricingModelOptions = useMemo(() => {
         const names = new Set<string>();
-        const sourceChannels = channels.filter((channel) => channel.enabled !== false);
+        const sourceChannels = channels.filter(
+            (channel) =>
+                channel.enabled !== false &&
+                (!pricingChannelId || channel.id === pricingChannelId),
+        );
         sourceChannels.forEach((channel) => channel.models?.forEach((name) => names.add(name)));
-        if (editingPricing?.model) names.add(editingPricing.model);
+        if (editingPricing?.model && (!pricingChannelId || editingPricing.channelId === pricingChannelId)) {
+            names.add(editingPricing.model);
+        }
         return [...names].sort().map((name) => ({ label: name, value: name }));
-    }, [channels, editingPricing?.model]);
+    }, [channels, editingPricing?.channelId, editingPricing?.model, pricingChannelId]);
 
     const preparePricingForm = (pricing: ModelPricing | null) => {
         setEditingPricing(pricing);

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -15598,28 +15598,38 @@ html:not(.dark) .creation-home .storyboard-workbench-bar-action:hover { backgrou
     .creation-home .creation-empty-suggest { grid-template-columns: 1fr; }
 }
 
-/* 空态布局收敛：banner 与下方对话列同宽，整组垂直居中；用首/末子项 auto margin 居中，
-   内容超高时自动 margin 归零、回到顶部对齐，避免 justify-content:center 在滚动容器里的裁切问题。 */
+/* 空态布局收敛：保持图片区、文案和输入区的文档流顺序，内容超高时由主区滚动承载。 */
+.creation-home .creation-empty-workspace {
+    justify-content: flex-start;
+}
+
+.creation-home .creation-empty-workspace > .creation-empty-art,
+.creation-home .creation-empty-workspace > .creation-chat-intro,
+.creation-home .creation-empty-workspace > .creation-empty-composer,
+.creation-home .creation-empty-workspace > .creation-empty-suggest {
+    flex: 0 0 auto;
+}
+
 .creation-empty-workspace > .creation-empty-art {
     width: min(820px, calc(100% - 28px));
     height: 200px;
-    margin: auto auto 20px;
+    margin: 0 auto 20px;
 }
 
 .creation-empty-workspace .creation-empty-art-frame.is-back { top: 18px; height: 146px; }
 .creation-empty-workspace .creation-empty-art-frame.is-main { top: 0; height: 182px; }
 .creation-empty-workspace .creation-empty-art-frame.is-front { top: 24px; height: 146px; }
 
-.creation-empty-workspace .creation-chat-intro { margin-top: 24px; margin-bottom: 18px; }
+.creation-empty-workspace .creation-chat-intro { margin: 0 auto 18px; }
 
-.creation-empty-workspace > .creation-empty-suggest { margin: 26px auto auto; }
+.creation-empty-workspace > .creation-empty-suggest { margin: 26px auto 0; }
 
 @media (max-width: 800px) {
     .creation-empty-workspace > .creation-empty-art { height: 168px; margin-bottom: 16px; }
     .creation-empty-workspace .creation-empty-art-frame.is-back { top: 14px; height: 122px; }
     .creation-empty-workspace .creation-empty-art-frame.is-main { top: 0; height: 152px; }
     .creation-empty-workspace .creation-empty-art-frame.is-front { top: 18px; height: 122px; }
-    .creation-empty-workspace .creation-chat-intro { margin-top: 18px; margin-bottom: 14px; }
+    .creation-empty-workspace .creation-chat-intro { margin-top: 0; margin-bottom: 14px; }
     .creation-empty-workspace > .creation-empty-suggest { margin-top: 20px; }
 }
 

--- a/web/test/admin-ui-regressions.test.ts
+++ b/web/test/admin-ui-regressions.test.ts
@@ -45,7 +45,10 @@ test("analytics keeps fixed range presets distinct and uses enabled channel mode
     expect(source).toContain("onChange={handlePricingModelChange}");
     expect(source).toContain('hasOwnProperty.call(changedValues, "model")');
     expect(source).toContain('if (matchingChannels.length) form.setFieldValue("channelId", matchingChannels[0].id)');
-    expect(source).toContain("const sourceChannels = channels.filter((channel) => channel.enabled !== false)");
+    expect(source).toContain("const sourceChannels = channels.filter(");
+    expect(source).toContain('Form.useWatch("channelId", form)');
+    expect(source).toContain("pricingChannelId");
+    expect(source).toContain("channel.id === pricingChannelId");
     expect(source).toContain('inputMode="decimal"');
     expect(source).toContain('className="admin-analytics-price-input"');
     expect(source).toContain('className="admin-analytics-price-field"');

--- a/web/test/create-empty-layout.test.ts
+++ b/web/test/create-empty-layout.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+test("create empty state keeps the banner and composer in document flow", () => {
+    const styles = readFileSync(resolve(import.meta.dir, "../src/styles/globals.css"), "utf8");
+    const layoutStart = styles.indexOf("/* 空态布局收敛：保持图片区、文案和输入区的文档流顺序");
+    const layoutEnd = styles.indexOf("/* ===== 素材库", layoutStart);
+    const layout = styles.slice(layoutStart, layoutEnd);
+
+    expect(layoutStart).toBeGreaterThanOrEqual(0);
+    expect(layoutEnd).toBeGreaterThan(layoutStart);
+    expect(layout).toContain("justify-content: flex-start;");
+    expect(layout).toContain("flex: 0 0 auto;");
+    expect(layout).toContain("margin: 0 auto 20px;");
+    expect(layout).not.toContain("margin: auto auto 20px;");
+    expect(layout).not.toContain("margin: 26px auto auto;");
+});


### PR DESCRIPTION
## 改动摘要

这次主要修复了两个使用上的问题。

第一，修复了数据梗概深度分析里的模型价格配置：

- 选择模型后会自动匹配对应渠道，不需要再手动选一次渠道
- 选择渠道后会自动筛选该渠道下已启用的模型
- 模型价格配置区域可以正常选择和编辑模型
- 不影响模型渠道管理页面

第二，修复了 `/create` 创作页面的响应式布局：

- 修复浏览器窗口大小变化时，图片、标题和输入框互相覆盖的问题
- 图片区、创作说明、输入框和建议卡现在保持稳定的上下排列
- 窗口高度不足时可以正常滚动查看，不会把输入框挤到图片上面
- 移动端布局也保留了响应式适配

## 风险与兼容性

本次只涉及前端筛选逻辑和页面布局，不修改数据库结构、接口协议、权限、费用计算或启动配置。

`.local/`、本地启动脚本、临时文件和本机配置没有提交。

## 验证

- 已手动验证 `/create` 页面窗口缩放布局，没有继续出现重叠
- `17 pass，0 fail`
- TypeScript 检查通过
- `git diff --check` 通过
- 保留上游署名和许可证通知