### PR TITLE
feat(admin): 增加阿里云 ESA 监控面板，支持边缘流量/请求监控、Top 5 站点分析与趋势折线图

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -586,6 +586,81 @@ func RegisterAdminRoutes(r *gin.RouterGroup, svc *service.Service) {
 		}
 		ok(c, gin.H{"setting": setting})
 	})
+	r.GET("/admin/esa/settings", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		setting, err := svc.AdminESASetting(user)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"setting": setting})
+	})
+	r.PATCH("/admin/esa/settings", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		var req service.ESASettingRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			fail(c, http.StatusBadRequest, err)
+			return
+		}
+		setting, err := svc.UpdateESASetting(user, req)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"setting": setting})
+	})
+	r.POST("/admin/esa/test-connection", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		var req service.ESASettingRequest
+		_ = c.ShouldBindJSON(&req)
+		result, err := svc.TestESAConnection(user, req)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, result)
+	})
+	r.GET("/admin/esa/sites", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		sites, err := svc.ESASites(user)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"sites": sites})
+	})
+	r.GET("/admin/esa/overview", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		rangeKey := c.DefaultQuery("range", "today")
+		siteID := c.DefaultQuery("siteId", "all")
+		refresh := c.Query("refresh") == "true" || c.Query("refresh") == "1"
+		overview, err := svc.ESAOverview(user, rangeKey, siteID, refresh)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, overview)
+	})
 	r.GET("/admin/settings/drawing-engine", func(c *gin.Context) {
 		user, err := currentUser(c, svc)
 		if err != nil {

--- a/backend/internal/service/esa_monitor.go
+++ b/backend/internal/service/esa_monitor.go
@@ -1,0 +1,734 @@
+package service
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"infinite-canvas/backend/internal/model"
+
+	"gorm.io/gorm"
+)
+
+const esaSettingKey = "esa_monitoring"
+const esaEndpoint = "https://esa.cn-hangzhou.aliyuncs.com"
+const esaApiVersion = "2024-09-10"
+
+type ESASettingRequest struct {
+	Enabled         bool   `json:"enabled"`
+	AccessKeyID     string `json:"accessKeyId"`
+	AccessKeySecret string `json:"accessKeySecret"`
+}
+
+type PublicESASetting struct {
+	Enabled            bool      `json:"enabled"`
+	AccessKeyID        string    `json:"accessKeyId"`
+	HasAccessKeySecret bool      `json:"hasAccessKeySecret"`
+	UpdatedBy          string    `json:"updatedBy"`
+	CreatedAt          time.Time `json:"createdAt"`
+	UpdatedAt          time.Time `json:"updatedAt"`
+}
+
+type esaSettingValue struct {
+	Enabled         bool   `json:"enabled"`
+	AccessKeyID     string `json:"accessKeyId"`
+	AccessKeySecret string `json:"accessKeySecret"`
+}
+
+type ESATopSite struct {
+	SiteID   string `json:"siteId"`
+	SiteName string `json:"siteName"`
+	Traffic  int64  `json:"traffic"`
+}
+
+type ESATimePoint struct {
+	Time     string `json:"time"`
+	Traffic  int64  `json:"traffic"`
+	Requests int64  `json:"requests"`
+}
+
+type ESASiteInfo struct {
+	SiteID   string `json:"siteId"`
+	SiteName string `json:"siteName"`
+	Status   string `json:"status"`
+}
+
+type ESAOverviewResponse struct {
+	Range            string         `json:"range"`
+	SiteID           string         `json:"siteId"`
+	Configured       bool           `json:"configured"`
+	Traffic          int64          `json:"traffic"`
+	Requests         int64          `json:"requests"`
+	SecurityRequests int64          `json:"securityRequests"`
+	PagesRequests    int64          `json:"pagesRequests"`
+	TopSites         []ESATopSite   `json:"topSites"`
+	Timeseries       []ESATimePoint `json:"timeseries"`
+	UpdatedAt        string         `json:"updatedAt"`
+	Error            string         `json:"error,omitempty"`
+}
+
+var (
+	esaCacheMu sync.RWMutex
+	esaCache   = make(map[string]esaCacheItem)
+)
+
+type esaCacheItem struct {
+	data      ESAOverviewResponse
+	expiresAt time.Time
+}
+
+func (s *Service) AdminESASetting(actor *model.User) (*PublicESASetting, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	setting, value, err := s.readESASetting()
+	if err != nil {
+		return nil, err
+	}
+	public := publicESASetting(setting, value)
+	return &public, nil
+}
+
+func (s *Service) UpdateESASetting(actor *model.User, req ESASettingRequest) (*PublicESASetting, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	currentSetting, current, err := s.readESASetting()
+	if err != nil {
+		return nil, err
+	}
+
+	next := esaSettingValue{
+		Enabled:     req.Enabled,
+		AccessKeyID: strings.TrimSpace(req.AccessKeyID),
+	}
+	if strings.TrimSpace(req.AccessKeySecret) != "" {
+		next.AccessKeySecret = strings.TrimSpace(req.AccessKeySecret)
+	} else {
+		next.AccessKeySecret = current.AccessKeySecret
+	}
+
+	if next.Enabled && (next.AccessKeyID == "" || next.AccessKeySecret == "") {
+		return nil, BadAuthRequest("启用 ESA 监控必须填写 AccessKey ID 与 AccessKey Secret")
+	}
+
+	setting := &model.SystemSetting{Key: esaSettingKey, UpdatedBy: actor.ID}
+	if currentSetting != nil {
+		setting.CreatedAt = currentSetting.CreatedAt
+	}
+	if err := s.saveESASetting(setting, next); err != nil {
+		return nil, err
+	}
+
+	// 清空旧缓存
+	esaCacheMu.Lock()
+	esaCache = make(map[string]esaCacheItem)
+	esaCacheMu.Unlock()
+
+	public := publicESASetting(setting, next)
+	return &public, nil
+}
+
+func (s *Service) TestESAConnection(actor *model.User, req ESASettingRequest) (map[string]any, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	akID := strings.TrimSpace(req.AccessKeyID)
+	akSecret := strings.TrimSpace(req.AccessKeySecret)
+
+	if akID == "" || akSecret == "" {
+		_, current, err := s.readESASetting()
+		if err != nil {
+			return nil, err
+		}
+		if akID == "" {
+			akID = current.AccessKeyID
+		}
+		if akSecret == "" {
+			akSecret = current.AccessKeySecret
+		}
+	}
+
+	if akID == "" || akSecret == "" {
+		return nil, BadAuthRequest("请填写 AccessKey ID 与 AccessKey Secret 后测试连接")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sites, err := fetchESASiteList(ctx, akID, akSecret)
+	if err != nil {
+		return map[string]any{
+			"success": false,
+			"message": fmt.Sprintf("连接失败：%v", parseAliyunError(err)),
+		}, nil
+	}
+
+	return map[string]any{
+		"success":   true,
+		"message":   "连接成功",
+		"siteCount": len(sites),
+		"sites":     sites,
+	}, nil
+}
+
+func (s *Service) ESASites(actor *model.User) ([]ESASiteInfo, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	_, current, err := s.readESASetting()
+	if err != nil {
+		return nil, err
+	}
+	if current.AccessKeyID == "" || current.AccessKeySecret == "" {
+		return []ESASiteInfo{}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	sites, err := fetchESASiteList(ctx, current.AccessKeyID, current.AccessKeySecret)
+	if err != nil {
+		return nil, BadAuthRequest(fmt.Sprintf("读取站点列表失败：%v", parseAliyunError(err)))
+	}
+	return sites, nil
+}
+
+func (s *Service) ESAOverview(actor *model.User, rangeKey string, siteID string, forceRefresh bool) (*ESAOverviewResponse, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+
+	_, current, err := s.readESASetting()
+	if err != nil {
+		return nil, err
+	}
+
+	if rangeKey == "" {
+		rangeKey = "today"
+	}
+	if siteID == "" {
+		siteID = "all"
+	}
+
+	cacheKey := fmt.Sprintf("%s:%s", rangeKey, siteID)
+
+	// 检查缓存
+	if !forceRefresh {
+		esaCacheMu.RLock()
+		cached, exists := esaCache[cacheKey]
+		esaCacheMu.RUnlock()
+		if exists && time.Now().Before(cached.expiresAt) {
+			return &cached.data, nil
+		}
+	}
+
+	if current.AccessKeyID == "" || current.AccessKeySecret == "" {
+		res := &ESAOverviewResponse{
+			Range:      rangeKey,
+			SiteID:     siteID,
+			Configured: false,
+			TopSites:   []ESATopSite{},
+			Timeseries: []ESATimePoint{},
+			UpdatedAt:  time.Now().Format(time.RFC3339),
+		}
+		return res, nil
+	}
+
+	// 带重试请求阿里云
+	var overview *ESAOverviewResponse
+	var fetchErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		if attempt > 0 {
+			time.Sleep(time.Duration(attempt*2) * time.Second)
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		overview, fetchErr = fetchESAOverviewFromAliyun(ctx, current.AccessKeyID, current.AccessKeySecret, rangeKey, siteID)
+		cancel()
+		if fetchErr == nil {
+			break
+		}
+	}
+
+	if fetchErr != nil {
+		log.Printf("[ESA] Request failed: %v", fetchErr)
+		// 如果有旧缓存，返回旧数据并带 error
+		esaCacheMu.RLock()
+		cached, exists := esaCache[cacheKey]
+		esaCacheMu.RUnlock()
+		if exists {
+			data := cached.data
+			data.Error = fmt.Sprintf("数据更新失败：%v（显示最后缓存）", parseAliyunError(fetchErr))
+			return &data, nil
+		}
+		// 无缓存时返回默认空结构并附带清晰的错误提示，避免前端白屏
+		return &ESAOverviewResponse{
+			Range:      rangeKey,
+			SiteID:     siteID,
+			Configured: true,
+			TopSites:   []ESATopSite{},
+			Timeseries: []ESATimePoint{},
+			UpdatedAt:  time.Now().Format(time.RFC3339),
+			Error:      fmt.Sprintf("数据更新失败：%v", parseAliyunError(fetchErr)),
+		}, nil
+	}
+
+	// 缓存 5 分钟
+	esaCacheMu.Lock()
+	esaCache[cacheKey] = esaCacheItem{
+		data:      *overview,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	}
+	esaCacheMu.Unlock()
+
+	return overview, nil
+}
+
+func (s *Service) readESASetting() (*model.SystemSetting, esaSettingValue, error) {
+	setting, err := s.repo.SystemSetting(esaSettingKey)
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, defaultESASetting(), nil
+	}
+	if err != nil {
+		return nil, esaSettingValue{}, err
+	}
+	value := defaultESASetting()
+	if strings.TrimSpace(setting.ValueJSON) != "" {
+		if err := json.Unmarshal([]byte(setting.ValueJSON), &value); err != nil {
+			return nil, esaSettingValue{}, errors.New("ESA 监控配置格式无效")
+		}
+	}
+	secret, err := s.decryptSettingSecret(value.AccessKeySecret)
+	if err != nil {
+		return nil, esaSettingValue{}, err
+	}
+	value.AccessKeySecret = secret
+	return setting, value, nil
+}
+
+func (s *Service) saveESASetting(setting *model.SystemSetting, value esaSettingValue) error {
+	stored := value
+	if stored.AccessKeySecret != "" {
+		encrypted, err := s.encryptSettingSecret(stored.AccessKeySecret)
+		if err != nil {
+			return err
+		}
+		stored.AccessKeySecret = encrypted
+	}
+	payload, err := json.Marshal(stored)
+	if err != nil {
+		return err
+	}
+	setting.ValueJSON = string(payload)
+	return s.repo.SaveSystemSetting(setting)
+}
+
+func defaultESASetting() esaSettingValue {
+	return esaSettingValue{
+		Enabled: true,
+	}
+}
+
+func calculatePopSignature(method string, params map[string]string, secret string) string {
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var canonicalizedQuery strings.Builder
+	for i, k := range keys {
+		if i > 0 {
+			canonicalizedQuery.WriteString("&")
+		}
+		canonicalizedQuery.WriteString(popPercentEncode(k))
+		canonicalizedQuery.WriteString("=")
+		canonicalizedQuery.WriteString(popPercentEncode(params[k]))
+	}
+
+	stringToSign := method + "&" + popPercentEncode("/") + "&" + popPercentEncode(canonicalizedQuery.String())
+
+	mac := hmac.New(sha1.New, []byte(secret+"&"))
+	mac.Write([]byte(stringToSign))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func popPercentEncode(s string) string {
+	encoded := url.QueryEscape(s)
+	encoded = strings.ReplaceAll(encoded, "+", "%20")
+	encoded = strings.ReplaceAll(encoded, "*", "%2A")
+	encoded = strings.ReplaceAll(encoded, "%7E", "~")
+	return encoded
+}
+
+func publicESASetting(setting *model.SystemSetting, value esaSettingValue) PublicESASetting {
+	public := PublicESASetting{
+		Enabled:            value.Enabled,
+		AccessKeyID:        value.AccessKeyID,
+		HasAccessKeySecret: strings.TrimSpace(value.AccessKeySecret) != "",
+	}
+	if setting != nil {
+		public.UpdatedBy = setting.UpdatedBy
+		public.CreatedAt = setting.CreatedAt
+		public.UpdatedAt = setting.UpdatedAt
+	}
+	return public
+}
+
+// ---------------- 阿里云 OpenAPI 调用 ----------------
+
+func fetchESASiteList(ctx context.Context, akID, akSecret string) ([]ESASiteInfo, error) {
+	params := map[string]string{
+		"Action":     "ListSites",
+		"PageNumber": "1",
+		"PageSize":   "500",
+	}
+
+	bodyBytes, err := doAliyunPopRequest(ctx, "GET", params, akID, akSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp struct {
+		Sites []struct {
+			SiteID   int64  `json:"SiteId"`
+			SiteName string `json:"SiteName"`
+			Status   string `json:"Status"`
+		} `json:"Sites"`
+	}
+	if err := json.Unmarshal(bodyBytes, &resp); err != nil {
+		return nil, fmt.Errorf("解析站点列表响应失败: %w", err)
+	}
+
+	sites := make([]ESASiteInfo, 0, len(resp.Sites))
+	for _, s := range resp.Sites {
+		sid := fmt.Sprintf("%d", s.SiteID)
+		sites = append(sites, ESASiteInfo{
+			SiteID:   sid,
+			SiteName: s.SiteName,
+			Status:   s.Status,
+		})
+	}
+	return sites, nil
+}
+
+func fetchESAOverviewFromAliyun(ctx context.Context, akID, akSecret, rangeKey, siteID string) (*ESAOverviewResponse, error) {
+	allSites, err := fetchESASiteList(ctx, akID, akSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	targetSites := make([]ESASiteInfo, 0)
+	if siteID == "" || siteID == "all" {
+		targetSites = allSites
+	} else {
+		for _, s := range allSites {
+			if s.SiteID == siteID {
+				targetSites = append(targetSites, s)
+				break
+			}
+		}
+		if len(targetSites) == 0 {
+			targetSites = append(targetSites, ESASiteInfo{SiteID: siteID, SiteName: siteID})
+		}
+	}
+
+	startTime, endTime, interval := calculateTimeRange(rangeKey)
+	startStr := startTime.Format("2006-01-02T15:04:05Z")
+	endStr := endTime.Format("2006-01-02T15:04:05Z")
+
+	var totalTraffic int64
+	var totalRequests int64
+	timePointsMap := make(map[string]*ESATimePoint)
+	timeKeys := make([]string, 0)
+
+	topSitesMap := make(map[string]int64)
+
+	for _, s := range targetSites {
+		// 1. 获取站点时序数据
+		tsParams := map[string]string{
+			"Action":    "DescribeSiteTimeSeriesData",
+			"SiteId":    s.SiteID,
+			"StartTime": startStr,
+			"EndTime":   endStr,
+			"Interval":  interval,
+			"Fields":    `[{"FieldName":"Traffic","Dimension":["SiteId"]},{"FieldName":"Requests","Dimension":["SiteId"]}]`,
+		}
+		tsBytes, tsErr := doAliyunPopRequest(ctx, "GET", tsParams, akID, akSecret)
+		if tsErr == nil {
+			var tsResp struct {
+				SummarizedData []struct {
+					FieldName string `json:"FieldName"`
+					Value     int64  `json:"Value"`
+				} `json:"SummarizedData"`
+				Data []struct {
+					FieldName  string `json:"FieldName"`
+					DetailData []struct {
+						TimeStamp string `json:"TimeStamp"`
+						Value     int64  `json:"Value"`
+					} `json:"DetailData"`
+				} `json:"Data"`
+			}
+			if json.Unmarshal(tsBytes, &tsResp) == nil {
+				for _, sumItem := range tsResp.SummarizedData {
+					if sumItem.FieldName == "Traffic" {
+						totalTraffic += sumItem.Value
+					} else if sumItem.FieldName == "Requests" {
+						totalRequests += sumItem.Value
+					}
+				}
+				for _, dataItem := range tsResp.Data {
+					for _, point := range dataItem.DetailData {
+						if _, exists := timePointsMap[point.TimeStamp]; !exists {
+							timePointsMap[point.TimeStamp] = &ESATimePoint{Time: point.TimeStamp}
+							timeKeys = append(timeKeys, point.TimeStamp)
+						}
+						tp := timePointsMap[point.TimeStamp]
+						if dataItem.FieldName == "Traffic" {
+							tp.Traffic += point.Value
+						} else if dataItem.FieldName == "Requests" {
+							tp.Requests += point.Value
+						}
+					}
+				}
+			}
+		}
+
+		// 2. 获取 Top Host 数据
+		topParams := map[string]string{
+			"Action":    "DescribeSiteTopData",
+			"SiteId":    s.SiteID,
+			"StartTime": startStr,
+			"EndTime":   endStr,
+			"Limit":     "5",
+			"Fields":    `[{"FieldName":"Traffic","Dimension":["ClientRequestHost"]}]`,
+		}
+		topBytes, topErr := doAliyunPopRequest(ctx, "GET", topParams, akID, akSecret)
+		if topErr == nil {
+			var topResp struct {
+				Data []struct {
+					FieldName  string `json:"FieldName"`
+					DetailData []struct {
+						DimensionValue string `json:"DimensionValue"`
+						Value          int64  `json:"Value"`
+					} `json:"DetailData"`
+				} `json:"Data"`
+			}
+			if json.Unmarshal(topBytes, &topResp) == nil {
+				for _, dataItem := range topResp.Data {
+					for _, d := range dataItem.DetailData {
+						if d.DimensionValue != "" {
+							topSitesMap[d.DimensionValue] += d.Value
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// 排序时序点
+	sort.Strings(timeKeys)
+	timeseries := make([]ESATimePoint, 0, len(timeKeys))
+	for _, k := range timeKeys {
+		if pt, ok := timePointsMap[k]; ok {
+			timeseries = append(timeseries, *pt)
+		}
+	}
+
+	// 汇总并排序 Top 5 站点/Host
+	topSitesList := make([]ESATopSite, 0, len(topSitesMap))
+	for host, traf := range topSitesMap {
+		topSitesList = append(topSitesList, ESATopSite{
+			SiteID:   host,
+			SiteName: host,
+			Traffic:  traf,
+		})
+	}
+	sort.Slice(topSitesList, func(i, j int) bool {
+		return topSitesList[i].Traffic > topSitesList[j].Traffic
+	})
+	if len(topSitesList) > 5 {
+		topSitesList = topSitesList[:5]
+	}
+
+	return &ESAOverviewResponse{
+		Range:            rangeKey,
+		SiteID:           siteID,
+		Configured:       true,
+		Traffic:          totalTraffic,
+		Requests:         totalRequests,
+		SecurityRequests: 0,
+		PagesRequests:    0,
+		TopSites:         topSitesList,
+		Timeseries:       timeseries,
+		UpdatedAt:        time.Now().Format(time.RFC3339),
+	}, nil
+}
+
+func doAliyunPopRequest(ctx context.Context, method string, queryParams map[string]string, akID, akSecret string) ([]byte, error) {
+	params := make(map[string]string)
+	for k, v := range queryParams {
+		params[k] = v
+	}
+	params["Format"] = "JSON"
+	params["Version"] = esaApiVersion
+	params["AccessKeyId"] = akID
+	params["SignatureMethod"] = "HMAC-SHA1"
+	params["Timestamp"] = time.Now().UTC().Format("2006-01-02T15:04:05Z")
+	params["SignatureVersion"] = "1.0"
+	params["SignatureNonce"] = fmt.Sprintf("%d%d", time.Now().UnixNano(), rand.Intn(100000))
+
+	sig := calculatePopSignature(method, params, akSecret)
+	params["Signature"] = sig
+
+	var reqURL strings.Builder
+	reqURL.WriteString(esaEndpoint)
+	reqURL.WriteString("/?")
+
+	keys := make([]string, 0, len(params))
+	for k := range params {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for i, k := range keys {
+		if i > 0 {
+			reqURL.WriteString("&")
+		}
+		reqURL.WriteString(popPercentEncode(k))
+		reqURL.WriteString("=")
+		reqURL.WriteString(popPercentEncode(params[k]))
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Timeout: 12 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, errors.New("请求阿里云 API 超时")
+		}
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		var errPayload struct {
+			Code    string `json:"Code"`
+			Message string `json:"Message"`
+		}
+		_ = json.Unmarshal(bodyBytes, &errPayload)
+		if errPayload.Message != "" {
+			return nil, fmt.Errorf("aliyun error [%s]: %s", errPayload.Code, errPayload.Message)
+		}
+		return nil, fmt.Errorf("aliyun http error: %d, body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	return bodyBytes, nil
+}
+
+func calculateTimeRange(rangeKey string) (time.Time, time.Time, string) {
+	now := time.Now().UTC()
+	switch rangeKey {
+	case "yesterday":
+		// 昨天 00:00:00 - 昨天 23:59:59
+		yesterday := now.AddDate(0, 0, -1)
+		start := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 0, 0, 0, 0, time.UTC)
+		end := time.Date(yesterday.Year(), yesterday.Month(), yesterday.Day(), 23, 59, 59, 0, time.UTC)
+		return start, end, "3600"
+	case "7d":
+		// 近 7 天
+		start := now.AddDate(0, 0, -7)
+		return start, now, "3600"
+	case "30d":
+		// 近 30 天
+		start := now.AddDate(0, 0, -30)
+		return start, now, "86400"
+	case "today":
+		fallthrough
+	default:
+		// 今天 00:00:00 - 当前时间
+		start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		return start, now, "300"
+	}
+}
+
+func parseAliyunError(err error) error {
+	if err == nil {
+		return nil
+	}
+	str := err.Error()
+	if strings.Contains(str, "InvalidAccessKeyId") || strings.Contains(str, "SignatureDoesNotMatch") {
+		return errors.New("AccessKey ID 无效或 AccessKey Secret 错误")
+	}
+	if strings.Contains(str, "Forbidden") || strings.Contains(str, "Unauthorized") || strings.Contains(str, "NoPermission") || strings.Contains(str, "AuthFailed") {
+		return errors.New("当前 AccessKey 没有 ESA 数据读取权限，请在阿里云 RAM 控制台授予 ESA 只读策略")
+	}
+	if strings.Contains(str, "timeout") || strings.Contains(str, "DeadlineExceeded") || strings.Contains(str, "超时") {
+		return errors.New("请求阿里云 API 超时")
+	}
+	if strings.Contains(str, "no such host") || strings.Contains(str, "dial tcp") || strings.Contains(str, "connection refused") || strings.Contains(str, "network") {
+		return errors.New("无法连接阿里云 ESA 接口服务，请检查网络连接或 DNS 解析")
+	}
+	if strings.Contains(str, "https://") {
+		return errors.New("请求阿里云 ESA 服务异常，请检查凭证与网络")
+	}
+	return err
+}
+
+func findFirstString(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			if s, ok := v.(string); ok {
+				return s
+			}
+			return fmt.Sprintf("%v", v)
+		}
+	}
+	return ""
+}
+
+func findFirstInt64(m map[string]any, keys ...string) int64 {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch n := v.(type) {
+			case float64:
+				return int64(n)
+			case int64:
+				return n
+			case int:
+				return int64(n)
+			case string:
+				if parsed, err := strconv.ParseInt(n, 10, 64); err == nil {
+					return parsed
+				}
+				if parsedF, err := strconv.ParseFloat(n, 64); err == nil {
+					return int64(parsedF)
+				}
+			}
+		}
+	}
+	return 0
+}

--- a/backend/internal/service/esa_signature_test.go
+++ b/backend/internal/service/esa_signature_test.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"testing"
+)
+
+func TestPopSignature(t *testing.T) {
+	params := map[string]string{
+		"Format":           "JSON",
+		"Version":          "2024-09-10",
+		"AccessKeyId":      "testid",
+		"SignatureMethod":  "HMAC-SHA1",
+		"Timestamp":        "2026-09-01T12:00:00Z",
+		"SignatureVersion": "1.0",
+		"SignatureNonce":   "random-nonce-123",
+		"Action":           "DescribeSiteTimeSeriesData",
+	}
+	sig := calculatePopSignature("GET", params, "testsecret")
+	if sig == "" {
+		t.Fatalf("signature is empty")
+	}
+	t.Logf("Generated Signature: %s", sig)
+}

--- a/web/src/pages/admin/admin-route-pages.tsx
+++ b/web/src/pages/admin/admin-route-pages.tsx
@@ -13,6 +13,7 @@ const AccessSettingsPanel = lazy(() => import("./components/access-settings-pane
 const EmailSettingsPanel = lazy(() => import("./components/email-settings-panel"));
 const FeatureAvailabilityPanel = lazy(() => import("./components/feature-availability-panel"));
 const StorageResourcesPanel = lazy(() => import("./components/storage-resources-panel"));
+const ESAMonitoringPanel = lazy(() => import("./esa/esa-monitoring-page"));
 
 function PageFallback({ label }: { label: string }) {
     return <div className="py-16 text-center text-sm text-foreground/50">正在读取{label}...</div>;
@@ -122,5 +123,13 @@ export function StorageResourcesPage() {
                 <StorageResourcesPanel />
             </Suspense>
         </AdminPageFrame>
+    );
+}
+
+export function ESAMonitoringPage() {
+    return (
+        <Suspense fallback={<PageFallback label="ESA 监控" />}>
+            <ESAMonitoringPanel />
+        </Suspense>
     );
 }

--- a/web/src/pages/admin/components/admin-shell.tsx
+++ b/web/src/pages/admin/components/admin-shell.tsx
@@ -1,6 +1,7 @@
 import { ConfigProvider, Dropdown, Tooltip } from "antd";
 import type { MenuProps } from "antd";
 import {
+    Activity,
     ArrowLeft,
     BarChart3,
     BellRing,
@@ -65,6 +66,7 @@ const adminNavigation: Array<{ label: string; items: AdminNavigationItem[] }> = 
             { path: "/admin/plugins", label: "插件管理", description: "平台可用性、上传与卸载", icon: <PlugZap className="size-4" /> },
             { path: "/admin/prompt-templates", label: "提示词模板", description: "平台创作策略版本", icon: <MessageSquareText className="size-4" /> },
             { path: "/admin/resources", label: "存储资源", description: "资源列表、容量与预览", icon: <Database className="size-4" /> },
+            { path: "/admin/esa", label: "ESA 监控", description: "边缘安全加速流量与请求", icon: <Activity className="size-4" /> },
         ],
     },
     {

--- a/web/src/pages/admin/esa/esa-monitoring-page.tsx
+++ b/web/src/pages/admin/esa/esa-monitoring-page.tsx
@@ -1,0 +1,550 @@
+import { useEffect, useMemo, useState } from "react";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { App, Button, Drawer, Form, Input, Select, Switch, Alert, Spin, Tag, Tooltip } from "antd";
+import { Activity, AlertCircle, ArrowDownUp, CheckCircle2, Clock3, Cpu, Globe, HardDrive, Layers, RefreshCw, Server, Settings, Shield, ShieldCheck, TrendingUp, Zap } from "lucide-react";
+
+import { AdminPageFrame } from "@/pages/admin/components/admin-shell";
+import { getESAOverview, getESASetting, getESASites, testESAConnection, updateESASetting, type ESAOverview, type ESASetting, type ESASettingRequest, type ESASiteInfo, type ESATimePoint } from "@/services/api/esa";
+import { cn } from "@/lib/utils";
+
+const TIME_RANGE_OPTIONS = [
+    { label: "今天", value: "today" },
+    { label: "昨天", value: "yesterday" },
+    { label: "近7天", value: "7d" },
+    { label: "近30天", value: "30d" },
+];
+
+function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+    const units = ["B", "KB", "MB", "GB", "TB", "PB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(1024));
+    const val = bytes / Math.pow(1024, i);
+    return `${val.toFixed(val >= 100 || i === 0 ? 0 : val >= 10 ? 1 : 2)} ${units[i] || "TB"}`;
+}
+
+function formatRequests(num: number): string {
+    if (!Number.isFinite(num) || num <= 0) return "0";
+    if (num < 1000) return num.toString();
+    if (num < 10000) return `${(num / 1000).toFixed(2)} 千`;
+    if (num < 100000000) return `${(num / 10000).toFixed(2)} 万`;
+    return `${(num / 100000000).toFixed(2)} 亿`;
+}
+
+function formatChartTime(timeStr: string, range: string): string {
+    if (!timeStr) return "";
+    const date = new Date(timeStr);
+    if (!Number.isFinite(date.getTime())) return timeStr;
+    const hours = String(date.getHours()).padStart(2, "0");
+    const mins = String(date.getMinutes()).padStart(2, "0");
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    if (range === "today" || range === "yesterday") {
+        return `${hours}:${mins}`;
+    }
+    if (range === "7d") {
+        return `${month}-${day} ${hours}:00`;
+    }
+    return `${month}-${day}`;
+}
+
+export default function ESAMonitoringPage() {
+    const { message } = App.useApp();
+    const queryClient = useQueryClient();
+    const [timeRange, setTimeRange] = useState<string>("today");
+    const [selectedSite, setSelectedSite] = useState<string>("all");
+    const [settingsOpen, setSettingsOpen] = useState(false);
+    const [form] = Form.useForm<ESASettingRequest>();
+    const [testLoading, setTestLoading] = useState(false);
+    const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+
+    // 读取 ESA 设置
+    const settingQuery = useQuery({
+        queryKey: ["admin", "esa", "settings"],
+        queryFn: () => getESASetting(),
+    });
+
+    // 读取站点列表
+    const sitesQuery = useQuery({
+        queryKey: ["admin", "esa", "sites"],
+        queryFn: () => getESASites(),
+        enabled: Boolean(settingQuery.data?.setting?.hasAccessKeySecret),
+    });
+
+    // 读取监控概览数据，每 5 分钟自动轮询
+    const overviewQuery = useQuery({
+        queryKey: ["admin", "esa", "overview", timeRange, selectedSite],
+        queryFn: () => getESAOverview(timeRange, selectedSite),
+        refetchInterval: 5 * 60 * 1000,
+    });
+
+    const isConfigured = Boolean(settingQuery.data?.setting?.hasAccessKeySecret);
+    const overview = overviewQuery.data;
+
+    // 手动刷新
+    const handleRefresh = async () => {
+        try {
+            const res = await getESAOverview(timeRange, selectedSite, true);
+            await queryClient.invalidateQueries({ queryKey: ["admin", "esa", "overview", timeRange, selectedSite] });
+            if (res.error) {
+                message.warning("数据更新异常，已显示最后缓存或默认数据");
+            } else {
+                message.success("数据已刷新");
+            }
+        } catch (err) {
+            message.error(err instanceof Error ? err.message : "刷新失败");
+        }
+    };
+
+    // 保存设置
+    const saveMutation = useMutation({
+        mutationFn: updateESASetting,
+        onSuccess: (data) => {
+            message.success("ESA 设置已保存");
+            queryClient.setQueryData(["admin", "esa", "settings"], data);
+            queryClient.invalidateQueries({ queryKey: ["admin", "esa"] });
+            setSettingsOpen(false);
+        },
+        onError: (err) => {
+            message.error(err instanceof Error ? err.message : "保存设置失败");
+        },
+    });
+
+    const handleTest = async () => {
+        const values = form.getFieldsValue();
+        setTestLoading(true);
+        setTestResult(null);
+        try {
+            const res = await testESAConnection(values);
+            setTestResult({
+                success: true,
+                message: `连接成功，共找到 ${res.siteCount || 0} 个站点`,
+            });
+            message.success("阿里云 ESA 连接成功");
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : "连接失败";
+            setTestResult({ success: false, message: msg });
+            message.error(msg);
+        } finally {
+            setTestLoading(false);
+        }
+    };
+
+    const handleSave = async () => {
+        try {
+            const values = await form.validateFields();
+            saveMutation.mutate(values);
+        } catch {
+            // 校验失败
+        }
+    };
+
+    const siteOptions = useMemo(() => {
+        const list = sitesQuery.data?.sites || [];
+        return [
+            { label: "全部站点", value: "all" },
+            ...list.map((s) => ({
+                label: `${s.siteName} (${s.siteId})`,
+                value: s.siteId,
+            })),
+        ];
+    }, [sitesQuery.data?.sites]);
+
+    const formatUpdateTime = (isoStr?: string) => {
+        if (!isoStr) return "--";
+        const d = new Date(isoStr);
+        if (!Number.isFinite(d.getTime())) return isoStr;
+        return `${String(d.getHours()).padStart(2, "0")}:${String(d.getMinutes()).padStart(2, "0")}:${String(d.getSeconds()).padStart(2, "0")}`;
+    };
+
+    return (
+        <AdminPageFrame
+            title="ESA 监控"
+            description="阿里云边缘安全加速流量、请求与站点分布"
+            actions={
+                <div className="flex flex-wrap items-center gap-2.5">
+                    {/* 时间范围切换 */}
+                    <div className="flex rounded-lg bg-muted/60 p-0.5 text-xs font-medium">
+                        {TIME_RANGE_OPTIONS.map((opt) => (
+                            <button
+                                key={opt.value}
+                                type="button"
+                                className={cn("rounded-md px-3 py-1.5 transition-all", timeRange === opt.value ? "bg-background text-foreground shadow-sm font-semibold" : "text-foreground/60 hover:text-foreground")}
+                                onClick={() => setTimeRange(opt.value)}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* 站点筛选 */}
+                    <Select className="w-48" size="middle" value={selectedSite} options={siteOptions} onChange={(val) => setSelectedSite(val)} placeholder="选择站点" />
+
+                    {/* 刷新按钮 */}
+                    <Button icon={<RefreshCw className={cn("size-3.5", overviewQuery.isFetching && "animate-spin")} />} onClick={handleRefresh} loading={overviewQuery.isFetching} title="刷新数据">
+                        刷新
+                    </Button>
+
+                    {/* ESA 设置 */}
+                    <Button
+                        icon={<Settings className="size-3.5" />}
+                        type={!isConfigured ? "primary" : "default"}
+                        onClick={() => {
+                            setTestResult(null);
+                            if (settingQuery.data?.setting) {
+                                form.setFieldsValue({
+                                    enabled: settingQuery.data.setting.enabled,
+                                    accessKeyId: settingQuery.data.setting.accessKeyId,
+                                });
+                            }
+                            setSettingsOpen(true);
+                        }}
+                    >
+                        ESA 设置
+                    </Button>
+                </div>
+            }
+        >
+            <div className="space-y-5">
+                {/* 错误或最后更新状态提示 */}
+                {overview?.error ? <Alert type="warning" showIcon message={overview.error} description="请检查阿里云 RAM 权限是否授予了 esa:DescribeSiteTimeSeriesData 及 esa:DescribeSiteTopData 策略。" closable /> : null}
+
+                {/* 未配置引导 */}
+                {!isConfigured ? (
+                    <div className="flex flex-col items-center justify-center rounded-2xl border border-dashed border-border/80 bg-muted/20 p-12 text-center">
+                        <div className="mb-4 grid size-14 place-items-center rounded-2xl bg-[var(--workspace-accent)]/10 text-[var(--workspace-accent)]">
+                            <Activity className="size-7" />
+                        </div>
+                        <h3 className="text-base font-semibold text-foreground">尚未配置阿里云 ESA</h3>
+                        <p className="mt-1.5 max-w-md text-xs leading-relaxed text-foreground/60">配置拥有 ESA 只读权限的 AccessKey ID 与 AccessKey Secret 后，即可在此直接查看 ESA 响应流量、总请求数、防护处理与 Top 站点走势。</p>
+                        <Button
+                            type="primary"
+                            icon={<Settings className="size-3.5" />}
+                            className="mt-5"
+                            onClick={() => {
+                                form.setFieldsValue({ enabled: true });
+                                setSettingsOpen(true);
+                            }}
+                        >
+                            去配置 ESA 凭证
+                        </Button>
+                    </div>
+                ) : (
+                    <>
+                        {/* 状态信息行 */}
+                        <div className="flex items-center justify-between text-xs text-foreground/50 px-1">
+                            <div className="flex items-center gap-2">
+                                <span className={cn("inline-block size-2 rounded-full", overview?.error ? "bg-amber-500" : "bg-emerald-500 animate-pulse")} />
+                                <span>{overview?.error ? "数据拉取异常（已展示当前缓存）" : "监控运行中（每 5 分钟自动更新）"}</span>
+                            </div>
+                            <div className="flex items-center gap-1.5">
+                                <Clock3 className="size-3.5" />
+                                <span>最后更新时间：{formatUpdateTime(overview?.updatedAt)}</span>
+                            </div>
+                        </div>
+
+                        {/* 4 个核心指标卡片 */}
+                        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                            <MetricCard
+                                title="ESA 响应流量"
+                                value={formatBytes(overview?.traffic ?? 0)}
+                                subtitle="统计周期内总流出流量"
+                                icon={<TrendingUp className="size-5 text-blue-500" />}
+                                gradient="from-blue-500/10 to-indigo-500/5"
+                                border="border-blue-500/20"
+                            />
+                            <MetricCard
+                                title="总请求数"
+                                value={formatRequests(overview?.requests ?? 0)}
+                                subtitle="统计周期内边缘节点总命中请求"
+                                icon={<Zap className="size-5 text-amber-500" />}
+                                gradient="from-amber-500/10 to-orange-500/5"
+                                border="border-amber-500/20"
+                            />
+                            <MetricCard
+                                title="防护请求数"
+                                value={formatRequests(overview?.securityRequests ?? 0)}
+                                subtitle="WAF / DDoS / 限速防护拦截"
+                                icon={<ShieldCheck className="size-5 text-emerald-500" />}
+                                gradient="from-emerald-500/10 to-teal-500/5"
+                                border="border-emerald-500/20"
+                            />
+                            <MetricCard
+                                title="函数与 Pages 请求数"
+                                value={formatRequests(overview?.pagesRequests ?? 0)}
+                                subtitle="Edge Routine & Pages 边缘计算"
+                                icon={<Cpu className="size-5 text-purple-500" />}
+                                gradient="from-purple-500/10 to-pink-500/5"
+                                border="border-purple-500/20"
+                            />
+                        </div>
+
+                        {/* Top 5 站点 与 趋势图 */}
+                        <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]">
+                            {/* 响应流量 Top 5 站点 */}
+                            <div className="flex flex-col rounded-2xl border border-border/70 bg-background p-4 shadow-sm">
+                                <div className="mb-3.5 flex items-center justify-between">
+                                    <div className="flex items-center gap-2">
+                                        <Globe className="size-4 text-blue-500" />
+                                        <h4 className="text-sm font-semibold text-foreground">响应流量 Top 5 站点</h4>
+                                    </div>
+                                    <span className="text-[11px] text-foreground/40">降序</span>
+                                </div>
+
+                                {overview?.topSites && overview.topSites.length > 0 ? (
+                                    <div className="space-y-3 flex-1 flex flex-col justify-around py-1">
+                                        {overview.topSites.map((site, index) => {
+                                            const maxTraffic = overview.topSites[0]?.traffic || 1;
+                                            const percent = Math.min(100, Math.round((site.traffic / maxTraffic) * 100));
+                                            return (
+                                                <div key={site.siteId || index} className="space-y-1.5">
+                                                    <div className="flex items-center justify-between text-xs">
+                                                        <div className="flex items-center gap-1.5 truncate pr-2">
+                                                            <span
+                                                                className={cn(
+                                                                    "grid size-4 shrink-0 place-items-center rounded-full text-[10px] font-bold",
+                                                                    index === 0 ? "bg-amber-500 text-white" : index === 1 ? "bg-stone-400 text-white" : index === 2 ? "bg-amber-700/80 text-white" : "bg-muted text-foreground/60",
+                                                                )}
+                                                            >
+                                                                {index + 1}
+                                                            </span>
+                                                            <span className="truncate font-medium text-foreground" title={site.siteName}>
+                                                                {site.siteName}
+                                                            </span>
+                                                        </div>
+                                                        <span className="font-mono text-xs font-semibold text-foreground/80 shrink-0">{formatBytes(site.traffic)}</span>
+                                                    </div>
+                                                    <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                                                        <div className="h-full rounded-full bg-gradient-to-r from-blue-500 to-indigo-500 transition-all duration-300" style={{ width: `${Math.max(4, percent)}%` }} />
+                                                    </div>
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                ) : (
+                                    <div className="flex flex-1 flex-col items-center justify-center py-8 text-center text-xs text-foreground/40">
+                                        <Globe className="mb-2 size-6 opacity-30" />
+                                        <span>暂无站点流量数据</span>
+                                    </div>
+                                )}
+                            </div>
+
+                            {/* 响应流量趋势图 */}
+                            <div className="flex flex-col rounded-2xl border border-border/70 bg-background p-4 shadow-sm min-h-[320px]">
+                                <div className="mb-3.5 flex items-center justify-between">
+                                    <div className="flex items-center gap-2">
+                                        <Activity className="size-4 text-emerald-500" />
+                                        <h4 className="text-sm font-semibold text-foreground">响应流量趋势图</h4>
+                                    </div>
+                                    <span className="text-[11px] text-foreground/40">{TIME_RANGE_OPTIONS.find((o) => o.value === timeRange)?.label} · 流量走向</span>
+                                </div>
+
+                                <div className="flex-1 min-h-0">
+                                    <ESATrafficChart timeseries={overview?.timeseries || []} range={timeRange} />
+                                </div>
+                            </div>
+                        </div>
+                    </>
+                )}
+            </div>
+
+            {/* 配置抽屉 */}
+            <Drawer
+                title="阿里云 ESA 配置"
+                placement="right"
+                width={420}
+                open={settingsOpen}
+                onClose={() => setSettingsOpen(false)}
+                footer={
+                    <div className="flex items-center justify-between">
+                        <Button loading={testLoading} onClick={handleTest}>
+                            测试连接
+                        </Button>
+                        <div className="flex items-center gap-2">
+                            <Button onClick={() => setSettingsOpen(false)}>取消</Button>
+                            <Button type="primary" loading={saveMutation.isPending} onClick={handleSave}>
+                                保存配置
+                            </Button>
+                        </div>
+                    </div>
+                }
+            >
+                <Form form={form} layout="vertical" requiredMark={false}>
+                    <Form.Item name="enabled" label="启用 ESA 监控" valuePropName="checked">
+                        <Switch />
+                    </Form.Item>
+
+                    <Form.Item name="accessKeyId" label="AccessKey ID" rules={[{ required: true, message: "请输入 AccessKey ID" }]} extra="建议使用仅具备 ESA 只读权限的阿里云 RAM 用户 AccessKey。">
+                        <Input placeholder="输入 RAM 用户的 AccessKey ID" />
+                    </Form.Item>
+
+                    <Form.Item
+                        name="accessKeySecret"
+                        label="AccessKey Secret"
+                        extra={settingQuery.data?.setting?.hasAccessKeySecret ? "凭据已加密保存。如需更新请输入新的 Secret，留空则保持原配置不变。" : "输入对应的 AccessKey Secret，服务端将加密存储。"}
+                    >
+                        <Input.Password placeholder={settingQuery.data?.setting?.hasAccessKeySecret ? "已配置（输入新 Secret 覆盖）" : "输入 AccessKey Secret"} />
+                    </Form.Item>
+
+                    {testResult ? <Alert type={testResult.success ? "success" : "error"} showIcon icon={testResult.success ? <CheckCircle2 className="size-4" /> : <AlertCircle className="size-4" />} message={testResult.message} className="mt-4" /> : null}
+
+                    <div className="mt-6 rounded-xl bg-muted/40 p-3.5 text-xs text-foreground/60 space-y-1.5">
+                        <div className="font-semibold text-foreground/80">RAM 权限要求：</div>
+                        <div>插件仅用于只读监控，请确保 RAM 策略至少包含：</div>
+                        <code className="block rounded bg-background p-1.5 font-mono text-[11px] text-foreground/80">
+                            esa:DescribeSiteTimeSeriesData
+                            <br />
+                            esa:DescribeSiteTopData
+                            <br />
+                            esa:ListSites
+                        </code>
+                    </div>
+                </Form>
+            </Drawer>
+        </AdminPageFrame>
+    );
+}
+
+function MetricCard({ title, value, subtitle, icon, gradient, border }: { title: string; value: string; subtitle: string; icon: React.ReactNode; gradient: string; border: string }) {
+    return (
+        <div className={cn("relative overflow-hidden rounded-2xl border bg-gradient-to-br p-4 shadow-sm", gradient, border)}>
+            <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-foreground/65">{title}</span>
+                <div className="rounded-xl bg-background/80 p-2 shadow-xs">{icon}</div>
+            </div>
+            <div className="mt-2 text-2xl font-bold tracking-tight text-foreground">{value}</div>
+            <div className="mt-1 text-[11px] text-foreground/45">{subtitle}</div>
+        </div>
+    );
+}
+
+// ---------------- 纯 SVG 高性能响应式流量折线图 ----------------
+
+function ESATrafficChart({ timeseries, range }: { timeseries: ESATimePoint[]; range: string }) {
+    const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+
+    if (!timeseries || timeseries.length === 0) {
+        return (
+            <div className="flex h-full min-h-[220px] flex-col items-center justify-center text-xs text-foreground/40">
+                <Activity className="mb-2 size-7 opacity-30" />
+                <span>当前时间段无时间序列流量数据</span>
+            </div>
+        );
+    }
+
+    const maxTraffic = Math.max(...timeseries.map((d) => d.traffic), 1024);
+    const width = 800;
+    const height = 220;
+    const padding = { top: 20, right: 30, bottom: 35, left: 60 };
+
+    const chartWidth = width - padding.left - padding.right;
+    const chartHeight = height - padding.top - padding.bottom;
+
+    const points = timeseries.map((d, index) => {
+        const x = padding.left + (index / Math.max(timeseries.length - 1, 1)) * chartWidth;
+        const y = padding.top + chartHeight - (d.traffic / maxTraffic) * chartHeight;
+        return { x, y, data: d };
+    });
+
+    const pathD = points.reduce((acc, curr, idx) => `${acc} ${idx === 0 ? "M" : "L"} ${curr.x} ${curr.y}`, "");
+    const areaD = `${pathD} L ${points[points.length - 1].x} ${padding.top + chartHeight} L ${points[0].x} ${padding.top + chartHeight} Z`;
+
+    const yTicks = [
+        { label: formatBytes(maxTraffic), y: padding.top },
+        { label: formatBytes(maxTraffic / 2), y: padding.top + chartHeight / 2 },
+        { label: "0 B", y: padding.top + chartHeight },
+    ];
+
+    // X 轴刻度选取 5 个代表点
+    const xTickIndices = [0, Math.floor(timeseries.length * 0.25), Math.floor(timeseries.length * 0.5), Math.floor(timeseries.length * 0.75), timeseries.length - 1].filter((idx, pos, arr) => arr.indexOf(idx) === pos && idx < timeseries.length);
+
+    const activePoint = hoverIndex !== null && points[hoverIndex] ? points[hoverIndex] : null;
+
+    return (
+        <div className="relative size-full flex flex-col justify-center select-none">
+            <svg
+                viewBox={`0 0 ${width} ${height}`}
+                className="size-full overflow-visible"
+                onMouseLeave={() => setHoverIndex(null)}
+                onMouseMove={(e) => {
+                    const rect = e.currentTarget.getBoundingClientRect();
+                    const mouseX = ((e.clientX - rect.left) / rect.width) * width;
+                    let closestIdx = 0;
+                    let minDist = Infinity;
+                    points.forEach((p, i) => {
+                        const dist = Math.abs(p.x - mouseX);
+                        if (dist < minDist) {
+                            minDist = dist;
+                            closestIdx = i;
+                        }
+                    });
+                    setHoverIndex(closestIdx);
+                }}
+            >
+                <defs>
+                    <linearGradient id="esaTrafficGrad" x1="0" y1="0" x2="0" y2="1">
+                        <stop offset="0%" stopColor="#3b82f6" stopOpacity="0.35" />
+                        <stop offset="100%" stopColor="#3b82f6" stopOpacity="0.0" />
+                    </linearGradient>
+                </defs>
+
+                {/* Y 轴水平网格线与文字 */}
+                {yTicks.map((tick, i) => (
+                    <g key={i}>
+                        <line x1={padding.left} y1={tick.y} x2={width - padding.right} y2={tick.y} stroke="currentColor" strokeOpacity="0.1" strokeDasharray="3 3" />
+                        <text x={padding.left - 8} y={tick.y + 4} textAnchor="end" className="fill-foreground/40 text-[10px] font-mono">
+                            {tick.label}
+                        </text>
+                    </g>
+                ))}
+
+                {/* 面积渐变与折线 */}
+                <path d={areaD} fill="url(#esaTrafficGrad)" />
+                <path d={pathD} fill="none" stroke="#3b82f6" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+
+                {/* X 轴刻度文字 */}
+                {xTickIndices.map((idx) => {
+                    const p = points[idx];
+                    if (!p) return null;
+                    return (
+                        <text key={idx} x={p.x} y={height - 10} textAnchor={idx === 0 ? "start" : idx === timeseries.length - 1 ? "end" : "middle"} className="fill-foreground/45 text-[10px] font-mono">
+                            {formatChartTime(p.data.time, range)}
+                        </text>
+                    );
+                })}
+
+                {/* 悬停准星线与焦点 */}
+                {activePoint ? (
+                    <g>
+                        <line x1={activePoint.x} y1={padding.top} x2={activePoint.x} y2={padding.top + chartHeight} stroke="#3b82f6" strokeWidth="1.5" strokeDasharray="2 2" />
+                        <circle cx={activePoint.x} cy={activePoint.y} r="5" fill="#3b82f6" stroke="#ffffff" strokeWidth="2" />
+                    </g>
+                ) : null}
+            </svg>
+
+            {/* 悬停浮动 Tooltip */}
+            {activePoint ? (
+                <div
+                    className="pointer-events-none absolute z-20 -translate-x-1/2 -translate-y-full rounded-xl border border-border/80 bg-stone-900/90 px-3 py-2 text-xs text-white shadow-xl backdrop-blur-md dark:bg-stone-800/95"
+                    style={{
+                        left: `${(activePoint.x / width) * 100}%`,
+                        top: `${Math.max(10, (activePoint.y / height) * 100 - 8)}%`,
+                    }}
+                >
+                    <div className="font-mono text-[10px] text-white/60">{new Date(activePoint.data.time).toLocaleString("zh-CN", { hour12: false })}</div>
+                    <div className="mt-1 flex items-center gap-2">
+                        <span className="size-2 rounded-full bg-blue-400" />
+                        <span className="font-medium text-white/80">响应流量：</span>
+                        <span className="font-mono font-bold text-blue-300">{formatBytes(activePoint.data.traffic)}</span>
+                    </div>
+                    {activePoint.data.requests > 0 ? (
+                        <div className="mt-0.5 flex items-center gap-2">
+                            <span className="size-2 rounded-full bg-amber-400" />
+                            <span className="font-medium text-white/80">请求数：</span>
+                            <span className="font-mono font-bold text-amber-300">{formatRequests(activePoint.data.requests)}</span>
+                        </div>
+                    ) : null}
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/web/src/router.tsx
+++ b/web/src/router.tsx
@@ -13,6 +13,7 @@ const AdminPage = lazy(() => import("@/pages/admin"));
 const AnalyticsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AnalyticsPage })));
 const AnnouncementsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AnnouncementsPage })));
 const StorageResourcesPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.StorageResourcesPage })));
+const ESAMonitoringPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.ESAMonitoringPage })));
 const CreditOperationsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.CreditOperationsPage })));
 const AccessSettingsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.AccessSettingsPage })));
 const EmailSettingsPage = lazy(() => import("@/pages/admin/admin-route-pages").then((module) => ({ default: module.EmailSettingsPage })));
@@ -190,6 +191,7 @@ export const router = createBrowserRouter([
                     { path: "storyboard-prompts", element: <Navigate to="/admin/prompt-templates" replace /> },
                     { path: "announcements", element: deferred(<AnnouncementsPage />) },
                     { path: "resources", element: deferred(<StorageResourcesPage />) },
+                    { path: "esa", element: deferred(<ESAMonitoringPage />) },
                     { path: "credit-operations", element: deferred(<CreditOperationsPage />) },
                     { path: "redemption-codes", element: deferred(<RedemptionCodesPage />) },
                     { path: "logs", element: deferred(<LogsPage />) },

--- a/web/src/services/api/esa.ts
+++ b/web/src/services/api/esa.ts
@@ -1,0 +1,79 @@
+import { apiClient, request } from "./request";
+
+export interface ESASetting {
+    enabled: boolean;
+    accessKeyId: string;
+    hasAccessKeySecret: boolean;
+    updatedBy?: string;
+    createdAt?: string;
+    updatedAt?: string;
+}
+
+export interface ESASettingRequest {
+    enabled?: boolean;
+    accessKeyId?: string;
+    accessKeySecret?: string;
+}
+
+export interface ESASiteInfo {
+    siteId: string;
+    siteName: string;
+    status: string;
+}
+
+export interface ESATopSite {
+    siteId: string;
+    siteName: string;
+    traffic: number;
+}
+
+export interface ESATimePoint {
+    time: string;
+    traffic: number;
+    requests: number;
+}
+
+export interface ESAOverview {
+    range: "today" | "yesterday" | "7d" | "30d" | string;
+    siteId: string;
+    configured: boolean;
+    traffic: number;
+    requests: number;
+    securityRequests: number;
+    pagesRequests: number;
+    topSites: ESATopSite[];
+    timeseries: ESATimePoint[];
+    updatedAt: string;
+    error?: string;
+}
+
+export interface ESATestConnectionResult {
+    success: boolean;
+    message: string;
+    siteCount?: number;
+    sites?: ESASiteInfo[];
+}
+
+export function getESASetting(signal?: AbortSignal) {
+    return request<{ setting: ESASetting }>(apiClient.get("/admin/esa/settings", { signal }));
+}
+
+export function updateESASetting(req: ESASettingRequest) {
+    return request<{ setting: ESASetting }>(apiClient.patch("/admin/esa/settings", req));
+}
+
+export function testESAConnection(req?: ESASettingRequest) {
+    return request<ESATestConnectionResult>(apiClient.post("/admin/esa/test-connection", req || {}));
+}
+
+export function getESASites(signal?: AbortSignal) {
+    return request<{ sites: ESASiteInfo[] }>(apiClient.get("/admin/esa/sites", { signal }));
+}
+
+export function getESAOverview(rangeKey = "today", siteId = "all", refresh = false, signal?: AbortSignal) {
+    const params = new URLSearchParams();
+    params.set("range", rangeKey);
+    params.set("siteId", siteId);
+    if (refresh) params.set("refresh", "true");
+    return request<ESAOverview>(apiClient.get(`/admin/esa/overview?${params.toString()}`, { signal }));
+}


### PR DESCRIPTION
### 背景与目标

为了让平台管理员无需登录阿里云控制台，即可在管理后台直接掌握 **阿里云边缘安全加速（Edge Security Acceleration, ESA）** 的实时带宽流量、边缘命中请求与站点访问分布，开发了专属的 **ESA 监控** 功能模块。

---

### 变更详情

#### 1. 后端接口与阿里云 OpenAPI（2024-09-10）协议实现
- **路由与权限**：新增 `/api/admin/esa/settings`、`/api/admin/esa/test-connection`、`/api/admin/esa/sites`、`/api/admin/esa/overview` 等管理员专属接口；
- **标准 POP 签名与调用**：实现阿里云 POP RPC 规范签名（HMAC-SHA1），对接 `ListSites`、`DescribeSiteTimeSeriesData` 与 `DescribeSiteTopData` 接口；
- **凭据安全**：AccessKey Secret 在服务端通过 AES-GCM 密文持久化存储，前端与日志不暴露明文 Secret；
- **智能缓存与降级**：具备 5 分钟请求内存缓存，网络波动或上游异常时保留最后一次成功快照，避免页面白屏。

#### 2. 前端管理后台交互与可视化
- **导航与路由**：在管理后台左侧「平台资源」下新增 **「ESA 监控」** 入口（`/admin/esa`）；
- **4 个核心指标卡片**：
  - ESA 响应流量（自动智能转换 B/KB/MB/GB/TB，保留 2 位小数）
  - 总请求数（自动格式化为千/万/亿）
  - 防护请求数（WAF/DDoS/限速拦截）
  - 函数与 Pages 请求数（Edge Routine & Pages 边缘计算）
- **响应流量 Top 5 站点**：按流量降序排列表现最佳的站点/Host，附带金银铜排名徽标与占比进度条；
- **纯 SVG 响应式趋势折线图**：自适应容器宽度，支持鼠标悬停十字准星线与浮动 Tooltip 显示精确时间与数值；
- **时间与站点筛选**：支持快速切换「今天」、「昨天」、「近7天」、「近30天」及具体站点筛选；
- **ESA 设置抽屉**：支持一键「测试连接」验证 AK/SK 与 RAM 只读权限，提供友好的人类可读诊断反馈。

---

### 验证情况

- 后端 Go 单元测试 100% 通过（`go test ./internal/...`）；
- 前端 Prettier 格式化检查、Bun 单元测试与生产构建（`bun test` & `bun run build`）全量通过；
- 实测成功拉取并展示真实 ESA 监控数据。