### PR TITLE
feat: 支持小数价格并优化模型选择器交互

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,11 @@ assets/prototypes/.*.drawio.bkp
 camera_language_guide.md
 .superdesign
 .playwright-cli/
+
+# Local deployment files
+hongniao-models.json
+update-yingce.sh
+更新影策.command
+本机部署说明.md
+红鸟模型价格清单.csv
+红鸟模型价格清单.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY --from=comfy-bridge-build /out/OpenAICanvas-ComfyBridge-linux-amd64 /app/we
 COPY --from=comfy-bridge-build /out/OpenAICanvas-ComfyBridge-linux-arm64 /app/web/public/OpenAICanvas-ComfyBridge-linux-arm64
 # Bun 1.3 与 TypeScript 7 的 tsc shim 在生产容器中解析路径异常；Bridge
 # 已在上一步完成校验，生产镜像直接执行 Vite 打包，类型检查留给开发 CI。
-RUN CANVAS_PREBUILT_BRIDGE=1 bun run build:bridge \
+RUN rm -rf node_modules/.vite dist \
+    && CANVAS_PREBUILT_BRIDGE=1 bun run build:bridge \
     && bun --bun ./node_modules/vite/bin/vite.js build
 
 # 运行镜像：nginx 托管静态前端，并在 Compose 中把 /api 转发到后端服务。

--- a/backend/internal/database/migrations.go
+++ b/backend/internal/database/migrations.go
@@ -10,11 +10,12 @@ import (
 	"gorm.io/gorm"
 )
 
-const CurrentSchemaVersion int64 = 3
+const CurrentSchemaVersion int64 = 4
 
 const baselineSchemaChecksum = "sha256:open-ai-canvas-schema-v1-20260830"
 const schemaMigrationAppliedAtIndexChecksum = "sha256:schema-migrations-applied-at-index-v2-20260830"
 const assetTaxonomyCandidateIdentityChecksum = "sha256:asset-taxonomy-candidate-identity-v3-20260831-r1"
+const decimalPriceColumnsChecksum = "sha256:decimal-price-columns-v4-20260901"
 
 const postgresSchemaMigrationLockID int64 = 73123910420260830
 
@@ -44,6 +45,7 @@ var schemaMigrations = []migration{
 	{version: 1, name: "baseline_gorm_schema", checksum: baselineSchemaChecksum, apply: migrateSchemaV1},
 	{version: 2, name: "schema_migrations_applied_at_index", checksum: schemaMigrationAppliedAtIndexChecksum, apply: migrateSchemaV2},
 	{version: 3, name: "asset_taxonomy_candidate_identity", checksum: assetTaxonomyCandidateIdentityChecksum, apply: migrateSchemaV3},
+	{version: 4, name: "decimal_price_columns", checksum: decimalPriceColumnsChecksum, apply: migrateSchemaV4},
 }
 
 func migrateSchemaV2(tx *gorm.DB) error {
@@ -87,6 +89,32 @@ func migrateSchemaV3(tx *gorm.DB) error {
 		}
 	}
 	return tx.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_project_asset_candidates_pending_identity ON project_asset_candidates(project_id, category, name_key) WHERE status = 'pending_confirmation' AND name_key <> ''").Error
+}
+
+func migrateSchemaV4(tx *gorm.DB) error {
+	// 将价格字段从 bigint 改为 numeric(20,6)，支持小数价格
+	priceColumns := []string{
+		"unit_price_microcredits",
+		"input_token_price_microcredits",
+		"output_token_price_microcredits",
+		"cached_token_price_microcredits",
+	}
+	tables := []string{"channel_models", "billing_orders", "logical_models"}
+	for _, table := range tables {
+		for _, col := range priceColumns {
+			if err := tx.Exec(fmt.Sprintf("ALTER TABLE %s ALTER COLUMN %s TYPE numeric(20,6)", table, col)).Error; err != nil {
+				return fmt.Errorf("修改 %s.%s 字段类型：%w", table, col, err)
+			}
+		}
+	}
+	// logical_models 表的价格字段名不同
+	logicalPriceColumns := []string{"input_price_microcredits", "output_price_microcredits", "cached_price_microcredits"}
+	for _, col := range logicalPriceColumns {
+		if err := tx.Exec(fmt.Sprintf("ALTER TABLE logical_models ALTER COLUMN %s TYPE numeric(20,6)", col)).Error; err != nil {
+			return fmt.Errorf("修改 logical_models.%s 字段类型：%w", col, err)
+		}
+	}
+	return nil
 }
 
 func MigrateSchema(db *gorm.DB) error {

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -1037,7 +1037,7 @@ func proxySystemRequestPath(c *gin.Context, svc *service.Service, user *model.Us
 		if logErr != nil {
 			_ = svc.MarkBillingUncertain(billingOrderID, "上游成功但调用日志写入失败，费用状态待核对")
 		} else if err := svc.SettleBilling(billingOrderID, ""); err != nil {
-			_ = svc.MarkBillingUncertain(billingOrderID, "上游成功但积分结算失败："+err.Error())
+			_ = svc.MarkBillingUncertain(billingOrderID, "上游成功但余额结算失败："+err.Error())
 		}
 	} else if statusCode == 524 {
 		_ = svc.MarkBillingUncertain(billingOrderID, "上游返回 524，费用状态待核对")

--- a/backend/internal/model/models_channel.go
+++ b/backend/internal/model/models_channel.go
@@ -36,10 +36,10 @@ type ChannelModel struct {
 	Capability                   string               `json:"capability" gorm:"size:32;index"`
 	Protocol                     ChannelInterfaceType `json:"protocol" gorm:"size:32;index"`
 	BillingMode                  string               `json:"billingMode" gorm:"size:32"`
-	UnitPriceMicrocredits        int64                `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64                `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64                `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64                `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64                `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64                `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64                `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64                `json:"cachedTokenPriceMicrocredits"`
 	PriceConfigured              bool                 `json:"priceConfigured" gorm:"index"`
 	Enabled                      bool                 `json:"enabled" gorm:"index"`
 	PriceVersion                 int64                `json:"priceVersion"`
@@ -69,10 +69,10 @@ type ChannelModelPriceTier struct {
 	VideoSeconds                 int               `json:"videoSeconds" gorm:"not null;default:0"`
 	ProviderModelKey             string            `json:"providerModelKey" gorm:"size:120"`
 	BillingMode                  string            `json:"billingMode" gorm:"size:32"`
-	UnitPriceMicrocredits        int64             `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64             `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64             `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64             `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64             `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64             `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64             `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64             `json:"cachedTokenPriceMicrocredits"`
 	PriceConfigured              bool              `json:"priceConfigured" gorm:"index"`
 	Enabled                      bool              `json:"enabled" gorm:"index"`
 	PriceVersion                 int64             `json:"priceVersion"`

--- a/backend/internal/model/models_finance.go
+++ b/backend/internal/model/models_finance.go
@@ -47,16 +47,16 @@ type BillingOrder struct {
 	Scene                        string        `json:"scene" gorm:"index;size:80"`
 	BillingMode                  string        `json:"billingMode" gorm:"size:32"`
 	PriceVersion                 int64         `json:"priceVersion"`
-	UnitPriceMicrocredits        int64         `json:"unitPriceMicrocredits"`
+	UnitPriceMicrocredits        float64         `json:"unitPriceMicrocredits"`
 	MultiplierBasisPoints        int64         `json:"multiplierBasisPoints"`
 	Quantity                     int64         `json:"quantity"`
 	AmountMicrocredits           int64         `json:"amountMicrocredits"`
 	ReservedAmountMicrocredits   int64         `json:"reservedAmountMicrocredits"`
 	ActualAmountMicrocredits     int64         `json:"actualAmountMicrocredits"`
 	RefundedAmountMicrocredits   int64         `json:"refundedAmountMicrocredits"`
-	InputTokenPriceMicrocredits  int64         `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64         `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64         `json:"cachedTokenPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64         `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64         `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64         `json:"cachedTokenPriceMicrocredits"`
 	InputTokens                  int64         `json:"inputTokens"`
 	OutputTokens                 int64         `json:"outputTokens"`
 	CachedTokens                 int64         `json:"cachedTokens"`

--- a/backend/internal/model/models_logical_model.go
+++ b/backend/internal/model/models_logical_model.go
@@ -27,10 +27,10 @@ type LogicalModel struct {
 	SourceChannelModelID    string `json:"sourceChannelModelId,omitempty" gorm:"size:36;index"`
 	PricePolicy             string `json:"pricePolicy" gorm:"size:24;default:unified"`
 	BillingMode             string `json:"billingMode" gorm:"size:32"`
-	UnitPriceMicrocredits   int64  `json:"unitPriceMicrocredits"`
-	InputPriceMicrocredits  int64  `json:"inputPriceMicrocredits"`
-	OutputPriceMicrocredits int64  `json:"outputPriceMicrocredits"`
-	CachedPriceMicrocredits int64  `json:"cachedPriceMicrocredits"`
+	UnitPriceMicrocredits   float64  `json:"unitPriceMicrocredits"`
+	InputPriceMicrocredits  float64  `json:"inputPriceMicrocredits"`
+	OutputPriceMicrocredits float64  `json:"outputPriceMicrocredits"`
+	CachedPriceMicrocredits float64  `json:"cachedPriceMicrocredits"`
 	// LegacyModelIDsJSON 用于创作端把已保存的旧 SKU 选择无缝映射到新的模型家族。
 	// 这只是目录兼容信息，任务、路由尝试和账单仍固定引用其创建时的 ID 快照。
 	LegacyModelIDsJSON string `json:"-" gorm:"type:text"`
@@ -92,10 +92,10 @@ type LogicalModelPriceSKU struct {
 	SelectorKey                  string     `json:"selectorKey" gorm:"size:500;not null;default:{};uniqueIndex:idx_logical_sku_active,priority:2,where:deleted_at IS NULL"`
 	SelectorJSON                 string     `json:"-" gorm:"type:text;not null;default:{}"`
 	BillingMode                  string     `json:"billingMode" gorm:"size:32"`
-	UnitPriceMicrocredits        int64      `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64      `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64      `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64      `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64      `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64      `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64      `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64      `json:"cachedTokenPriceMicrocredits"`
 	Priority                     int        `json:"priority" gorm:"index"`
 	Enabled                      bool       `json:"enabled" gorm:"index"`
 	Version                      int        `json:"version"`

--- a/backend/internal/protocol/builtin.go
+++ b/backend/internal/protocol/builtin.go
@@ -73,8 +73,8 @@ func Builtins() *Registry {
 	}
 	registry, err := NewRegistry(
 		openAIChatAdapter(), openAIResponsesAdapter(), claudeAdapter(),
-		openAIImagesAdapter(), grokImagesAdapter(), arkImagesAdapter(), jimengImagesAdapter(), geminiImagesAdapter(),
-		openAIVideosAdapter(), newAPIChannel1Adapter(), newAPIVideosAdapter(), xAIVideosAdapter(), arkVideosAdapter(), jimengVideosAdapter(), geminiVeoAdapter(), novitaVideosAdapter(), miniMaxVideosAdapter(),
+		openAIImagesAdapter(), grokImagesAdapter(), arkImagesAdapter(), jimengImagesAdapter(), geminiImagesAdapter(), hongniaoImagesAdapter(), grsaiImagesAdapter(),
+		openAIVideosAdapter(), newAPIChannel1Adapter(), newAPIVideosAdapter(), xAIVideosAdapter(), arkVideosAdapter(), jimengVideosAdapter(), geminiVeoAdapter(), novitaVideosAdapter(), miniMaxVideosAdapter(), hongniaoVideosAdapter(),
 		openAIAudioAdapter(), asyncAudioAdapter(), agnesAdapter(),
 	)
 	if err != nil {
@@ -358,6 +358,144 @@ func newAPIChannel1Adapter() Adapter {
 		}
 		return jsonSpec(http.MethodPost, "/v1/videos", map[string]any{"model": r.Model, "input": input, "parameters": parameters}), nil
 	})
+}
+
+func hongniaoVideosAdapter() Adapter {
+	info := metadata("hongniao-video", "红鸟视频", "HongNiao", CapabilityVideo, "POST /v1/videos", "GET /v1/videos/{task_id}", "application/json")
+	info.Parameters = videoParams()
+	return videoAdapter(info, func(r GenerationRequest) (RequestSpec, error) {
+		// 红鸟 /v1/videos 真实字段：seconds(整数秒)、aspect_ratio(蛇形)，参考素材为 images/audios/videos。
+		body := map[string]any{"model": r.Model, "prompt": r.Prompt, "seconds": defaultInt(r.Duration, 5)}
+		if r.AspectRatio != "" {
+			body["aspect_ratio"] = r.AspectRatio
+		}
+		if images := mediaValues(r.Images); len(images) > 0 {
+			body["images"] = images
+		}
+		if audios := mediaValues(r.Audios); len(audios) > 0 {
+			body["audios"] = audios
+		}
+		if videos := mediaValues(r.Videos); len(videos) > 0 {
+			body["videos"] = videos
+		}
+		if r.GenerateAudio {
+			body["generate_audio"] = true
+		}
+		return jsonSpec(http.MethodPost, "/v1/videos", body), nil
+	})
+}
+
+func hongniaoImagesAdapter() Adapter {
+	info := metadata("hongniao-image", "红鸟图像", "HongNiao", CapabilityImage, "POST /v1/images", "GET /v1/images/{task_id}", "application/json")
+	info.Parameters = mediaParams()
+	return asyncMediaAdapter(info, CapabilityImage, func(r GenerationRequest) (RequestSpec, error) {
+		body := map[string]any{"model": r.Model, "prompt": r.Prompt}
+		if r.AspectRatio != "" {
+			// 红鸟官方字段为下划线 aspect_ratio
+			body["aspect_ratio"] = r.AspectRatio
+		}
+		if images := mediaValues(r.Images); len(images) > 0 {
+			body["images"] = images
+		}
+		model := strings.ToLower(strings.TrimSpace(r.Model))
+		if strings.HasPrefix(model, "banana2") {
+			// banana2-S / banana2-S_copy：顶层 resolution，仅支持小写 1k/2k，默认 1k
+			resolution := strings.ToLower(strings.TrimSpace(r.Quality))
+			if resolution != "2k" {
+				resolution = "1k"
+			}
+			body["resolution"] = resolution
+		} else {
+			// gpt-image / ph-gpt-image 系列：质量参数嵌套在 parameters.quality，取值 high/medium/low
+			quality := "high"
+			switch strings.ToLower(strings.TrimSpace(r.Quality)) {
+			case "medium", "1k", "standard":
+				quality = "medium"
+			case "low", "fast", "draft":
+				quality = "low"
+			}
+			body["parameters"] = map[string]any{"quality": quality}
+		}
+		return jsonSpec(http.MethodPost, "/v1/images", body), nil
+	})
+}
+
+// grsaiImagesAdapter 对接 Grsai 中转站的图像生成接口。
+// 原生端点是 POST /v1/api/generate（创建任务）+ GET /v1/api/result?id={task_id}（轮询结果），
+// 同时支撑 gpt-image-2/gpt-image-2-vip 与 nano-banana 系列。
+// 与通用异步解析器的差异：
+//   - 结果放在响应里的 results[] 数组（通用解析器只认 images/data/url）；
+//   - 违规状态返回 violation，需要当作失败处理，而不是继续轮询；
+//   - nano-banana 系列用 imageSize 表达分辨率（1K/2K/4K），gpt-image-2 系列则把分辨率写进 aspectRatio 像素值。
+func grsaiImagesAdapter() Adapter {
+	info := metadata("grsai-image", "Grsai 图像", "Grsai", CapabilityImage, "POST /v1/api/generate", "GET /v1/api/result?id={task_id}", "application/json")
+	info.Parameters = mediaParams()
+	return builtinAdapter{
+		info: info,
+		create: func(r GenerationRequest) (RequestSpec, error) {
+			body := map[string]any{"model": r.Model, "prompt": r.Prompt, "replyType": "async"}
+			copyIf(body, "aspectRatio", r.AspectRatio)
+			if strings.HasPrefix(strings.ToLower(strings.TrimSpace(r.Model)), "nano-banana") {
+				copyIf(body, "imageSize", defaultValue(r.Resolution, r.Quality))
+			}
+			if images := mediaValues(r.Images); len(images) > 0 {
+				body["images"] = images
+			}
+			return jsonSpec(http.MethodPost, "/v1/api/generate", body), nil
+		},
+		parseCreate: parseGrsaiCreate,
+		poll: func(c PollContext) (RequestSpec, error) {
+			return RequestSpec{Method: http.MethodGet, Path: "/v1/api/result?id=" + url.QueryEscape(c.TaskID)}, nil
+		},
+		parsePoll: parseGrsaiPoll,
+	}
+}
+
+func parseGrsaiCreate(payload map[string]any) (CreateResult, error) {
+	status := normalizeStatus(firstString(payload, "status", "state"))
+	if strings.EqualFold(firstString(payload, "status", "state"), "violation") {
+		status = StatusFailed
+	}
+	id := firstString(payload, "id", "task_id", "taskId")
+	if id == "" {
+		return CreateResult{}, fmt.Errorf("Grsai 创建响应没有返回任务 id")
+	}
+	if status == "" {
+		status = StatusPending
+	}
+	return CreateResult{TaskID: id, Status: status, Message: firstString(payload, "error", "message")}, nil
+}
+
+func parseGrsaiPoll(c PollContext, payload map[string]any) (PollResult, error) {
+	status := normalizeStatus(firstString(payload, "status", "state"))
+	if strings.EqualFold(firstString(payload, "status", "state"), "violation") {
+		status = StatusFailed
+	}
+	message := firstString(payload, "error", "message", "fail_reason")
+	if status == StatusFailed || status == StatusCancelled {
+		return PollResult{TaskID: c.TaskID, Status: status, Message: message}, nil
+	}
+	if status == StatusSucceeded {
+		images := make([]MediaReference, 0)
+		if results, ok := payload["results"].([]any); ok {
+			for _, item := range results {
+				if media, ok := item.(map[string]any); ok {
+					if value := firstString(media, "url"); value != "" {
+						images = append(images, MediaReference{URL: value, Kind: "image"})
+					}
+				}
+			}
+		}
+		images = append(images, mediaFromArray(payload["data"], CapabilityImage)...)
+		if value := firstString(payload, "url"); value != "" {
+			images = append(images, MediaReference{URL: value, Kind: "image"})
+		}
+		return PollResult{TaskID: c.TaskID, Status: StatusSucceeded, Result: &Result{Images: images}, Message: message}, nil
+	}
+	if status == "" {
+		status = StatusProcessing
+	}
+	return PollResult{TaskID: c.TaskID, Status: status, Message: message}, nil
 }
 
 func xAIVideosAdapter() Adapter {

--- a/backend/internal/protocol/manifest.go
+++ b/backend/internal/protocol/manifest.go
@@ -85,6 +85,15 @@ func LoadInstalledProviders(data []byte, resolve AdapterResolver) ([]Adapter, er
 		if err := normalizeManifest(&manifest); err != nil {
 			return nil, err
 		}
+		// manifest.Metadata 由 JSON 反序列化得到，Create/Poll/Cancel 等运行时字段
+		// 带 json:"-" 标签不会落盘；这里从 host 内置适配器补回，使包装后的
+		// metadataAdapter 仍能正确暴露轮询等能力（例如判断同步/异步协议）。
+		delegateMeta := adapter.Metadata()
+		manifest.Metadata.Create = delegateMeta.Create
+		manifest.Metadata.Poll = delegateMeta.Poll
+		manifest.Metadata.Cancel = delegateMeta.Cancel
+		manifest.Metadata.ContentType = delegateMeta.ContentType
+		manifest.Metadata.RequiresPublicMediaURLs = delegateMeta.RequiresPublicMediaURLs
 		return []Adapter{metadataAdapter{metadata: manifest.Metadata, delegate: adapter}}, nil
 	}
 	if len(manifest.Contributes.Providers) == 0 {

--- a/backend/internal/repository/finance.go
+++ b/backend/internal/repository/finance.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"math"
 	"strconv"
 	"strings"
 	"time"
@@ -830,31 +831,23 @@ func tokenUsageAmount(order model.BillingOrder, usage *BillingUsage) (int64, err
 	if input < 0 {
 		input = 0
 	}
-	inputAmount, ok := safeTokenUsageProduct(input, order.InputTokenPriceMicrocredits)
-	if !ok {
+	inputAmount := safeTokenUsageProduct(input, order.InputTokenPriceMicrocredits)
+	outputAmount := safeTokenUsageProduct(usage.OutputTokens, order.OutputTokenPriceMicrocredits)
+	cachedAmount := safeTokenUsageProduct(usage.CachedTokens, order.CachedTokenPriceMicrocredits)
+	base := inputAmount + outputAmount + cachedAmount
+	if order.MultiplierBasisPoints <= 0 {
 		return 0, errors.New("invalid token usage amount")
 	}
-	outputAmount, ok := safeTokenUsageProduct(usage.OutputTokens, order.OutputTokenPriceMicrocredits)
-	if !ok || inputAmount > 1<<63-1-outputAmount {
-		return 0, errors.New("invalid token usage amount")
-	}
-	cachedAmount, ok := safeTokenUsageProduct(usage.CachedTokens, order.CachedTokenPriceMicrocredits)
-	base := inputAmount + outputAmount
-	if !ok || base > 1<<63-1-cachedAmount {
-		return 0, errors.New("invalid token usage amount")
-	}
-	base += cachedAmount
-	if order.MultiplierBasisPoints <= 0 || base > (1<<63-1-9_999_999_999)/order.MultiplierBasisPoints {
-		return 0, errors.New("invalid token usage amount")
-	}
-	return (base*order.MultiplierBasisPoints + 9_999_999_999) / 10_000_000_000, nil
+	// 价格为 float64（微积分/token），最终金额向上取整为整数微积分
+	amount := base * float64(order.MultiplierBasisPoints) / 10_000_000_000
+	return int64(math.Ceil(amount)), nil
 }
 
-func safeTokenUsageProduct(tokens int64, price int64) (int64, bool) {
-	if tokens < 0 || price < 0 || (tokens > 0 && price > (1<<63-1)/tokens) {
-		return 0, false
+func safeTokenUsageProduct(tokens int64, price float64) float64 {
+	if tokens < 0 || price < 0 {
+		return 0
 	}
-	return tokens * price, true
+	return float64(tokens) * price
 }
 
 func (r *Repository) AdjustCredits(userID string, actorUserID string, amount int64, note string) (*model.CreditAccount, error) {

--- a/backend/internal/service/admin.go
+++ b/backend/internal/service/admin.go
@@ -124,10 +124,10 @@ type PublicChannelModelPrice struct {
 	Capability                   string                     `json:"capability"`
 	Protocol                     model.ChannelInterfaceType `json:"protocol"`
 	BillingMode                  string                     `json:"billingMode"`
-	UnitPriceMicrocredits        int64                      `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64                      `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64                      `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64                      `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64                      `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64                      `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64                      `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64                      `json:"cachedTokenPriceMicrocredits"`
 	CapabilityConfig             *ModelCapabilityConfig     `json:"capabilityConfig,omitempty"`
 }
 

--- a/backend/internal/service/analytics.go
+++ b/backend/internal/service/analytics.go
@@ -394,7 +394,7 @@ func (s *Service) AdminAPICallLogsCSV(actor *model.User, query APICallLogQuery) 
 	var buffer bytes.Buffer
 	buffer.WriteString("\xEF\xBB\xBF")
 	writer := csv.NewWriter(&buffer)
-	_ = writer.Write([]string{"时间", "用户", "用户账号", "渠道", "模型", "能力", "状态", "轮询次数", "耗时毫秒", "输入Token", "输出Token", "缓存Token", "积分计费(微积分)", "积分计费状态", "上游估算费用(微单位)", "币种", "错误码", "错误"})
+	_ = writer.Write([]string{"时间", "用户", "用户账号", "渠道", "模型", "能力", "状态", "轮询次数", "耗时毫秒", "输入Token", "输出Token", "缓存Token", "余额计费(微积分)", "余额计费状态", "上游估算费用(微单位)", "币种", "错误码", "错误"})
 	for _, log := range logs {
 		startedAt := log.StartedAt
 		if startedAt.IsZero() {

--- a/backend/internal/service/channel_models.go
+++ b/backend/internal/service/channel_models.go
@@ -25,10 +25,10 @@ type ChannelModelRequest struct {
 	Capability                   string                         `json:"capability"`
 	Protocol                     string                         `json:"protocol"`
 	BillingMode                  string                         `json:"billingMode"`
-	UnitPriceMicrocredits        int64                          `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64                          `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64                          `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64                          `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64                          `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64                          `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64                          `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64                          `json:"cachedTokenPriceMicrocredits"`
 	PriceConfigured              bool                           `json:"priceConfigured"`
 	Enabled                      *bool                          `json:"enabled"`
 	CapabilityConfig             *ModelCapabilityConfig         `json:"capabilityConfig"`
@@ -45,10 +45,10 @@ type ChannelModelPriceTierRequest struct {
 	VideoSeconds                 int               `json:"videoSeconds"`
 	ProviderModelKey             string            `json:"providerModelKey"`
 	BillingMode                  string            `json:"billingMode"`
-	UnitPriceMicrocredits        int64             `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64             `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64             `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64             `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64             `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64             `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64             `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64             `json:"cachedTokenPriceMicrocredits"`
 	PriceConfigured              bool              `json:"priceConfigured"`
 	Enabled                      *bool             `json:"enabled"`
 }
@@ -473,14 +473,14 @@ func validateChannelModelTierPricing(capability string, protocol model.ChannelIn
 		return BadAuthRequest("Token 计费仅支持文本模型和火山方舟视频协议")
 	}
 	if input.UnitPriceMicrocredits < 0 || input.InputTokenPriceMicrocredits < 0 || input.OutputTokenPriceMicrocredits < 0 || input.CachedTokenPriceMicrocredits < 0 {
-		return BadAuthRequest("模型积分价格不能小于 0")
+		return BadAuthRequest("模型价格不能小于 0")
 	}
 	if !input.PriceConfigured {
 		return nil
 	}
-	const maxTokenPriceMicrocredits = int64(1_000_000) * CreditScale
+	const maxTokenPriceMicrocredits = float64(1_000_000) * float64(CreditScale)
 	if input.InputTokenPriceMicrocredits > maxTokenPriceMicrocredits || input.OutputTokenPriceMicrocredits > maxTokenPriceMicrocredits || input.CachedTokenPriceMicrocredits > maxTokenPriceMicrocredits {
-		return BadAuthRequest("Token 每百万用量价格不能超过 1,000,000 积分")
+		return BadAuthRequest("Token 每百万用量价格不能超过 1,000,000")
 	}
 	return nil
 }

--- a/backend/internal/service/credit_policy.go
+++ b/backend/internal/service/credit_policy.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"math"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -36,7 +37,7 @@ func validateCreditPolicy(policy CreditPolicy) error {
 		return BadAuthRequest("注册和签到奖励不能小于 0")
 	}
 	if policy.SignupBonusMicrocredits > 1_000_000*CreditScale || policy.CheckinBonusMicrocredits > 100_000*CreditScale {
-		return BadAuthRequest("积分奖励超出允许范围")
+		return BadAuthRequest("奖励金额超出允许范围")
 	}
 	if policy.DefaultMultiplierBPS <= 0 || policy.DefaultMultiplierBPS > 1_000_000 {
 		return BadAuthRequest("默认模型倍率必须在 0.0001-100 之间")
@@ -59,7 +60,7 @@ func (s *Service) creditPolicy() (CreditPolicy, error) {
 	}
 	var policy CreditPolicy
 	if json.Unmarshal([]byte(setting.ValueJSON), &policy) != nil {
-		return CreditPolicy{}, errors.New("积分策略配置格式无效")
+		return CreditPolicy{}, errors.New("余额策略配置格式无效")
 	}
 	if policy.ModelMultiplierBPS == nil {
 		policy.ModelMultiplierBPS = map[string]int64{}
@@ -116,7 +117,7 @@ func (s *Service) ensureSignupBonus(userID string) error {
 	if err != nil || policy.SignupBonusMicrocredits == 0 {
 		return err
 	}
-	_, _, err = s.repo.GrantCreditsOnce(userID, model.CreditLedgerSignupBonus, policy.SignupBonusMicrocredits, "signup:"+userID, "新用户默认积分")
+	_, _, err = s.repo.GrantCreditsOnce(userID, model.CreditLedgerSignupBonus, policy.SignupBonusMicrocredits, "signup:"+userID, "新用户默认余额")
 	return err
 }
 
@@ -149,20 +150,15 @@ func (s *Service) publicCreditPolicy(userID string) (PublicCreditPolicy, error) 
 }
 
 // 单价、数量和倍率全程使用整数并向上取整，避免浮点误差造成少扣积分。
-func creditAmount(unitPrice int64, quantity int64, multiplierBPS int64) (int64, error) {
+func creditAmount(unitPrice float64, quantity int64, multiplierBPS int64) (int64, error) {
 	if unitPrice < 0 || quantity <= 0 || multiplierBPS <= 0 {
-		return 0, errors.New("积分计费参数无效")
+		return 0, errors.New("余额计费参数无效")
 	}
-	if unitPrice > (1<<63-1)/quantity {
-		return 0, errors.New("积分计费金额溢出")
-	}
-	base := unitPrice * quantity
-	if base > ((1<<63-1)-9_999)/multiplierBPS {
-		return 0, errors.New("积分计费金额溢出")
-	}
-	amount := (base*multiplierBPS + 9_999) / 10_000
+	base := unitPrice * float64(quantity)
+	// 价格为 float64（微积分/次或秒），最终金额向上取整为整数微积分
+	amount := int64(math.Ceil(base * float64(multiplierBPS) / 10_000))
 	if amount < 0 {
-		return 0, fmt.Errorf("积分计费金额无效：%d", amount)
+		return 0, fmt.Errorf("余额计费金额无效：%d", amount)
 	}
 	return amount, nil
 }

--- a/backend/internal/service/feature_availability.go
+++ b/backend/internal/service/feature_availability.go
@@ -133,7 +133,7 @@ func (s *Service) RequireFeature(feature string) error {
 	case FeatureTaskCenter:
 		return Forbidden("任务中心暂未开放")
 	case FeatureCredits:
-		return Forbidden("积分功能暂未开放")
+		return Forbidden("余额功能暂未开放")
 	case FeatureCustomChannels:
 		return Forbidden("自定义渠道暂未开放")
 	case FeatureFrontendModels:

--- a/backend/internal/service/finance.go
+++ b/backend/internal/service/finance.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"math"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -159,7 +160,7 @@ func (s *Service) AdminCreateRedeemBatch(actor *model.User, req CreateRedeemBatc
 		return nil, err
 	}
 	if req.AmountMicrocredits <= 0 {
-		return nil, BadAuthRequest("兑换码积分必须大于 0")
+		return nil, BadAuthRequest("兑换码面值必须大于 0")
 	}
 	if req.Count <= 0 || req.Count > 5000 {
 		return nil, BadAuthRequest("单批兑换码数量需为 1-5000")
@@ -271,7 +272,7 @@ func (s *Service) AdminAdjustCredits(actor *model.User, userID string, req Admin
 		return nil, err
 	}
 	if req.AmountMicrocredits == 0 {
-		return nil, BadAuthRequest("调账积分不能为 0")
+		return nil, BadAuthRequest("调账金额不能为 0")
 	}
 	note := strings.TrimSpace(req.Note)
 	if note == "" {
@@ -282,7 +283,7 @@ func (s *Service) AdminAdjustCredits(actor *model.User, userID string, req Admin
 	}
 	account, err := s.repo.AdjustCredits(userID, actor.ID, req.AmountMicrocredits, truncateRunes(note, 500))
 	if errors.Is(err, repository.ErrInsufficientCredits) {
-		return nil, BadAuthRequest("用户可用积分不足，不能执行本次扣减")
+		return nil, BadAuthRequest("用户可用余额不足，不能执行本次扣减")
 	}
 	if err != nil {
 		return nil, err
@@ -494,7 +495,7 @@ func (s *Service) newLogicalModelBillingOrder(userID string, task *model.Task, i
 	amount := int64(0)
 	switch logicalModel.BillingMode {
 	case "fixed_request":
-		amount = logicalModel.UnitPriceMicrocredits
+		amount = int64(math.Ceil(logicalModel.UnitPriceMicrocredits))
 	case "per_second":
 		quantity = billingQuantity(capability, config["videoSeconds"])
 		if capability != "video" || quantity <= 0 {
@@ -553,7 +554,7 @@ func (s *Service) ReserveProxyBillingWithBody(userID string, channelID string, m
 	}
 	if err := s.repo.ReserveBillingOrder(order); err != nil {
 		if errors.Is(err, repository.ErrInsufficientCredits) {
-			return nil, BadAuthRequest("积分不足，请先使用兑换码充值")
+			return nil, BadAuthRequest("余额不足，请先使用兑换码充值")
 		}
 		return nil, err
 	}
@@ -574,7 +575,7 @@ func (s *Service) newBillingOrderWithPriceTier(userID string, taskID string, ide
 	}
 	tier := channelModelPriceTierForBilling(*item, priceTierID, capability, intents...)
 	if tier == nil {
-		return nil, BadAuthRequest("当前模型尚未配置所选规格的用户积分价格")
+		return nil, BadAuthRequest("当前模型尚未配置所选规格的用户价格")
 	}
 	quantity := int64(1)
 	amount := int64(0)
@@ -784,30 +785,22 @@ func tokenEstimateAmount(item *model.ChannelModel, estimate tokenBillingEstimate
 	if item == nil || estimate.InputTokens < 0 || estimate.OutputTokens <= 0 || multiplierBPS <= 0 {
 		return 0, errors.New("Token 计费参数无效")
 	}
-	inputAmount, ok := safeTokenProduct(estimate.InputTokens, item.InputTokenPriceMicrocredits)
-	if !ok {
-		return 0, errors.New("Token 计费金额溢出")
-	}
-	outputAmount, ok := safeTokenProduct(estimate.OutputTokens, item.OutputTokenPriceMicrocredits)
-	if !ok || inputAmount > 1<<63-1-outputAmount {
-		return 0, errors.New("Token 计费金额溢出")
-	}
+	inputAmount := safeTokenProduct(estimate.InputTokens, item.InputTokenPriceMicrocredits)
+	outputAmount := safeTokenProduct(estimate.OutputTokens, item.OutputTokenPriceMicrocredits)
 	base := inputAmount + outputAmount
-	if base > (1<<63-1-9_999_999_999)/multiplierBPS {
-		return 0, errors.New("Token 计费金额溢出")
-	}
-	amount := (base*multiplierBPS + 9_999_999_999) / 10_000_000_000
+	// 价格为 float64（微积分/token），最终金额向上取整为整数微积分
+	amount := int64(math.Ceil(base * float64(multiplierBPS) / 10_000_000_000))
 	if amount <= 0 {
 		return 0, errors.New("Token 计费金额必须大于 0")
 	}
 	return amount, nil
 }
 
-func safeTokenProduct(tokens int64, price int64) (int64, bool) {
-	if tokens < 0 || price < 0 || (tokens > 0 && price > (1<<63-1)/tokens) {
-		return 0, false
+func safeTokenProduct(tokens int64, price float64) float64 {
+	if tokens < 0 || price < 0 {
+		return 0
 	}
-	return tokens * price, true
+	return float64(tokens) * price
 }
 
 func billingQuantity(capability string, value any) int64 {

--- a/backend/internal/service/logical_model_quote.go
+++ b/backend/internal/service/logical_model_quote.go
@@ -1,6 +1,9 @@
 package service
 
-import "infinite-canvas/backend/internal/model"
+import (
+	"math"
+	"infinite-canvas/backend/internal/model"
+)
 
 // LogicalModelQuote 是创作端当前参数命中的实际供应线路报价。
 // Token 视频在上游返回真实 usage 前只能预估，创建任务仍以账务预留逻辑为准。
@@ -55,7 +58,7 @@ func (s *Service) QuoteLogicalModel(logicalModelID string, intent ModelRequestIn
 	switch routed.LogicalModel.BillingMode {
 	case "fixed_request":
 		quantity = 1
-		amount = routed.LogicalModel.UnitPriceMicrocredits
+		amount = int64(math.Ceil(routed.LogicalModel.UnitPriceMicrocredits))
 	case "per_second":
 		if capability != "video" || quantity <= 0 {
 			return nil, BadAuthRequest("当前模型按时长计费，但请求未提供有效时长")

--- a/backend/internal/service/logical_models.go
+++ b/backend/internal/service/logical_models.go
@@ -28,10 +28,10 @@ type LogicalModelRequest struct {
 	SortOrder               int    `json:"sortOrder"`
 	PricePolicy             string `json:"pricePolicy"`
 	BillingMode             string `json:"billingMode"`
-	UnitPriceMicrocredits   int64  `json:"unitPriceMicrocredits"`
-	InputPriceMicrocredits  int64  `json:"inputPriceMicrocredits"`
-	OutputPriceMicrocredits int64  `json:"outputPriceMicrocredits"`
-	CachedPriceMicrocredits int64  `json:"cachedPriceMicrocredits"`
+	UnitPriceMicrocredits   float64  `json:"unitPriceMicrocredits"`
+	InputPriceMicrocredits  float64  `json:"inputPriceMicrocredits"`
+	OutputPriceMicrocredits float64  `json:"outputPriceMicrocredits"`
+	CachedPriceMicrocredits float64  `json:"cachedPriceMicrocredits"`
 	// LegacyModelIDs 只用于将用户本地保存的旧目录选择迁移到当前模型家族，
 	// 不能用它重写任务、账单或路由尝试中的不可变快照。
 	LegacyModelIDs []string              `json:"legacyModelIds"`
@@ -58,13 +58,13 @@ type PublicLogicalModel struct {
 	SortOrder               int                           `json:"sortOrder"`
 	PricePolicy             string                        `json:"pricePolicy"`
 	PricingMode             string                        `json:"pricingMode"`
-	DisplayPrice            *int64                        `json:"displayPrice,omitempty"`
+	DisplayPrice            *float64                        `json:"displayPrice,omitempty"`
 	PriceLabel              string                        `json:"priceLabel"`
 	BillingMode             string                        `json:"billingMode"`
-	UnitPriceMicrocredits   int64                         `json:"unitPriceMicrocredits"`
-	InputPriceMicrocredits  int64                         `json:"inputPriceMicrocredits"`
-	OutputPriceMicrocredits int64                         `json:"outputPriceMicrocredits"`
-	CachedPriceMicrocredits int64                         `json:"cachedPriceMicrocredits"`
+	UnitPriceMicrocredits   float64                         `json:"unitPriceMicrocredits"`
+	InputPriceMicrocredits  float64                         `json:"inputPriceMicrocredits"`
+	OutputPriceMicrocredits float64                         `json:"outputPriceMicrocredits"`
+	CachedPriceMicrocredits float64                         `json:"cachedPriceMicrocredits"`
 	PriceTiers              []PublicLogicalModelPriceTier `json:"priceTiers"`
 	LegacyModelIDs          []string                      `json:"legacyModelIds"`
 	CapabilitySpec          CapabilitySpec                `json:"capabilitySpec"`
@@ -81,10 +81,10 @@ type PublicLogicalModelPriceTier struct {
 	Resolution                   string            `json:"resolution"`
 	VideoSeconds                 int               `json:"videoSeconds"`
 	BillingMode                  string            `json:"billingMode"`
-	UnitPriceMicrocredits        int64             `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64             `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64             `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64             `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64             `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64             `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64             `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64             `json:"cachedTokenPriceMicrocredits"`
 }
 
 type AdminLogicalRoute struct {
@@ -1090,7 +1090,7 @@ func numericRange(minimum float64, maximum float64, step float64) OptionConstrai
 
 // computeModelPriceDisplay 计算模型的价格展示信息
 // 返回：pricingMode, displayPrice, priceLabel
-func computeModelPriceDisplay(model model.LogicalModel, priceTiers []PublicLogicalModelPriceTier) (string, *int64, string) {
+func computeModelPriceDisplay(model model.LogicalModel, priceTiers []PublicLogicalModelPriceTier) (string, *float64, string) {
 	if model.PricePolicy == "channel" {
 		// 跟随渠道价格
 		if len(priceTiers) == 0 {
@@ -1128,7 +1128,7 @@ func computeModelPriceDisplay(model model.LogicalModel, priceTiers []PublicLogic
 }
 
 // getTierDisplayPrice 获取价格档的展示价格
-func getTierDisplayPrice(tier PublicLogicalModelPriceTier) int64 {
+func getTierDisplayPrice(tier PublicLogicalModelPriceTier) float64 {
 	if tier.BillingMode == "fixed_request" || tier.BillingMode == "per_second" {
 		return tier.UnitPriceMicrocredits
 	}

--- a/backend/internal/service/model_catalog.go
+++ b/backend/internal/service/model_catalog.go
@@ -41,7 +41,7 @@ type PublicChannelModel struct {
 	CapabilityConfig map[string]any                `json:"capabilityConfig,omitempty"`
 	PriceTiers       []PublicChannelModelPriceTier `json:"priceTiers"`
 	PricingMode      string                        `json:"pricingMode"`
-	DisplayPrice     *int64                        `json:"displayPrice,omitempty"`
+	DisplayPrice     *float64                        `json:"displayPrice,omitempty"`
 	PriceLabel       string                        `json:"priceLabel"`
 	Available        bool                          `json:"available"`
 }
@@ -53,10 +53,10 @@ type PublicChannelModelPriceTier struct {
 	Resolution                   string            `json:"resolution"`
 	VideoSeconds                 int               `json:"videoSeconds"`
 	BillingMode                  string            `json:"billingMode"`
-	UnitPriceMicrocredits        int64             `json:"unitPriceMicrocredits"`
-	InputTokenPriceMicrocredits  int64             `json:"inputTokenPriceMicrocredits"`
-	OutputTokenPriceMicrocredits int64             `json:"outputTokenPriceMicrocredits"`
-	CachedTokenPriceMicrocredits int64             `json:"cachedTokenPriceMicrocredits"`
+	UnitPriceMicrocredits        float64             `json:"unitPriceMicrocredits"`
+	InputTokenPriceMicrocredits  float64             `json:"inputTokenPriceMicrocredits"`
+	OutputTokenPriceMicrocredits float64             `json:"outputTokenPriceMicrocredits"`
+	CachedTokenPriceMicrocredits float64             `json:"cachedTokenPriceMicrocredits"`
 }
 
 // ModelCatalog 返回统一的模型目录
@@ -194,7 +194,7 @@ func (s *Service) sanitizeChannelModel(cm *model.ChannelModel) PublicChannelMode
 }
 
 // computeChannelModelPriceDisplay 计算渠道模型的价格展示信息
-func computeChannelModelPriceDisplay(cm *model.ChannelModel, priceTiers []PublicChannelModelPriceTier) (string, *int64, string) {
+func computeChannelModelPriceDisplay(cm *model.ChannelModel, priceTiers []PublicChannelModelPriceTier) (string, *float64, string) {
 	if len(priceTiers) == 0 {
 		return "provider", nil, "未配置"
 	}
@@ -212,7 +212,7 @@ func computeChannelModelPriceDisplay(cm *model.ChannelModel, priceTiers []Public
 }
 
 // getChannelTierDisplayPrice 获取渠道价格档的展示价格
-func getChannelTierDisplayPrice(tier PublicChannelModelPriceTier) int64 {
+func getChannelTierDisplayPrice(tier PublicChannelModelPriceTier) float64 {
 	if tier.BillingMode == "fixed_request" || tier.BillingMode == "per_second" {
 		return tier.UnitPriceMicrocredits
 	}

--- a/backend/internal/service/model_router.go
+++ b/backend/internal/service/model_router.go
@@ -1096,7 +1096,7 @@ func (s *Service) switchTaskToNextRoute(task *model.Task, attempts []model.Route
 	previousRouteID := task.RouteID
 	if err := s.repo.SwitchTaskLogicalRoute(task.ID, previousRouteID, selected.Route.ID, string(encoded), task.BillingOrderID, selected.ChannelModel.ChannelID, selected.ChannelModel.ID, replacement); err != nil {
 		if errors.Is(err, repository.ErrInsufficientCredits) {
-			return nil, BadAuthRequest("模型服务价格发生变化，当前积分余额不足")
+			return nil, BadAuthRequest("模型服务价格发生变化，当前余额不足")
 		}
 		return nil, err
 	}

--- a/backend/internal/service/outbound.go
+++ b/backend/internal/service/outbound.go
@@ -347,11 +347,18 @@ func resolveOutboundHostWithPolicy(ctx context.Context, host string, allowPrivat
 		return nil, BadAuthRequest("外部服务域名没有可用地址")
 	}
 	if !allowPrivateHost {
+		// 过滤掉私有/回环/链路本地地址，保留至少一个公网地址即可放行。
+		// 避免域名同时解析到私有 IPv6 ULA 和公网 IPv4 时被整体拒绝（代理 fake-ip 环境常见）。
+		publicAddresses := make([]net.IP, 0, len(addresses))
 		for _, ip := range addresses {
-			if blockedOutboundIP(ip) {
-				return nil, BadAuthRequest("不允许访问本机、内网或链路本地地址")
+			if !blockedOutboundIP(ip) {
+				publicAddresses = append(publicAddresses, ip)
 			}
 		}
+		if len(publicAddresses) == 0 {
+			return nil, BadAuthRequest("不允许访问本机、内网或链路本地地址")
+		}
+		addresses = publicAddresses
 	}
 	return addresses, nil
 }

--- a/backend/internal/service/price_validation.go
+++ b/backend/internal/service/price_validation.go
@@ -4,7 +4,7 @@ import "infinite-canvas/backend/internal/model"
 
 // ValidateChannelModelPrice 校验渠道模型价格配置的有效性
 // 根据 billingMode 检查必要的价格字段是否已配置
-func ValidateChannelModelPrice(billingMode string, capability string, protocol model.ChannelInterfaceType, unitPrice, inputPrice, outputPrice, cachedPrice int64) bool {
+func ValidateChannelModelPrice(billingMode string, capability string, protocol model.ChannelInterfaceType, unitPrice, inputPrice, outputPrice, cachedPrice float64) bool {
 	switch billingMode {
 	case "fixed_request":
 		// 固定价格模式：0 表示免费，负数无效。
@@ -36,7 +36,7 @@ func ValidatePriceTierPrice(tier *model.ChannelModelPriceTier, capability string
 
 // ComputePriceConfigured 根据价格内容计算 PriceConfigured 标志
 // 不再允许手动设置 PriceConfigured，必须由价格字段派生
-func ComputePriceConfigured(billingMode string, capability string, protocol model.ChannelInterfaceType, unitPrice, inputPrice, outputPrice, cachedPrice int64) bool {
+func ComputePriceConfigured(billingMode string, capability string, protocol model.ChannelInterfaceType, unitPrice, inputPrice, outputPrice, cachedPrice float64) bool {
 	return ValidateChannelModelPrice(billingMode, capability, protocol, unitPrice, inputPrice, outputPrice, cachedPrice)
 }
 
@@ -70,7 +70,7 @@ func HasValidPrice(channelModel *model.ChannelModel) bool {
 }
 
 // ValidateLogicalModelPrice 校验前台模型的价格配置
-func ValidateLogicalModelPrice(pricePolicy string, billingMode string, unitPrice, inputPrice, outputPrice, cachedPrice int64) bool {
+func ValidateLogicalModelPrice(pricePolicy string, billingMode string, unitPrice, inputPrice, outputPrice, cachedPrice float64) bool {
 	if pricePolicy == "channel" {
 		// 跟随渠道价格，不需要校验前台价格
 		return true

--- a/backend/internal/service/protocol_registry.go
+++ b/backend/internal/service/protocol_registry.go
@@ -34,6 +34,25 @@ func declarativeProtocolAdapterForContext(ctx context.Context, id string) (proto
 	return adapter, true
 }
 
+// hostAsyncAdapterForContext 返回内置（Go 原生）的异步协议适配器：
+// 它们在插件装载时被标记为 "host:<id>" 而非 "declarative"，但同样实现了
+// BuildCreate/ParseCreate/BuildPoll/ParsePoll，可由 runProtocolAdapterTask 执行。
+// 仅识别声明了 Poll 路径的异步适配器；同步适配器（如 openai-image）继续走各自的专用路径。
+func hostAsyncAdapterForContext(ctx context.Context, id string) (protocol.Adapter, bool) {
+	adapter, ok := protocolAdapterForContext(ctx, id)
+	if !ok {
+		return nil, false
+	}
+	meta := adapter.Metadata()
+	if !strings.HasPrefix(meta.Execution, "host:") {
+		return nil, false
+	}
+	if strings.TrimSpace(meta.Poll) == "" {
+		return nil, false
+	}
+	return adapter, true
+}
+
 func agentProtocolAdapterForContext(ctx context.Context, id string) (protocol.AgentAdapter, bool) {
 	registry, _ := ctx.Value(protocolRegistryContextKey{}).(*protocol.Registry)
 	if registry == nil {

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -1505,6 +1505,10 @@ func runImageTask(ctx context.Context, input canvasGenerationInput) (map[string]
 	if input.Config.InterfaceType == string(model.ChannelInterfaceGeminiImage) {
 		return runGeminiImageTask(ctx, input)
 	}
+	// 内置异步协议（如 hongniao-image、grsai-image）走通用适配器执行路径
+	if adapter, ok := hostAsyncAdapterForContext(ctx, input.Config.InterfaceType); ok {
+		return runProtocolAdapterTask(ctx, input, adapter)
+	}
 	var payload imageResponse
 	if input.Mask != nil {
 		// 蒙版编辑是强校验写路径：协议能力不明确时必须失败，不能静默退化为整图重绘。
@@ -2234,6 +2238,10 @@ func runAudioTask(ctx context.Context, input canvasGenerationInput) (map[string]
 	if _, ok := declarativeProtocolAdapterForContext(ctx, input.Config.InterfaceType); ok {
 		return runDeclarativeProtocolTask(ctx, input)
 	}
+	// 内置异步音频协议走通用适配器执行路径
+	if adapter, ok := hostAsyncAdapterForContext(ctx, input.Config.InterfaceType); ok {
+		return runProtocolAdapterTask(ctx, input, adapter)
+	}
 	if resolved, ok := input.Metadata["resolvedCharacterVersions"].([]interface{}); ok && len(resolved) > 0 {
 		voiceKey := metadataString(input.Metadata, "resolvedCharacterVoiceKey")
 		if voiceKey == "" || strings.TrimSpace(input.Config.AudioVoice) != voiceKey {
@@ -2766,6 +2774,10 @@ func runVideoTask(ctx context.Context, input canvasGenerationInput) (map[string]
 	}
 	if isSeedanceVideoConfig(input.Config) {
 		return runSeedanceVideosTask(ctx, input)
+	}
+	// 内置异步协议（如 hongniao-video）走通用适配器执行路径
+	if adapter, ok := hostAsyncAdapterForContext(ctx, input.Config.InterfaceType); ok {
+		return runProtocolAdapterTask(ctx, input, adapter)
 	}
 	if len(input.ReferenceVideos) > 0 || len(input.ReferenceAudios) > 0 {
 		return nil, errors.New("OpenAI 风格视频接口不支持参考视频或参考音频，请切换到 Seedance / Agent Plan 渠道")

--- a/backend/internal/service/provider_task_cancellation.go
+++ b/backend/internal/service/provider_task_cancellation.go
@@ -84,7 +84,7 @@ func (s *Service) requestProviderCancellation(ctx context.Context, task *model.T
 		s.CancelComfyBridgeRequest(task.ProviderRequestID)
 		if requestErr == nil && request.Status == "queued" {
 			if err := s.taskBilling().RefundBilling(task.BillingOrderID, "本地 ComfyUI Bridge 请求在领取前取消"); err != nil {
-				return s.markProviderCancellationUncertain(task, "Bridge 请求已取消，但积分退回失败："+err.Error())
+				return s.markProviderCancellationUncertain(task, "Bridge 请求已取消，但余额退回失败："+err.Error())
 			}
 			now := time.Now()
 			if err := s.repo.UpdateTaskProviderCancellation(task.ID, model.ProviderCancelStatusRequested, model.ProviderCancelStatusConfirmed, "", nil, &now); err != nil {
@@ -136,13 +136,13 @@ func (s *Service) reconcileProviderCancellation(ctx context.Context, task *model
 	switch outcome {
 	case providerCancellationConfirmed:
 		if err := billing.RefundBilling(task.BillingOrderID, "上游已确认取消"); err != nil {
-			return s.deferProviderCancellation(task, "上游已取消，但积分退回失败："+err.Error())
+			return s.deferProviderCancellation(task, "上游已取消，但余额退回失败："+err.Error())
 		}
 		now := time.Now()
 		if err := s.repo.UpdateTaskProviderCancellation(task.ID, model.ProviderCancelStatusRequested, model.ProviderCancelStatusConfirmed, "", nil, &now); err != nil {
 			return err
 		}
-		_ = s.log(task.UserID, task.ID, "info", "上游已确认取消，积分已退回", providerStatus)
+		_ = s.log(task.UserID, task.ID, "info", "上游已确认取消，余额已退回", providerStatus)
 	case providerCancellationSucceeded:
 		errorText := "取消请求发出前上游已完成，费用已结算"
 		var billingErr error
@@ -161,9 +161,9 @@ func (s *Service) reconcileProviderCancellation(ctx context.Context, task *model
 			return billingErr
 		}
 	case providerCancellationFailed:
-		errorText := "上游任务已失败，取消状态无法确认，积分已退回"
+		errorText := "上游任务已失败，取消状态无法确认，余额已退回"
 		if err := billing.RefundBilling(task.BillingOrderID, errorText); err != nil {
-			return s.deferProviderCancellation(task, "上游任务已失败，但积分退回失败："+err.Error())
+			return s.deferProviderCancellation(task, "上游任务已失败，但余额退回失败："+err.Error())
 		}
 		if err := s.repo.UpdateTaskProviderCancellation(task.ID, model.ProviderCancelStatusRequested, model.ProviderCancelStatusUncertain, errorText, nil, nil); err != nil {
 			return err

--- a/backend/internal/service/provider_task_recovery.go
+++ b/backend/internal/service/provider_task_recovery.go
@@ -166,8 +166,8 @@ func (s *Service) queryFailedVideoTask(ctx context.Context, task *model.Task, cl
 	billingSettled := true
 	if err := billing.SettleBilling(task.BillingOrderID, providerRequestID); err != nil {
 		billingSettled = false
-		uncertainErr := billing.MarkBillingUncertain(task.BillingOrderID, "人工查询确认生成成功，但积分结算失败："+err.Error())
-		_ = s.log(task.UserID, task.ID, "error", "任务恢复成功但积分结算失败，已进入待核对", err.Error())
+		uncertainErr := billing.MarkBillingUncertain(task.BillingOrderID, "人工查询确认生成成功，但余额结算失败："+err.Error())
+		_ = s.log(task.UserID, task.ID, "error", "任务恢复成功但余额结算失败，已进入待核对", err.Error())
 		if uncertainErr != nil {
 			return nil, errors.Join(err, fmt.Errorf("记录任务恢复后的计费待核对状态失败：%w", uncertainErr))
 		}

--- a/backend/internal/service/task_creation.go
+++ b/backend/internal/service/task_creation.go
@@ -116,7 +116,7 @@ func (s *Service) CreateTask(userID string, req CreateTaskRequest) (*model.Task,
 		return nil, BadAuthRequest(fmt.Sprintf("同时排队或运行的任务最多 %d 个，请等待已有任务完成", policy.Task.ActiveTaskLimit))
 	}
 	if errors.Is(err, repository.ErrInsufficientCredits) {
-		return nil, BadAuthRequest("积分不足，请先使用兑换码充值")
+		return nil, BadAuthRequest("余额不足，请先使用兑换码充值")
 	}
 	if errors.Is(err, repository.ErrLogicalModelUnavailable) {
 		return nil, BadAuthRequest("所选模型已停用、归档或配置已更新，请重新选择")

--- a/backend/internal/service/task_lifecycle.go
+++ b/backend/internal/service/task_lifecycle.go
@@ -80,7 +80,7 @@ func (w *taskLifecycleCoordinator) retryTask(userID string, id string) (*model.T
 	}
 	task, err = s.repo.RetryTaskWithBilling(userID, task, billingOrder, policy.Task.ActiveTaskLimit)
 	if errors.Is(err, repository.ErrInsufficientCredits) {
-		return nil, BadAuthRequest("积分不足，请先使用兑换码充值")
+		return nil, BadAuthRequest("余额不足，请先使用兑换码充值")
 	}
 	if errors.Is(err, repository.ErrActiveTaskLimit) {
 		return nil, BadAuthRequest(fmt.Sprintf("同时排队或运行的任务最多 %d 个，请等待已有任务完成", policy.Task.ActiveTaskLimit))
@@ -185,7 +185,7 @@ func (w *taskLifecycleCoordinator) cancelTask(_ context.Context, userID string, 
 			billingErr = s.taskBilling().MarkBillingUncertain(task.BillingOrderID, "用户取消时上游请求 ID 尚未确认，费用待核对")
 		}
 		if billingErr != nil {
-			_ = s.log(task.UserID, task.ID, "error", "取消任务后处理积分失败，已保留人工核对线索", billingErr.Error())
+			_ = s.log(task.UserID, task.ID, "error", "取消任务后处理余额失败，已保留人工核对线索", billingErr.Error())
 		}
 	}
 

--- a/backend/internal/service/task_terminal.go
+++ b/backend/internal/service/task_terminal.go
@@ -234,9 +234,9 @@ func (c *taskTerminalCoordinator) handleSuccess(task *model.Task) error {
 		}
 	}
 	if err := c.billing.SettleBilling(task.BillingOrderID, ""); err != nil {
-		uncertainErr := c.billing.MarkBillingUncertain(task.BillingOrderID, "生成成功但积分结算失败："+err.Error())
-		_ = c.logger.log(task.UserID, task.ID, "error", "积分结算失败，已进入待核对", err.Error())
-		completionErr = errors.Join(completionErr, fmt.Errorf("积分结算失败：%w", err))
+		uncertainErr := c.billing.MarkBillingUncertain(task.BillingOrderID, "生成成功但余额结算失败："+err.Error())
+		_ = c.logger.log(task.UserID, task.ID, "error", "余额结算失败，已进入待核对", err.Error())
+		completionErr = errors.Join(completionErr, fmt.Errorf("余额结算失败：%w", err))
 		if uncertainErr != nil {
 			completionErr = errors.Join(completionErr, fmt.Errorf("记录计费待核对状态失败：%w", uncertainErr))
 		}

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -14,6 +14,11 @@ services:
       dockerfile: backend/Dockerfile
       args:
         GOPROXY: ${GOPROXY:-https://proxy.golang.org,direct}
+    # 红鸟站点在 Cloudflare 后面；本机 Clash 的 fake-ip 会让后端 SSRF 校验把域名判成内网地址，
+    # 这里把域名固定到真实公网 IP（Cloudflare anycast）。若日后该 IP 失效，用 DoH 重新解析后更新。
+    extra_hosts:
+      - "open.hongniaoai.com:172.67.214.119"
+      - "api.hongniaoai.com:172.67.214.119"
 
   web:
     image: open-ai-canvas-web:server

--- a/web/src/components/auth/require-feature.tsx
+++ b/web/src/components/auth/require-feature.tsx
@@ -12,7 +12,7 @@ type FeatureKey = "shortDramaEnabled" | "taskCenterEnabled" | "creditsEnabled" |
 const featureNames: Record<FeatureKey, string> = {
     shortDramaEnabled: "短剧创作",
     taskCenterEnabled: "任务中心",
-    creditsEnabled: "积分中心",
+    creditsEnabled: "余额中心",
     frontendModelsEnabled: "前台模型",
     pluginCenterEnabled: "插件中心",
 };

--- a/web/src/components/canvas/canvas-active-task-panel.tsx
+++ b/web/src/components/canvas/canvas-active-task-panel.tsx
@@ -135,7 +135,7 @@ function ActiveTaskCard({
     const startedAt = task.startedAt || task.createdAt;
     const elapsedMs = Math.max(0, now - parseTime(startedAt));
     const durationLabel = `${task.status === "queued" ? "已等待" : "已运行"} ${formatDuration(elapsedMs)}`;
-    const billingLabel = task.billing ? `冻结 ${formatCredits(task.billing.amountMicrocredits)} 积分` : "未计费";
+    const billingLabel = task.billing ? `冻结 ${formatCredits(task.billing.amountMicrocredits)}` : "未计费";
     const statusTone = task.status === "running" ? theme.accent.primary : theme.node.muted;
     const transition = reducedMotion ? { duration: 0 } : aceternityMotion.spring.panel;
 

--- a/web/src/components/canvas/canvas-assistant-panel.tsx
+++ b/web/src/components/canvas/canvas-assistant-panel.tsx
@@ -4,7 +4,7 @@ import { Copy, Cpu, Settings2, Trash2, X } from "lucide-react";
 import { Button, Modal, Segmented, Select, Tooltip } from "antd";
 import { motion } from "motion/react";
 
-import { modelDisplayName, modelIcon, normalizeModelOptionValue, resolveModelChannel, resolveModelRequestConfig, selectableModelsByCapability, useConfigStore, useEffectiveConfig, type AiConfig } from "@/stores/use-config-store";
+import { modelDisplayName, modelIcon, modelOptionName, normalizeModelOptionValue, resolveModelChannel, resolveModelRequestConfig, selectableModelsByCapability, useConfigStore, useEffectiveConfig, type AiConfig } from "@/stores/use-config-store";
 import { canvasThemes } from "@/lib/canvas-theme";
 import { nanoid } from "nanoid";
 import { requestToolResponse, type ResponseFunctionTool, type ResponseInputMessage, type ResponseToolCall } from "@/services/api/image";
@@ -1207,13 +1207,16 @@ function AgentTextModelPicker({ config, value, onChange }: { config: AiConfig; v
     const options = useMemo(() => Array.from(new Set([value, ...selectableModelsByCapability(config, "text")].filter(Boolean))), [config, value]);
     const current = value || "";
     return (
-        <div className="min-w-0 max-w-[240px]" onMouseDown={(event) => event.stopPropagation()} onPointerDown={(event) => event.stopPropagation()}>
+        <div className="min-w-0 max-w-[240px]">
             <Select<string>
                 size="small"
                 variant="borderless"
                 value={current || undefined}
                 className="agent-text-model-select w-full"
                 popupMatchSelectWidth={288}
+                listHeight={320}
+                virtual={false}
+                getPopupContainer={(node) => node.parentElement || document.body}
                 options={options.map((model) => ({ value: model, label: agentModelLabel(config, model) }))}
                 notFoundContent={<span className="block py-2 text-center text-xs text-foreground/48">暂无文本模型</span>}
                 optionRender={(option) => {
@@ -1240,6 +1243,8 @@ function AgentTextModelPicker({ config, value, onChange }: { config: AiConfig; v
         </div>
     );
 }
+
+
 
 function agentModelSource(config: AiConfig, model: string) {
     const channel = resolveModelChannel(config, model);

--- a/web/src/components/canvas/canvas-node-prompt-panel.tsx
+++ b/web/src/components/canvas/canvas-node-prompt-panel.tsx
@@ -296,8 +296,8 @@ export function CanvasNodePromptPanel({ node, isRunning, onPromptChange, onConfi
 
     const renderSubmitButton = (expanded: boolean) => {
         const showCost = creditsEnabled && credits !== null;
-        const formattedCredits = credits?.toLocaleString("zh-CN", { maximumFractionDigits: 6 });
-        const actionLabel = isRunning ? "生成中" : showCost ? `预计消耗 ${formattedCredits} 积分，生成` : "生成";
+        const formattedCredits = credits != null ? "¥" + credits.toLocaleString("zh-CN", { maximumFractionDigits: 6 }) : undefined;
+        const actionLabel = isRunning ? "生成中" : showCost ? `预计消耗 ${formattedCredits}，生成` : "生成";
         return (
             <Button
                 type="text"

--- a/web/src/components/layout/workspace-account-menu.tsx
+++ b/web/src/components/layout/workspace-account-menu.tsx
@@ -22,7 +22,7 @@ export function WorkspaceAccountMenu() {
 
     const balance = availableMicrocredits === null
         ? "--"
-        : (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+        : "¥" + (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
 
     if (!hydrated) {
         return <span className="size-9 animate-pulse rounded-[var(--r-md)] bg-foreground/[.06]" aria-hidden />;
@@ -41,7 +41,7 @@ export function WorkspaceAccountMenu() {
                         <UserAvatar user={user} className="size-8" />
                         <div className="min-w-0 flex-1">
                             <div className="flex min-w-0 items-center gap-1.5"><span className="truncate text-sm font-medium">{user.displayName || user.username}</span><IdentityProviderBadge user={user} /></div>
-                            {creditsEnabled ? <div className="mt-0.5 truncate text-[var(--fs-label)] tabular-nums text-foreground/45">可用 {balance} 积分</div> : null}
+                            {creditsEnabled ? <div className="mt-0.5 truncate text-[var(--fs-label)] tabular-nums text-foreground/45">可用 {balance}</div> : null}
                         </div>
                     </div>
 

--- a/web/src/components/layout/workspace-sidebar-footer.tsx
+++ b/web/src/components/layout/workspace-sidebar-footer.tsx
@@ -32,7 +32,7 @@ export function WorkspaceSidebarFooter({ expandedClassName, collapsedClassName, 
     const { availableMicrocredits } = useWalletBalance(user?.id, creditsEnabled);
     const balance = availableMicrocredits === null
         ? "--"
-        : (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+        : "¥" + (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
 
     const handleLogout = async () => {
         try {
@@ -71,7 +71,7 @@ export function WorkspaceSidebarFooter({ expandedClassName, collapsedClassName, 
                                 <UserAvatar user={user} className="size-8" />
                                 <div className="min-w-0 flex-1">
                                     <div className="flex min-w-0 items-center gap-1.5"><span className="truncate text-sm font-medium">{user.displayName || user.username}</span><IdentityProviderBadge user={user} /></div>
-                                    {creditsEnabled ? <div className="mt-0.5 truncate text-[var(--fs-label)] tabular-nums text-foreground/45">可用 {balance} 积分</div> : null}
+                                    {creditsEnabled ? <div className="mt-0.5 truncate text-[var(--fs-label)] tabular-nums text-foreground/45">可用 {balance}</div> : null}
                                 </div>
                             </div>
 
@@ -94,11 +94,11 @@ export function WorkspaceSidebarFooter({ expandedClassName, collapsedClassName, 
                         </div>
                     )}
                 >
-                    <button type="button" className={cn("app-workspace-account-button flex min-h-10 w-full min-w-0 items-center overflow-hidden rounded-md text-left transition-colors hover:bg-surface-hover", accountClassName)} title={creditsEnabled ? `${user.displayName || user.username} · ${balance} 积分` : user.displayName || user.username}>
+                    <button type="button" className={cn("app-workspace-account-button flex min-h-10 w-full min-w-0 items-center overflow-hidden rounded-md text-left transition-colors hover:bg-surface-hover", accountClassName)} title={creditsEnabled ? `${user.displayName || user.username} · ${balance}` : user.displayName || user.username}>
                         <UserAvatar user={user} className="size-7" />
                         <span className={cn("min-w-0 flex-1 flex-col", expandedClassName)}>
                             <span className="truncate text-xs font-medium">{user.displayName || user.username}</span>
-                            {creditsEnabled ? <span className="mt-0.5 block truncate text-[var(--fs-micro)] tabular-nums text-foreground/42">{balance} 积分</span> : null}
+                            {creditsEnabled ? <span className="mt-0.5 block truncate text-[var(--fs-micro)] tabular-nums text-foreground/42">{balance}</span> : null}
                         </span>
                         <ChevronRight className={cn("size-3.5 shrink-0 text-foreground/30", expandedClassName)} />
                     </button>

--- a/web/src/components/layout/workspace-sidebar-nav.tsx
+++ b/web/src/components/layout/workspace-sidebar-nav.tsx
@@ -360,7 +360,7 @@ export function WorkspaceSidebarNav({ collapsed, onNavigate, onOpenSearch, onExp
 
     const balance = availableMicrocredits === null
         ? "--"
-        : (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
+        : "¥" + (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 2 });
 
     const { groups, footer } = useMemo(() => buildNav(features, balance, user?.role === "admin"), [features, balance, user?.role]);
 

--- a/web/src/components/layout/workspace-top-bar.tsx
+++ b/web/src/components/layout/workspace-top-bar.tsx
@@ -16,7 +16,7 @@ const PAGE_TITLES: Record<string, string> = {
     tasks: "任务",
     assets: "素材",
     skills: "技能库",
-    wallet: "积分中心",
+    wallet: "余额中心",
     settings: "设置",
 };
 

--- a/web/src/components/model-picker.tsx
+++ b/web/src/components/model-picker.tsx
@@ -245,7 +245,6 @@ export function ModelPicker({ config, value, onChange, capability, className, po
                             <ModelIcon config={config} model={current} />
                         </span>
                         <span className="min-w-0 flex-1 truncate">{current ? (creationVariant ? pickerModelDisplayName(config, current, showConfiguredModelName) : pickerModelOptionLabel(config, current, showConfiguredModelName)) : placeholder}</span>
-                        {showSelectedPrice && creditsEnabled ? <ModelPrice price={currentPrice} quote={routeQuote} compact /> : null}
                     </span>
                     <ChevronDown className={cn("canvas-model-picker-chevron", open && "is-open")} aria-hidden="true" />
                 </button>
@@ -284,7 +283,22 @@ function ModelLabel({
     const logicalCost = channel.modelCosts?.find((item) => item.model === modelOptionName(model));
     const logicalSpec = logicalCost?.logicalCapabilitySpec;
     const videoProfile = capability === "video" ? modelCapabilityConfigFor(config, model).video : undefined;
-    const capabilitySummary = disabledReason || logicalCost?.description?.trim() || (logicalSpec ? logicalCapabilitySummary(logicalSpec) : videoProfile ? `${formatDurationSummary(videoProfile)} · ${videoProfile.resolutions.map((item) => item.toUpperCase()).join("/")}` : meta.description);
+    const capabilitySummary = disabledReason || logicalCost?.description?.trim() || (logicalSpec ? logicalCapabilitySummary(logicalSpec, logicalCost?.logicalCapabilityProfiles) : videoProfile ? videoCapabilitySummary(videoProfile) : meta.description);
+
+    // 文本模型：在灰色描述位置显示价格
+    const textPrice = (() => {
+        if (capability !== "text" || !logicalCost || logicalCost.billingMode !== "token") return null;
+        const input = logicalCost.inputTokenPriceMicrocredits || 0;
+        const output = logicalCost.outputTokenPriceMicrocredits || 0;
+        if (input <= 0 && output <= 0) return null;
+        const format = (value: number) => "¥" + formatDecimalPrice(value);
+        const parts = [];
+        if (input > 0) parts.push(`入${format(input)}`);
+        if (output > 0) parts.push(`出${format(output)}`);
+        return parts.join(" ");
+    })();
+    const subtitle = textPrice || capabilitySummary;
+
     return (
         <span className="flex w-full min-w-0 items-center gap-1.5 overflow-hidden py-0">
             <span className="grid size-6 shrink-0 place-items-center rounded-md" style={{ background: theme.toolbar.itemHover }}>
@@ -292,11 +306,11 @@ function ModelLabel({
             </span>
             <span className="min-w-0 flex-1 overflow-hidden">
                 <span className="block min-w-0 truncate text-[var(--fs-label)] font-medium leading-none">{pickerModelDisplayName(config, model, showConfiguredModelName)}</span>
-                <span className="mt-1 block truncate text-[var(--fs-tiny)]" style={{ color: theme.node.muted }} title={capabilitySummary}>
-                    {capabilitySummary}
+                <span className="mt-1 block truncate text-[var(--fs-tiny)]" style={{ color: textPrice ? "var(--color-amber-500)" : theme.node.muted }} title={subtitle}>
+                    {subtitle}
                 </span>
             </span>
-            {showPrice ? <ModelPrice price={modelMenuPrice(config, model, capability, true)} /> : null}
+            {showPrice && !textPrice ? <ModelPrice price={modelMenuPrice(config, model, capability, true)} /> : null}
             {!creationVariant && meta.time ? (
                 <span className="shrink-0 rounded-full px-1.5 py-0.5 text-[var(--fs-tiny)] tabular-nums" style={{ background: theme.toolbar.itemHover, color: theme.node.muted }}>
                     {meta.time}
@@ -306,7 +320,7 @@ function ModelLabel({
     );
 }
 
-function logicalCapabilitySummary(spec: NonNullable<NonNullable<AiConfig["channels"][number]["modelCosts"]>[number]["logicalCapabilitySpec"]>) {
+function logicalCapabilitySummary(spec: NonNullable<NonNullable<AiConfig["channels"][number]["modelCosts"]>[number]["logicalCapabilitySpec"]>, profiles?: NonNullable<NonNullable<AiConfig["channels"][number]["modelCosts"]>[number]["logicalCapabilityProfiles"]>) {
     const operationLabels: Record<string, string> = {
         text_to_video: "文生视频",
         image_to_video: "图生视频",
@@ -338,20 +352,67 @@ function logicalCapabilitySummary(spec: NonNullable<NonNullable<AiConfig["channe
         audioSpeed: "语速",
     };
     const values: string[] = [];
-    values.push(...(spec.operations || []).map((operation) => operationLabels[operation] || operation));
+    // 视频模型不显示操作模式（文生/图生/全模态），做视频的都懂；其他能力仍显示
+    if (spec.capability !== "video") {
+        values.push(...(spec.operations || []).map((operation) => operationLabels[operation] || operation));
+    }
     for (const [name, constraint] of Object.entries(spec.inputs || {})) {
-        if (constraint.max <= 0) continue;
         const definition = inputLabels[name];
         if (!definition) continue;
-        values.push(spec.capability === "text" ? `支持${definition.label}` : `${definition.label}最多 ${constraint.max}${definition.unit}`);
+        // 用渠道规格里最宽松的值（避免所有渠道交集导致显示偏小）
+        let maxValue = constraint.max || 0;
+        if (profiles?.length) {
+            for (const profile of profiles) {
+                const profileMax = profile.inputs?.[name]?.max;
+                if (profileMax !== undefined && profileMax > maxValue) {
+                    maxValue = profileMax;
+                }
+            }
+        }
+        if (maxValue <= 0) continue;
+        values.push(spec.capability === "text" ? `支持${definition.label}` : `${definition.label}最多 ${maxValue}${definition.unit}`);
     }
     for (const [name, constraint] of Object.entries(spec.options || {})) {
         const label = optionLabels[name];
         if (!label) continue;
+        // 视频时长不再列出所有秒数，改为显示最长时长
+        if (name === "videoSeconds" || name === "duration") {
+            if (constraint.values?.length) {
+                const maxSeconds = Math.max(...constraint.values.map(Number).filter(Number.isFinite));
+                values.push(`最长 ${maxSeconds} 秒`);
+            } else if (constraint.max !== undefined) {
+                values.push(`最长 ${constraint.max} 秒`);
+            }
+            continue;
+        }
         if (constraint.values?.length) values.push(`${label} ${constraint.values.map(publicScalarLabel).join("/")}`);
         else if (constraint.min !== undefined && constraint.max !== undefined) values.push(`${label} ${constraint.min}-${constraint.max}`);
     }
-    return values.slice(0, 2).join(" · ") || "智能匹配当前输入";
+    // 视频模型显示更多参数（操作模式 + 参考素材 + 时长 + 分辨率），不限制只取前2个
+    const maxItems = spec.capability === "video" ? 6 : 2;
+    return values.slice(0, maxItems).join(" · ") || "智能匹配当前输入";
+}
+
+// 渠道模型（无 logicalSpec）的视频能力说明，用 videoProfile 生成简洁格式
+function videoCapabilitySummary(profile: NonNullable<ReturnType<typeof modelCapabilityConfigFor>["video"]>) {
+    const values: string[] = [];
+    // 参考素材
+    const ref = profile.references || {};
+    if (ref.maxImages > 0) values.push(`参考图最多 ${ref.maxImages} 张`);
+    if (ref.maxVideos > 0) values.push(`参考视频最多 ${ref.maxVideos} 个`);
+    if (ref.maxAudios > 0) values.push(`参考音频最多 ${ref.maxAudios} 个`);
+    // 最长时长
+    const dur = profile.duration || {};
+    if (dur.max !== undefined) {
+        values.push(`最长 ${dur.max} 秒`);
+    } else if (dur.values?.length) {
+        values.push(`最长 ${Math.max(...dur.values)} 秒`);
+    }
+    // 分辨率
+    if (profile.resolutions?.length) {
+        values.push(`分辨率 ${profile.resolutions.map((r) => r.toUpperCase()).join("/")}`);
+    }
+    return values.slice(0, 6).join(" · ") || "智能匹配当前输入";
 }
 
 function publicScalarLabel(value: unknown) {
@@ -382,7 +443,19 @@ function modelMenuPrice(config: AiConfig, model: string, capability?: ModelCapab
 		const matched = summary ? tiers : priceTiersForCurrentSelection(tiers, capability, config, requirements);
         return channelTierPriceSummary(matched.length ? matched : tiers, tiers);
     }
-    if (cost.billingMode === "token") return { kind: "estimate" };
+    if (cost.billingMode === "token") {
+        const input = cost.inputTokenPriceMicrocredits || 0;
+        const output = cost.outputTokenPriceMicrocredits || 0;
+        if (input > 0 || output > 0) {
+            const format = (value: number) => "¥" + formatDecimalPrice(value);
+            const parts = [];
+            if (input > 0) parts.push(`入${format(input)}`);
+            if (output > 0) parts.push(`出${format(output)}`);
+            const label = parts.join(" ");
+            return { kind: "tiers", label, compactLabel: label, title: `输入 ${format(input)}/1M tokens，输出 ${format(output)}/1M tokens` };
+        }
+        return { kind: "estimate" };
+    }
     return { kind: "fixed", value: cost.unitPriceMicrocredits / 1_000_000, unit: cost.billingMode === "per_second" ? "秒" : "次" };
 }
 
@@ -408,13 +481,14 @@ function channelTierPriceSummary(
         .filter((tier) => tier.billingMode === "per_second")
         .map((tier) => tier.unitPriceMicrocredits / 1_000_000)
         .filter((value) => value > 0);
-    const hasTokenTier = visibleTiers.some((tier) => tier.billingMode === "token");
+    const tokenTiers = visibleTiers.filter((tier) => tier.billingMode === "token");
+    const hasTokenTier = tokenTiers.length > 0;
     const label = fixedRequestValues.length
-        ? formatPriceRange(fixedRequestValues, "积分")
+        ? formatPriceRange(fixedRequestValues, "")
         : perSecondValues.length
-            ? formatPriceRange(perSecondValues, "积分/秒")
+            ? formatPriceRange(perSecondValues, "/秒")
             : hasTokenTier
-                ? "按量预估"
+                ? formatTokenPriceRange(tokenTiers)
                 : "未配置";
     return {
         kind: "tiers",
@@ -426,8 +500,32 @@ function channelTierPriceSummary(
 
 function formatPriceRange(values: number[], suffix: string) {
     const unique = Array.from(new Set(values)).sort((left, right) => left - right);
-    const format = (value: number) => value.toLocaleString("zh-CN", { maximumFractionDigits: 3 });
-    return unique.length === 1 ? `${format(unique[0])} ${suffix}` : `${format(unique[0])}-${format(unique[unique.length - 1])} ${suffix}`;
+    const format = (value: number) => "¥" + value.toLocaleString("zh-CN", { maximumFractionDigits: 3 });
+    const base = unique.length === 1 ? format(unique[0]) : `${format(unique[0])}-${format(unique[unique.length - 1])}`;
+    return suffix ? `${base} ${suffix}` : base;
+}
+
+function formatTokenPriceRange(tiers: NonNullable<NonNullable<AiConfig["channels"][number]["modelCosts"]>[number]["logicalPriceTiers"]>) {
+    // 价格单位：微积分/token，1 微积分 = ¥1/1M tokens，价格支持小数
+    const inputValues = tiers
+        .map((tier) => (tier as any).inputTokenPriceMicrocredits || 0)
+        .filter((value) => value > 0);
+    const outputValues = tiers
+        .map((tier) => (tier as any).outputTokenPriceMicrocredits || 0)
+        .filter((value) => value > 0);
+    const format = (value: number) => "¥" + formatDecimalPrice(value);
+    const inputStr = inputValues.length ? `入${format(inputValues[0])}` : "";
+    const outputStr = outputValues.length ? `出${format(outputValues[0])}` : "";
+    return [inputStr, outputStr].filter(Boolean).join(" ") || "按量预估";
+}
+
+// 格式化小数价格，保留所有有效小数位，去掉末尾多余的零
+function formatDecimalPrice(value: number): string {
+    if (value === 0) return "0";
+    // 先转字符串，处理浮点数精度问题
+    const str = value.toPrecision(10);
+    // 去掉末尾的零和小数点
+    return str.replace(/\.?0+$/, "");
 }
 
 function tierResolutionLabel(value: string) {
@@ -455,18 +553,26 @@ function tierSpecificationLabel(tier: NonNullable<NonNullable<AiConfig["channels
 }
 
 function tierPriceLabel(tier: NonNullable<NonNullable<AiConfig["channels"][number]["modelCosts"]>[number]["logicalPriceTiers"]>[number]) {
-    if (tier.billingMode === "token") return "按量预估";
-    return `${formatPriceRange([tier.unitPriceMicrocredits / 1_000_000], tier.billingMode === "per_second" ? "积分/秒" : "积分")}`;
+    if (tier.billingMode === "token") {
+        const input = (tier as any).inputTokenPriceMicrocredits || 0;
+        const output = (tier as any).outputTokenPriceMicrocredits || 0;
+        const format = (value: number) => "¥" + formatDecimalPrice(value);
+        const parts = [];
+        if (input > 0) parts.push(`输入${format(input)}/1M`);
+        if (output > 0) parts.push(`输出${format(output)}/1M`);
+        return parts.length ? parts.join(" ") : "按量预估";
+    }
+    return `${formatPriceRange([tier.unitPriceMicrocredits / 1_000_000], tier.billingMode === "per_second" ? "/秒" : "")}`;
 }
 
 function ModelPrice({ price, quote, compact = false }: { price: ModelMenuPrice | null | undefined; quote?: LogicalModelQuote; compact?: boolean }) {
     if (quote) {
-        const amount = (quote.amountMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 3 });
+        const amount = "¥" + (quote.amountMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 3 });
         const label = quote.estimated ? `预计 ${amount}` : `${amount}`;
         return (
-            <span className="inline-flex shrink-0 items-center gap-0.5 text-[var(--fs-tiny)] font-bold tabular-nums text-amber-600 dark:text-amber-300" title={`${quote.estimated ? "预计" : "本次"}消耗 ${amount} 积分`}>
+            <span className="inline-flex shrink-0 items-center gap-0.5 text-[var(--fs-tiny)] font-bold tabular-nums text-amber-600 dark:text-amber-300" title={`${quote.estimated ? "预计" : "本次"}消耗 ${amount}`}>
                 <Coins className="size-3" />
-                {compact ? label : `${label} 积分`}
+                {label}
             </span>
         );
     }
@@ -484,9 +590,9 @@ function ModelPrice({ price, quote, compact = false }: { price: ModelMenuPrice |
         return <span className="shrink-0 text-[var(--fs-tiny)] font-medium text-amber-600 dark:text-amber-300">按量预估</span>;
     }
     return (
-        <span className="inline-flex shrink-0 items-center gap-0.5 text-[var(--fs-tiny)] font-bold tabular-nums text-amber-600 dark:text-amber-300" title={`每${price.unit}消耗 ${price.value.toLocaleString("zh-CN", { maximumFractionDigits: 6 })} 积分`}>
+        <span className="inline-flex shrink-0 items-center gap-0.5 text-[var(--fs-tiny)] font-bold tabular-nums text-amber-600 dark:text-amber-300" title={`每${price.unit}消耗 ¥${price.value.toLocaleString("zh-CN", { maximumFractionDigits: 6 })}`}>
             <Coins className="size-3" />
-            {price.value.toLocaleString("zh-CN", { maximumFractionDigits: compact ? 3 : 6 })}/{price.unit}
+            ¥{price.value.toLocaleString("zh-CN", { maximumFractionDigits: compact ? 3 : 6 })}/{price.unit}
         </span>
     );
 }

--- a/web/src/constant/credits.tsx
+++ b/web/src/constant/credits.tsx
@@ -12,5 +12,5 @@ export function CreditSymbol({ className, ...props }: ComponentProps<"span">) {
 }
 
 export function formatCredits(value: number, maximumFractionDigits = 6) {
-    return (value / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits });
+    return "¥" + (value / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits });
 }

--- a/web/src/constant/navigation-tools.ts
+++ b/web/src/constant/navigation-tools.ts
@@ -45,7 +45,7 @@ export const navigationTools = [
     },
     {
         slug: "wallet",
-        label: "积分中心",
+        label: "余额中心",
         icon: CircleDollarSign,
         section: "工作台管理",
     },

--- a/web/src/hooks/use-wallet-balance.ts
+++ b/web/src/hooks/use-wallet-balance.ts
@@ -17,7 +17,7 @@ export function useWalletBalance(userId?: string, enabled = true) {
         enabled: Boolean(activeUserId),
         queryFn: async () => {
             const wallet = await getWallet(1, 1);
-            if (wallet.account.userId !== activeUserId) throw new Error("积分账户与当前用户不一致");
+            if (wallet.account.userId !== activeUserId) throw new Error("余额账户与当前用户不一致");
             return wallet.account.availableMicrocredits;
         },
         staleTime: WALLET_REFRESH_INTERVAL_MS,
@@ -35,7 +35,7 @@ export function useWalletBalance(userId?: string, enabled = true) {
     }, [activeUserId, queryClient]);
 
     useEffect(() => {
-        if (query.error) console.warn("积分余额刷新失败", query.error);
+        if (query.error) console.warn("余额刷新失败", query.error);
     }, [query.error]);
 
     return {

--- a/web/src/lib/generation-error.ts
+++ b/web/src/lib/generation-error.ts
@@ -1,6 +1,6 @@
 export const CONTENT_MODERATION_ERROR_CODE = "sensitive_words_detected";
 
-export const CONTENT_MODERATION_MESSAGE = "内容审核未通过，本次平台积分未扣除或已退还。请修改提示词后重新生成。";
+export const CONTENT_MODERATION_MESSAGE = "内容审核未通过，本次平台费用未扣除或已退还。请修改提示词后重新生成。";
 
 const DEFAULT_GENERATION_ERROR_MESSAGE = "生成失败，请稍后重试。";
 const NETWORK_ERROR_MESSAGE = "网络异常。";

--- a/web/src/lib/user-session.ts
+++ b/web/src/lib/user-session.ts
@@ -121,7 +121,7 @@ function managedModelChannels(models: PublicLogicalModel[]) {
             inputTokenPriceMicrocredits: item.inputPriceMicrocredits,
             outputTokenPriceMicrocredits: item.outputPriceMicrocredits,
             cachedTokenPriceMicrocredits: item.cachedPriceMicrocredits,
-            capabilityConfig: projectLogicalCapability(item.capabilitySpec, item.defaultOptions),
+            capabilityConfig: projectLogicalCapability(item.capabilitySpec, item.defaultOptions, item.capabilityProfiles),
             logicalModelId: item.id,
             logicalCapabilitySpec: item.capabilitySpec,
             logicalCapabilityProfiles: item.capabilityProfiles,
@@ -191,7 +191,7 @@ function systemChannelModelChannels(channels: PublicChannelCatalog[]): ModelChan
     });
 }
 
-function projectLogicalCapability(spec: CapabilitySpec, defaults: Record<string, unknown>): ModelCapabilityConfig {
+function projectLogicalCapability(spec: CapabilitySpec, defaults: Record<string, unknown>, profiles?: CapabilitySpec[]): ModelCapabilityConfig {
     const projected = defaultModelCapabilityConfig();
     if (spec.capability === "image" && projected.image) {
         projected.image.references.maxImages = spec.inputs?.image?.max ?? 0;
@@ -227,7 +227,17 @@ function projectLogicalCapability(spec: CapabilitySpec, defaults: Record<string,
         projected.video.defaultRatio = concreteDefault(defaults.size, projected.video.ratios, "");
         projected.video.resolutions = stringValues(spec.options?.vquality || spec.options?.resolution);
         projected.video.defaultResolution = String(defaults.vquality ?? projected.video.resolutions[0] ?? "");
-        projected.video.generateAudio = booleanOption(spec.options?.videoGenerateAudio, defaults.videoGenerateAudio);
+        // 合并渠道规格：默认规格不支持音频但某渠道支持时，启用并默认打开
+        const audioSpec = spec.options?.videoGenerateAudio;
+        const audioSupportedBySpec = (audioSpec?.values || []).some((v) => v === true || v === "true");
+        const audioSupportedByProfile = profiles?.some((p) =>
+            (p.options?.videoGenerateAudio?.values || []).some((v) => v === true || v === "true"),
+        );
+        if (!audioSupportedBySpec && audioSupportedByProfile) {
+            projected.video.generateAudio = { supported: true, default: true };
+        } else {
+            projected.video.generateAudio = booleanOption(audioSpec, defaults.videoGenerateAudio);
+        }
         projected.video.watermark = booleanOption(spec.options?.videoWatermark, defaults.videoWatermark);
     }
     return projected;

--- a/web/src/pages/admin/admin-route-pages.tsx
+++ b/web/src/pages/admin/admin-route-pages.tsx
@@ -65,12 +65,12 @@ export function CreditOperationsPage() {
     const [activeOperation, setActiveOperation] = useState<"policy" | "adjustment" | null>(null);
     return (
         <AdminPageFrame
-            title="积分运营"
-            description="异常计费核对、积分策略与人工调账"
+            title="余额运营"
+            description="异常计费核对、余额策略与人工调账"
             actions={
                 <>
                     <Button icon={<Settings2 className="size-4" />} onClick={() => setActiveOperation("policy")}>
-                        积分策略
+                        余额策略
                     </Button>
                     <Button type="primary" icon={<UserRoundCog className="size-4" />} onClick={() => setActiveOperation("adjustment")}>
                         人工调账
@@ -78,7 +78,7 @@ export function CreditOperationsPage() {
                 </>
             }
         >
-            <Suspense fallback={<PageFallback label="积分运营数据" />}>
+            <Suspense fallback={<PageFallback label="余额运营数据" />}>
                 <CreditOperationsPanel users={references.users} activeOperation={activeOperation} onOperationChange={setActiveOperation} />
             </Suspense>
         </AdminPageFrame>

--- a/web/src/pages/admin/components/admin-shell.tsx
+++ b/web/src/pages/admin/components/admin-shell.tsx
@@ -71,7 +71,7 @@ const adminNavigation: Array<{ label: string; items: AdminNavigationItem[] }> = 
         label: "运营",
         items: [
             { path: "/admin/announcements", label: "系统公告", description: "发布、关闭与历史公告", icon: <BellRing className="size-4" /> },
-            { path: "/admin/credit-operations", label: "积分运营", description: "人工调账与异常计费", icon: <Coins className="size-4" /> },
+            { path: "/admin/credit-operations", label: "余额运营", description: "人工调账与异常计费", icon: <Coins className="size-4" /> },
             { path: "/admin/redemption-codes", label: "兑换码", description: "生成与查看兑换码批次", icon: <TicketCheck className="size-4" /> },
             { path: "/admin/logs", label: "请求明细", description: "上游调用与费用", icon: <FileClock className="size-4" /> },
         ],

--- a/web/src/pages/admin/components/admin-user-detail-drawer.tsx
+++ b/web/src/pages/admin/components/admin-user-detail-drawer.tsx
@@ -51,7 +51,7 @@ export function AdminUserDetailDrawer({ userId, onClose, previousUserId, nextUse
                     setLedgerTotal(result.total);
                 }
             })
-            .catch((error) => active && message.error(error instanceof Error ? error.message : "读取积分流水失败"));
+            .catch((error) => active && message.error(error instanceof Error ? error.message : "读取余额流水失败"));
         return () => {
             active = false;
         };
@@ -121,14 +121,14 @@ export function AdminUserDetailDrawer({ userId, onClose, previousUserId, nextUse
                                             { key: "email", label: "邮箱", children: detail.user.email || "未填写" },
                                             { key: "role", label: "角色", children: detail.user.role === "admin" ? "管理员" : "普通用户" },
                                             { key: "status", label: "状态", children: <AdminStatusBadge label={detail.user.status === "active" ? "启用" : "停用"} tone={detail.user.status === "active" ? "success" : "neutral"} /> },
-                                            { key: "available", label: "可用积分", children: formatCredits(detail.account.availableMicrocredits) },
-                                            { key: "reserved", label: "冻结积分", children: formatCredits(detail.account.reservedMicrocredits) },
+                                            { key: "available", label: "可用余额", children: formatCredits(detail.account.availableMicrocredits) },
+                                            { key: "reserved", label: "冻结余额", children: formatCredits(detail.account.reservedMicrocredits) },
                                             { key: "created", label: "注册时间", children: formatTime(detail.user.createdAt) },
                                             { key: "login", label: "最后登录", children: formatTime(detail.user.lastLoginAt) },
                                         ]}
                                     />
                                     <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-                                        {Object.entries({ 积分流水: detail.counts.ledgerEntries, 生成任务: detail.counts.tasks, 上游请求: detail.counts.apiCalls, 管理操作: detail.counts.auditEvents }).map(([label, value]) => (
+                                        {Object.entries({ 余额流水: detail.counts.ledgerEntries, 生成任务: detail.counts.tasks, 上游请求: detail.counts.apiCalls, 管理操作: detail.counts.auditEvents }).map(([label, value]) => (
                                             <div key={label} className="rounded-md border border-border p-3">
                                                 <div className="text-xs text-foreground/50">{label}</div>
                                                 <div className="mt-1 text-xl font-semibold tabular-nums">{value}</div>
@@ -154,7 +154,7 @@ export function AdminUserDetailDrawer({ userId, onClose, previousUserId, nextUse
                         },
                         {
                             key: "ledger",
-                            label: `积分流水 ${detail.counts.ledgerEntries}`,
+                            label: `余额流水 ${detail.counts.ledgerEntries}`,
                             children: (
                                 <AdminDataTable
                                     table={{

--- a/web/src/pages/admin/components/api-log-detail-drawer.tsx
+++ b/web/src/pages/admin/components/api-log-detail-drawer.tsx
@@ -73,7 +73,7 @@ function LogDetail({ log, querying, onQueryProviderTask }: { log: ApiCallLog; qu
         ["总耗时", formatDuration(log.durationMs)],
         ["视频轮询", log.capability === "video" ? `${log.pollCount || 0} 次` : "--"],
         ["Token", log.usageAvailable ? `${log.inputTokens} 输入 / ${log.outputTokens} 输出 / ${log.cachedTokens} 缓存` : "未返回"],
-        ["积分计费", billingText(log)],
+        ["余额计费", billingText(log)],
         ["上游成本", log.costAvailable ? `${log.currency || "USD"} ${(log.estimatedCostMicros / 1_000_000).toFixed(6)}` : "未配置成本"],
         ["错误信息", [log.errorCode, log.error].filter(Boolean).join(" · ") || "--"],
         ["方法与路径", `${log.method} ${log.path}`],
@@ -110,10 +110,10 @@ function LogDetail({ log, querying, onQueryProviderTask }: { log: ApiCallLog; qu
 }
 
 function billingText(log: ApiCallLog) {
-    if (!log.billingAvailable) return "未扣积分";
+    if (!log.billingAvailable) return "未扣费";
     const status = log.billingStatus || "reserved";
     const statusLabel = ({ settled: "已结算", refunded: "已退回", uncertain: "待核对", running: "运行中", reserved: "已预授权" } as const)[status];
-    return `${formatCredits(log.billingAmountMicrocredits)} 积分 · ${statusLabel}`;
+    return `${formatCredits(log.billingAmountMicrocredits)} · ${statusLabel}`;
 }
 
 function PayloadPanel({ value, empty }: { value?: string; empty: string }) {

--- a/web/src/pages/admin/components/channel-model-manager.tsx
+++ b/web/src/pages/admin/components/channel-model-manager.tsx
@@ -538,7 +538,7 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                     ) : null}
 
                     <section className="admin-form-section admin-model-editor-section">
-                        <SectionHeading title="用户积分价格" description="默认只需填写一个统一价格；需要区分生成方式、质量或尺寸时，再添加规格价格。" />
+                        <SectionHeading title="用户价格" description="默认只需填写一个统一价格；需要区分生成方式、质量或尺寸时，再添加规格价格。" />
                         <div className="admin-model-editor-section-content">
                             <Form.List
                                 name="priceTiers"
@@ -732,7 +732,7 @@ function PriceTierFields({
                                 </div>
                             )
                         ) : (
-                            <Form.Item className="admin-price-tier-unit-price mb-0" name={[index, "unitPrice"]} label={billingMode === "per_second" ? "每秒消耗积分" : "每次消耗积分"} rules={[{ required: true, message: "请输入积分价格" }]}>
+                            <Form.Item className="admin-price-tier-unit-price mb-0" name={[index, "unitPrice"]} label={billingMode === "per_second" ? "每秒消耗金额" : "每次消耗金额"} rules={[{ required: true, message: "请输入价格" }]}>
                                 <InputNumber className="w-full" min={0} max={1_000_000} precision={6} step={0.1} />
                             </Form.Item>
                         )}
@@ -790,7 +790,7 @@ function priceTierLabel(tier: ChannelModelPriceTier) {
     ].filter(Boolean);
     const spec = specParts.length ? specParts.join(" / ") : "默认规格";
     if (tier.billingMode === "token") return `${spec} · ${formatCredits(tier.outputTokenPriceMicrocredits)} / 百万 Token`;
-    return `${spec} · ${formatCredits(tier.unitPriceMicrocredits)} 积分 / ${tier.billingMode === "per_second" ? "秒" : "次"}`;
+    return `${spec} · ${formatCredits(tier.unitPriceMicrocredits)} / ${tier.billingMode === "per_second" ? "秒" : "次"}`;
 }
 
 function operationOptions(capability: EditableCapability | undefined) {
@@ -806,5 +806,5 @@ function operationLabel(operation: string) {
 }
 
 function formatCredits(value: number) {
-    return (value / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 6 });
+    return "¥" + (value / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 6 });
 }

--- a/web/src/pages/admin/components/credit-operations-panel.tsx
+++ b/web/src/pages/admin/components/credit-operations-panel.tsx
@@ -112,7 +112,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                 });
             })
             .catch((error) => {
-                if (active) message.error(error instanceof Error ? error.message : "读取积分策略失败");
+                if (active) message.error(error instanceof Error ? error.message : "读取余额策略失败");
             })
             .finally(() => {
                 if (active) setLoadingPolicy(false);
@@ -175,10 +175,10 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                 defaultMultiplierBasisPoints: Math.round(values.defaultMultiplier * 10_000),
                 modelMultiplierBasisPoints,
             });
-            message.success("积分策略已保存，将应用于后续创建的计费订单");
+            message.success("余额策略已保存，将应用于后续创建的计费订单");
             onOperationChange(null);
         } catch (error) {
-            message.error(error instanceof Error ? error.message : "保存积分策略失败");
+            message.error(error instanceof Error ? error.message : "保存余额策略失败");
         } finally {
             setSavingPolicy(false);
         }
@@ -187,18 +187,18 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
     const previewAdjustment = (values: AdjustmentFormValues) => {
         const amount = Number(values.amount);
         if (!Number.isFinite(amount) || amount === 0) {
-            message.error("积分变化不能为 0");
+            message.error("余额变化不能为 0");
             return;
         }
         try {
             toMicrocredits(amount);
         } catch (error) {
-            message.error(error instanceof Error ? error.message : "积分变化超出可处理范围");
+            message.error(error instanceof Error ? error.message : "余额变化超出可处理范围");
             return;
         }
         const user = adjustmentUsers.find((item) => item.id === values.userId);
         if (amount < 0 && hasCreditBalance(user) && user.availableMicrocredits + toMicrocredits(amount) < 0) {
-            message.error("扣减后可用积分不能低于 0");
+            message.error("扣减后可用余额不能低于 0");
             return;
         }
         setPendingAdjustment({ ...values, amount, note: values.note.trim() });
@@ -226,9 +226,9 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             adjustmentForm.resetFields();
             setPendingAdjustment(null);
             onOperationChange(null);
-            message.success(`用户积分已调整，当前可用积分 ${formatCredits(result.account.availableMicrocredits)}`);
+            message.success(`用户余额已调整，当前可用余额 ${formatCredits(result.account.availableMicrocredits)}`);
         } catch (error) {
-            message.error(error instanceof Error ? error.message : "调整积分失败");
+            message.error(error instanceof Error ? error.message : "调整余额失败");
         } finally {
             setAdjusting(false);
         }
@@ -247,7 +247,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
         try {
             if (resolutionTarget.kind === "single") {
                 await resolveAdminBillingOrder(resolutionTarget.order.id, { action: resolutionTarget.action, note });
-                message.success(resolutionTarget.action === "settle" ? "计费订单已结算" : "预授权积分已退回");
+                message.success(resolutionTarget.action === "settle" ? "计费订单已结算" : "预授权余额已退回");
             } else {
                 const result = await resolveAdminBillingOrders({
                     ids: resolutionTarget.orders.map((order) => order.id),
@@ -264,7 +264,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                     await reload(page, pageSize);
                     return;
                 }
-                message.success(resolutionTarget.action === "settle" ? `已结算 ${result.resolvedCount} 条订单` : `已退回 ${result.resolvedCount} 条订单的预授权积分`);
+                message.success(resolutionTarget.action === "settle" ? `已结算 ${result.resolvedCount} 条订单` : `已退回 ${result.resolvedCount} 条订单的预授权余额`);
             }
             setResolutionTarget(null);
             resolutionForm.resetFields();
@@ -314,7 +314,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             ),
         },
         {
-            title: "预授权积分",
+            title: "预授权余额",
             width: 125,
             align: "center",
             render: (_, order) => <span className="font-medium tabular-nums">{formatCredits(getReservedAmount(order))}</span>,
@@ -326,7 +326,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             render: (_, order) =>
                 order.billingMode === "token" ? (
                     <div className="text-xs leading-5">
-                        <div className="font-medium tabular-nums">{order.status === "settled" ? `${formatCredits(order.actualAmountMicrocredits)} 积分` : "等待用量结算"}</div>
+                        <div className="font-medium tabular-nums">{order.status === "settled" ? `${formatCredits(order.actualAmountMicrocredits)}` : "等待用量结算"}</div>
                         <div className="text-foreground/50">
                             输入 {order.inputTokens} · 输出 {order.outputTokens} · 缓存 {order.cachedTokens}
                         </div>
@@ -363,7 +363,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
     const hasFilters = Boolean(keyword || orderStatus !== "review");
     const resolutionOrders = resolutionTarget?.kind === "batch" ? resolutionTarget.orders : resolutionTarget ? [resolutionTarget.order] : [];
     const resolutionReservedTotal = resolutionOrders.reduce((sum, order) => sum + getReservedAmount(order), 0);
-    const resolutionTitle = resolutionTarget ? (resolutionTarget.action === "settle" ? (resolutionTarget.kind === "batch" ? "批量确认结算" : "确认结算计费订单") : resolutionTarget.kind === "batch" ? "批量退回预授权积分" : "确认退回预授权积分") : "";
+    const resolutionTitle = resolutionTarget ? (resolutionTarget.action === "settle" ? (resolutionTarget.kind === "batch" ? "批量确认结算" : "确认结算计费订单") : resolutionTarget.kind === "batch" ? "批量退回预授权余额" : "确认退回预授权余额") : "";
 
     return (
         <div className="admin-credit-operations flex min-h-0 flex-1 flex-col">
@@ -463,7 +463,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             </section>
 
             <Drawer
-                title="积分策略"
+                title="余额策略"
                 open={activeOperation === "policy"}
                 size="min(700px, 100vw)"
                 onClose={() => {
@@ -490,21 +490,21 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                 </div>
                 {loadingPolicy ? (
                     <div className="admin-credit-drawer-loading" role="status">
-                        正在读取积分策略…
+                        正在读取余额策略…
                     </div>
                 ) : (
                     <Form form={policyForm} layout="vertical" requiredMark={false} initialValues={{ modelMultipliers: [] }} onFinish={(values) => void savePolicy(values)}>
                         <section className="admin-credit-drawer-section">
                             <div className="admin-credit-drawer-section-heading">
                                 <h3>基础规则</h3>
-                                <p>积分支持最多 6 位小数，倍率支持最多 4 位小数。</p>
+                                <p>余额支持最多 6 位小数，倍率支持最多 4 位小数。</p>
                             </div>
                             <div className="admin-credit-policy-grid">
                                 <Form.Item
                                     name="signupBonus"
-                                    label="注册赠送积分"
+                                    label="注册赠送余额"
                                     rules={[
-                                        { required: true, message: "请填写注册积分" },
+                                        { required: true, message: "请填写注册余额" },
                                         { type: "number", min: 0, max: 1_000_000, message: "请输入 0–1,000,000" },
                                     ]}
                                 >
@@ -512,9 +512,9 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                                 </Form.Item>
                                 <Form.Item
                                     name="checkinBonus"
-                                    label="每日签到积分"
+                                    label="每日签到余额"
                                     rules={[
-                                        { required: true, message: "请填写签到积分" },
+                                        { required: true, message: "请填写签到余额" },
                                         { type: "number", min: 0, max: 100_000, message: "请输入 0–100,000" },
                                     ]}
                                 >
@@ -607,7 +607,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             >
                 <div className="admin-credit-drawer-intro is-warning">
                     <strong>账务写入操作</strong>
-                    <p>提交后会立即写入积分流水和管理员审计记录，请填写可追溯的处理依据。</p>
+                    <p>提交后会立即写入余额流水和管理员审计记录，请填写可追溯的处理依据。</p>
                 </div>
                 <Form form={adjustmentForm} layout="vertical" requiredMark={false} onFinish={previewAdjustment}>
                     <section className="admin-credit-drawer-section">
@@ -628,12 +628,12 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                         {selectedAdjustmentUser ? <CreditAccountSummary user={selectedAdjustmentUser} /> : null}
                         <Form.Item
                             name="amount"
-                            label="积分变化"
-                            extra="正数增加，负数扣减；扣减只能使用可用积分。"
+                            label="余额变化"
+                            extra="正数增加，负数扣减；扣减只能使用可用余额。"
                             rules={[
-                                { required: true, message: "请填写积分变化" },
+                                { required: true, message: "请填写余额变化" },
                                 {
-                                    validator: (_, value) => (typeof value === "number" && Number.isFinite(value) && value !== 0 ? Promise.resolve() : Promise.reject(new Error("积分变化不能为 0"))),
+                                    validator: (_, value) => (typeof value === "number" && Number.isFinite(value) && value !== 0 ? Promise.resolve() : Promise.reject(new Error("余额变化不能为 0"))),
                                 },
                             ]}
                         >
@@ -647,7 +647,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             </Drawer>
 
             <Modal
-                title={pendingAdjustment?.amount && pendingAdjustment.amount < 0 ? "确认扣减用户积分" : "确认增加用户积分"}
+                title={pendingAdjustment?.amount && pendingAdjustment.amount < 0 ? "确认扣减用户余额" : "确认增加用户余额"}
                 open={Boolean(pendingAdjustment)}
                 okText={pendingAdjustment?.amount && pendingAdjustment.amount < 0 ? "确认扣减" : "确认增加"}
                 cancelText="返回修改"
@@ -664,14 +664,14 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             >
                 {pendingAdjustment ? (
                     <div className="admin-operation-confirmation">
-                        <p className="admin-operation-confirmation-copy">请再次核对用户、积分变化和处理依据。确认后将立即写入账务流水。</p>
+                        <p className="admin-operation-confirmation-copy">请再次核对用户、余额变化和处理依据。确认后将立即写入账务流水。</p>
                         <dl className="admin-operation-confirmation-grid">
                             <div>
                                 <dt>目标用户</dt>
                                 <dd>{formatUserLabel(pendingAdjustmentUser, pendingAdjustment.userId)}</dd>
                             </div>
                             <div>
-                                <dt>积分变化</dt>
+                                <dt>余额变化</dt>
                                 <dd className={pendingAdjustment.amount < 0 ? "is-negative" : "is-positive"}>
                                     {pendingAdjustment.amount > 0 ? "+" : ""}
                                     {formatCredits(toMicrocredits(pendingAdjustment.amount))}
@@ -718,7 +718,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
             >
                 {resolutionTarget ? (
                     <div className="admin-operation-confirmation">
-                        <p className="admin-operation-confirmation-copy">{resolutionTarget.action === "settle" ? "结算会依据订单计费方式确认实际费用；Token 订单可能退回差额，也可能补扣可用积分。" : "退回操作只会释放尚未结算订单的预授权积分。"}</p>
+                        <p className="admin-operation-confirmation-copy">{resolutionTarget.action === "settle" ? "结算会依据订单计费方式确认实际费用；Token 订单可能退回差额，也可能补扣可用余额。" : "退回操作只会释放尚未结算订单的预授权余额。"}</p>
                         <dl className="admin-operation-confirmation-grid">
                             <div>
                                 <dt>订单数量</dt>
@@ -726,7 +726,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
                             </div>
                             <div>
                                 <dt>预授权总额</dt>
-                                <dd>{formatCredits(resolutionReservedTotal)} 积分</dd>
+                                <dd>{formatCredits(resolutionReservedTotal)}</dd>
                             </div>
                             {resolutionTarget.kind === "single" ? (
                                 <>
@@ -761,7 +761,7 @@ export default function CreditOperationsPanel({ users, activeOperation, onOperat
 
 function CreditAccountSummary({ user }: { user: AdjustmentUser }) {
     if (!hasCreditBalance(user)) {
-        return <div className="admin-credit-account-summary is-unavailable">选择远程搜索结果后可核对当前可用与冻结积分。</div>;
+        return <div className="admin-credit-account-summary is-unavailable">选择远程搜索结果后可核对当前可用与冻结余额。</div>;
     }
     return (
         <dl className="admin-credit-account-summary">
@@ -795,7 +795,7 @@ function formatUserLabel(user: AdjustmentUser | undefined, fallback: string) {
 
 function toMicrocredits(value: number) {
     const result = Math.round(Number(value) * 1_000_000);
-    if (!Number.isSafeInteger(result)) throw new Error("积分变化超出可处理范围");
+    if (!Number.isSafeInteger(result)) throw new Error("余额变化超出可处理范围");
     return result;
 }
 

--- a/web/src/pages/admin/components/feature-availability-panel.tsx
+++ b/web/src/pages/admin/components/feature-availability-panel.tsx
@@ -33,8 +33,8 @@ const workspaceFeatureRows: FeatureRow[] = [
     },
     {
         key: "creditsEnabled",
-        title: "积分计费",
-        description: "控制钱包入口及新任务的积分预授权与结算。",
+        title: "余额计费",
+        description: "控制钱包入口及新任务的余额预授权与结算。",
         icon: <Coins className="size-4" aria-hidden="true" />,
     },
     {
@@ -151,8 +151,8 @@ export default function FeatureAvailabilityPanel() {
         if (!savedFeatures || saving || savedFeatures[key] === enabled) return;
         if (key === "creditsEnabled" && !enabled) {
             modal.confirm({
-                title: "关闭用户积分功能？",
-                content: "保存后新创建的任务和系统渠道请求将不再扣减积分；已经冻结的计费订单仍按原规则结算，已有余额和流水继续保留。",
+                title: "关闭用户余额功能？",
+                content: "保存后新创建的任务和系统渠道请求将不再扣减余额；已经冻结的计费订单仍按原规则结算，已有余额和流水继续保留。",
                 okText: "确认关闭",
                 cancelText: "取消",
                 okButtonProps: { danger: true },

--- a/web/src/pages/admin/components/redemption-codes-panel.tsx
+++ b/web/src/pages/admin/components/redemption-codes-panel.tsx
@@ -122,7 +122,7 @@ export default function RedemptionCodesPanel({ createOpen, onCreateOpenChange, o
         const amountMicrocredits = Math.round(amount * MICRO_CREDITS_PER_CREDIT);
         const totalMicrocredits = amountMicrocredits * count;
         if (!Number.isFinite(amount) || amount <= 0 || !Number.isSafeInteger(amountMicrocredits) || amountMicrocredits <= 0 || !Number.isInteger(count) || count < 1 || count > 5000 || !Number.isSafeInteger(totalMicrocredits)) {
-            message.error("积分面额或生成数量超出可安全处理的范围");
+            message.error("面额或生成数量超出可安全处理的范围");
             return;
         }
         let expiresAt: string | undefined;
@@ -212,7 +212,7 @@ export default function RedemptionCodesPanel({ createOpen, onCreateOpenChange, o
                 </div>
             ),
         },
-        { title: "单码积分", dataIndex: "amountMicrocredits", width: 120, align: "center", render: (value) => <span className="font-medium tabular-nums">{formatCredits(value)}</span> },
+        { title: "单码面值", dataIndex: "amountMicrocredits", width: 120, align: "center", render: (value) => <span className="font-medium tabular-nums">{formatCredits(value)}</span> },
         { title: "总数", dataIndex: "count", width: 80, align: "center", render: (value) => <span className="tabular-nums">{value}</span> },
         { title: "状态分布", width: 300, align: "center", render: (_, batch) => <BatchStatusDistribution batch={batch} /> },
         { title: "过期时间", dataIndex: "expiresAt", width: 180, align: "center", render: (value) => (value ? formatTime(value) : <AdminStatusBadge label="永久有效" tone="info" />) },
@@ -282,7 +282,7 @@ export default function RedemptionCodesPanel({ createOpen, onCreateOpenChange, o
                             className="app-list-search"
                             prefix={<Search className="size-4 text-foreground/40" />}
                             value={keyword}
-                            placeholder="搜索批次备注、积分或数量"
+                            placeholder="搜索批次备注、面额或数量"
                             onChange={(event) => {
                                 setKeyword(event.target.value);
                                 setPage(1);
@@ -442,19 +442,19 @@ function CreateRedeemBatchDrawer({
                     <section className="admin-redemption-drawer-section">
                         <div className="admin-redemption-drawer-section-heading">
                             <h3>批次参数</h3>
-                            <p>积分最多保留 6 位小数；单批最多生成 5,000 个兑换码。</p>
+                            <p>面额最多保留 6 位小数；单批最多生成 5,000 个兑换码。</p>
                         </div>
                         <div className="admin-redemption-form-grid">
                             <Form.Item
                                 name="amount"
-                                label="每个兑换码的积分"
+                                label="每个兑换码的面额"
                                 rules={[
-                                    { required: true, message: "请填写积分面额" },
+                                    { required: true, message: "请填写面额" },
                                     {
                                         validator: (_, value) => {
                                             const numberValue = Number(value);
                                             const microcredits = Math.round(numberValue * MICRO_CREDITS_PER_CREDIT);
-                                            return Number.isFinite(numberValue) && numberValue > 0 && Number.isSafeInteger(microcredits) && microcredits > 0 ? Promise.resolve() : Promise.reject(new Error("请输入可安全处理且大于 0 的积分"));
+                                            return Number.isFinite(numberValue) && numberValue > 0 && Number.isSafeInteger(microcredits) && microcredits > 0 ? Promise.resolve() : Promise.reject(new Error("请输入可安全处理且大于 0 的面额"));
                                         },
                                     },
                                 ]}
@@ -495,7 +495,7 @@ function CreateRedeemBatchDrawer({
                         </Form.Item>
                         <dl className="admin-redemption-live-summary" aria-label="待生成批次摘要">
                             <div>
-                                <dt>单码积分</dt>
+                                <dt>单码面值</dt>
                                 <dd>{Number(watchedAmount) > 0 ? formatCredits(Math.round(Number(watchedAmount) * MICRO_CREDITS_PER_CREDIT)) : "--"}</dd>
                             </div>
                             <div>
@@ -532,7 +532,7 @@ function CreateRedeemBatchDrawer({
                         <p className="admin-operation-confirmation-copy">请核对本批次的总发放额度和有效期。确认后会立即生成，不能撤销整批记录。</p>
                         <dl className="admin-operation-confirmation-grid">
                             <div>
-                                <dt>单码积分</dt>
+                                <dt>单码面值</dt>
                                 <dd>{formatCredits(pending.amountMicrocredits)}</dd>
                             </div>
                             <div>
@@ -748,7 +748,7 @@ function RedeemBatchCodesModal({ batch, onClose, onBatchChanged }: { batch: Rede
                 item.status === "unused" ? (
                     <Popconfirm
                         title={`禁用尾号 ${item.codeSuffix} 的兑换码？`}
-                        description={`该兑换码面值 ${formatCredits(item.amountMicrocredits)} 积分，禁用后无法恢复。`}
+                        description={`该兑换码面值 ${formatCredits(item.amountMicrocredits)}，禁用后无法恢复。`}
                         okText="确认禁用"
                         cancelText="取消"
                         okButtonProps={{ danger: true }}
@@ -789,7 +789,7 @@ function RedeemBatchCodesModal({ batch, onClose, onBatchChanged }: { batch: Rede
             {!plaintextAvailable ? <div className="admin-redemption-sensitive-notice is-warning">该批次创建于加密回看功能上线前，系统当时只保存了哈希，无法恢复完整明文；核销状态和审计信息仍可查看。</div> : null}
             <div className="admin-redemption-detail-summary">
                 <BatchStatusDistribution batch={batchSummary || batch || emptyBatchSummary} />
-                <span>单码 {formatCredits(batchSummary?.amountMicrocredits ?? batch?.amountMicrocredits ?? 0)} 积分</span>
+                <span>单码 {formatCredits(batchSummary?.amountMicrocredits ?? batch?.amountMicrocredits ?? 0)}</span>
                 <span>总数 {batchSummary?.count ?? batch?.count ?? 0}</span>
                 <span>{batchSummary?.expiresAt || batch?.expiresAt ? `到期 ${formatTime(batchSummary?.expiresAt || batch?.expiresAt)}` : "永久有效"}</span>
                 <span>创建 {formatTime(batchSummary?.createdAt || batch?.createdAt)}</span>
@@ -867,8 +867,8 @@ function isMutationResultUncertain(error: unknown) {
 function formatBatchDisableImpact(batch: RedeemBatch) {
     const availableCount = batch.availableCount ?? 0;
     const affectedMicrocredits = batch.amountMicrocredits * availableCount;
-    const total = Number.isSafeInteger(affectedMicrocredits) ? `，面值合计 ${formatCredits(affectedMicrocredits)} 积分` : "";
-    return `将禁用当前 ${availableCount} 个可用兑换码（单码 ${formatCredits(batch.amountMicrocredits)} 积分${total}）`;
+    const total = Number.isSafeInteger(affectedMicrocredits) ? `，面值合计 ${formatCredits(affectedMicrocredits)}` : "";
+    return `将禁用当前 ${availableCount} 个可用兑换码（单码 ${formatCredits(batch.amountMicrocredits)}${total}）`;
 }
 
 function formatTime(value?: string | null) {

--- a/web/src/pages/admin/logs/logs-page.tsx
+++ b/web/src/pages/admin/logs/logs-page.tsx
@@ -97,7 +97,7 @@ export default function LogsPage() {
                 ),
         },
         { title: "耗时", dataIndex: "durationMs", width: 112, render: (value) => <span className="tabular-nums">{formatDuration(value)}</span> },
-        { title: "积分计费", width: 145, render: (_, log) => <BillingSummary log={log} /> },
+        { title: "余额计费", width: 145, render: (_, log) => <BillingSummary log={log} /> },
         {
             title: "Tokens",
             width: 166,
@@ -125,7 +125,7 @@ export default function LogsPage() {
     return (
         <AdminPageFrame
             title="请求明细"
-            description="上游调用与积分计费"
+            description="上游调用与余额计费"
             actions={
                 <AdminExportButton
                     exportFile={() => exportAdminApiLogs({ keyword: debouncedKeyword || undefined, status: status === "all" ? undefined : status })}
@@ -258,12 +258,12 @@ function formatDuration(value: number) {
 }
 
 function BillingSummary({ log }: { log: ApiCallLog }) {
-    if (!log.billingAvailable) return <span className="text-foreground/35">未扣积分</span>;
+    if (!log.billingAvailable) return <span className="text-foreground/35">未扣费</span>;
     const status = log.billingStatus || "reserved";
     const statusLabel = ({ settled: "已结算", refunded: "已退回", uncertain: "待核对", running: "运行中", reserved: "已预授权" } as const)[status];
     return (
         <div>
-            <div className="tabular-nums">{formatCredits(log.billingAmountMicrocredits)} 积分</div>
+            <div className="tabular-nums">{formatCredits(log.billingAmountMicrocredits)}</div>
             <div className="text-xs text-foreground/40">{statusLabel}</div>
         </div>
     );

--- a/web/src/pages/admin/users/users-columns.tsx
+++ b/web/src/pages/admin/users/users-columns.tsx
@@ -11,7 +11,7 @@ export type UserColumnKey = "user" | "email" | "credits" | "role" | "status" | "
 export const userColumnOptions: Array<{ key: UserColumnKey; label: string; locked?: boolean }> = [
     { key: "user", label: "用户", locked: true },
     { key: "email", label: "邮箱" },
-    { key: "credits", label: "当前积分" },
+    { key: "credits", label: "当前余额" },
     { key: "role", label: "角色" },
     { key: "status", label: "状态" },
     { key: "createdAt", label: "注册时间" },
@@ -46,11 +46,11 @@ export function createUserColumns({
         { key: "email", title: "邮箱", dataIndex: "email", align: "center", render: (email) => email || <span className="text-foreground/40">未填写</span> },
         {
             key: "credits",
-            title: "当前积分",
+            title: "当前余额",
             dataIndex: "availableMicrocredits",
             width: 130,
             align: "center",
-            render: (value, user) => <span className="tabular-nums" title={`冻结积分：${formatCredits(user.reservedMicrocredits)}`}>{formatCredits(value)}</span>,
+            render: (value, user) => <span className="tabular-nums" title={`冻结余额：${formatCredits(user.reservedMicrocredits)}`}>{formatCredits(value)}</span>,
         },
         { key: "role", title: "角色", dataIndex: "role", width: 110, align: "center", render: (role) => <AdminStatusBadge label={role === "admin" ? "管理员" : "普通用户"} tone={role === "admin" ? "info" : "neutral"} /> },
         { key: "status", title: "状态", dataIndex: "status", width: 110, align: "center", render: (status) => <AdminStatusBadge label={status === "active" ? "已启用" : "已停用"} tone={status === "active" ? "success" : "neutral"} /> },
@@ -74,7 +74,7 @@ export function createUserColumns({
                             disabled: user.id === actorId,
                             confirm: {
                                 title: user.status === "active" ? "停用这个用户？" : "重新启用这个用户？",
-                                description: user.status === "active" ? "停用后会清除该用户登录态，但保留身份、任务和积分流水。" : "启用后，该用户可以重新登录并继续使用原有数据。",
+                                description: user.status === "active" ? "停用后会清除该用户登录态，但保留身份、任务和余额流水。" : "启用后，该用户可以重新登录并继续使用原有数据。",
                                 okText: user.status === "active" ? "确认停用" : "确认启用",
                             },
                             onClick: () => onToggleStatus(user),

--- a/web/src/pages/admin/users/users-drawer.tsx
+++ b/web/src/pages/admin/users/users-drawer.tsx
@@ -93,7 +93,7 @@ export function AdminUserEditDrawer({
                 <Form.Item name="role" label="角色" extra={editingSelf ? "不能在此修改当前管理员自己的角色。" : "角色变更会立即影响后台访问权限。"}>
                     <Select disabled={editingSelf} options={[{ label: "管理员", value: "admin" }, { label: "普通用户", value: "user" }]} />
                 </Form.Item>
-                <Form.Item name="status" label="账号状态" extra={editingSelf ? "不能停用当前登录账号。" : "停用后会清除登录态，但保留身份、任务和积分流水。"}>
+                <Form.Item name="status" label="账号状态" extra={editingSelf ? "不能停用当前登录账号。" : "停用后会清除登录态，但保留身份、任务和余额流水。"}>
                     <Select disabled={editingSelf} options={[{ label: "已启用", value: "active" }, { label: "已停用", value: "disabled" }]} />
                 </Form.Item>
             </Form>

--- a/web/src/pages/admin/users/users-panel.tsx
+++ b/web/src/pages/admin/users/users-panel.tsx
@@ -114,7 +114,7 @@ export default function UsersPanel({ onUserChanged }: { onUserChanged?: (user: L
     const bulkDisable = () => {
         modal.confirm({
             title: `停用选中的 ${selectedUserIds.length} 个用户？`,
-            content: "这些用户的全部登录态会被清除，身份、任务和积分流水继续保留。操作会整体成功或整体回滚。",
+            content: "这些用户的全部登录态会被清除，身份、任务和余额流水继续保留。操作会整体成功或整体回滚。",
             okText: "确认批量停用",
             cancelText: "取消",
             okButtonProps: { danger: true },

--- a/web/src/pages/canvas/canvas-project-top-bar.tsx
+++ b/web/src/pages/canvas/canvas-project-top-bar.tsx
@@ -222,15 +222,15 @@ export function CanvasTopBar({
                     </CanvasTopBarTooltip>
                     {compactAgentStatus ? <CompactAgentStatus status={compactAgentStatus} onClick={onToggleAgent} /> : null}
                     {user && creditsEnabled ? (
-                        <CanvasTopBarTooltip label="查看积分明细">
+                        <CanvasTopBarTooltip label="查看余额明细">
                             <Link
                                 to="/wallet"
                                 className="canvas-topbar-action inline-flex h-9 min-w-[5.5rem] items-center justify-center gap-1.5 rounded-lg px-2.5 text-xs font-medium tabular-nums"
                                 style={{ color: theme.node.text }}
-                                aria-label="查看积分明细"
+                                aria-label="查看余额明细"
                             >
                                 {refreshing && availableMicrocredits === null ? <LoaderCircle className="size-3.5 animate-spin opacity-60" /> : <Coins className="size-3.5" />}
-                                <span>{availableMicrocredits === null ? "--" : (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 3 })}</span>
+                                <span>{availableMicrocredits === null ? "--" : "¥" + (availableMicrocredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 3 })}</span>
                             </Link>
                         </CanvasTopBarTooltip>
                     ) : null}

--- a/web/src/pages/canvas/project.tsx
+++ b/web/src/pages/canvas/project.tsx
@@ -518,7 +518,7 @@ function InfiniteCanvasPage() {
             }
             Modal.confirm({
                 title: "取消生成任务？",
-                content: "任务会立即停止本地执行；如果已经提交到上游，系统会继续核对取消结果和积分状态。",
+                content: "任务会立即停止本地执行；如果已经提交到上游，系统会继续核对取消结果和余额状态。",
                 okText: "取消任务",
                 okButtonProps: { danger: true },
                 cancelText: "继续等待",

--- a/web/src/pages/canvas/use-canvas-generation-executor.ts
+++ b/web/src/pages/canvas/use-canvas-generation-executor.ts
@@ -81,7 +81,7 @@ export function useCanvasGenerationExecutor({
             new Promise<boolean>((resolve) => {
                 modal.confirm({
                     title: "再次生成相同内容？",
-                    content: "当前节点已使用相同提示词、模型、参数和参考素材提交过任务。再次生成会新建任务，并可能再次消耗积分。",
+                    content: "当前节点已使用相同提示词、模型、参数和参考素材提交过任务。再次生成会新建任务，并可能再次消耗余额。",
                     okText: "仍然生成",
                     cancelText: "取消",
                     centered: true,

--- a/web/src/pages/create/index.tsx
+++ b/web/src/pages/create/index.tsx
@@ -1233,8 +1233,8 @@ function CreationComposer(props: ComposerProps) {
         seconds: props.mode === "video" ? props.seconds : 1,
     });
     const showCost = creditsEnabled && credits !== null;
-    const formattedCredits = credits?.toLocaleString("zh-CN", { maximumFractionDigits: 6 });
-    const actionLabel = props.referenceReplacementBusy ? "正在替换参考图" : props.busy ? "生成中" : showCost ? `预计消耗 ${formattedCredits} 积分，发送` : "发送";
+    const formattedCredits = credits != null ? "¥" + credits.toLocaleString("zh-CN", { maximumFractionDigits: 6 }) : undefined;
+    const actionLabel = props.referenceReplacementBusy ? "正在替换参考图" : props.busy ? "生成中" : showCost ? `预计消耗 ${formattedCredits}，发送` : "发送";
     const placeholder = props.mode === "text"
         ? "描述你的故事、角色或想继续讨论的创意"
         : props.mode === "image"

--- a/web/src/pages/projects/detail/workflow-production-workbench.tsx
+++ b/web/src/pages/projects/detail/workflow-production-workbench.tsx
@@ -170,7 +170,7 @@ export default function WorkflowProductionWorkbench(props: Props) {
     const quoteRequestKey = JSON.stringify(quoteRequest || null);
     const [quotedCredits, setQuotedCredits] = useState<number | null>(null);
     const generationCredits = quotedCredits ?? configuredCredits;
-    const formattedGenerationCredits = generationCredits?.toLocaleString("zh-CN", { maximumFractionDigits: 6 });
+    const formattedGenerationCredits = generationCredits != null ? "¥" + generationCredits.toLocaleString("zh-CN", { maximumFractionDigits: 6 }) : undefined;
     const modelSummary = routedModel ? modelDisplayName(effectiveConfig, routedModel) : "未选择模型";
     const durationSummary = `${Number(watchedDuration || Math.max(0.5, (selectedShot?.durationMs || 3000) / 1000))}s`;
     const resolutionSummary = generationCapability === "video" ? formatVideoResolutionLabel(resolution) : imageQuality.toUpperCase();
@@ -537,7 +537,7 @@ export default function WorkflowProductionWorkbench(props: Props) {
                         </div>
                         <footer className="workflow-editor-actions">
                             <div className="workflow-generation-cost" aria-live="polite">
-                                {creditsEnabled && formattedGenerationCredits ? <><CreditSymbol /><span>本次预计 {formattedGenerationCredits} 积分</span></> : creditsEnabled && routedModel ? <span>本次费用将在提交时按实际规格计算</span> : null}
+                                {creditsEnabled && formattedGenerationCredits ? <><CreditSymbol /><span>本次预计 {formattedGenerationCredits}</span></> : creditsEnabled && routedModel ? <span>本次费用将在提交时按实际规格计算</span> : null}
                             </div>
                             <div className="flex items-center gap-2"><Button danger icon={<Trash2 className="size-4" />} loading={deleteShot.isPending} disabled={saveShot.isPending || selectedShotSubmitting || changeAssetBinding.isPending} onClick={requestDeleteShot}>删除镜头</Button><Button htmlType="submit" icon={<Save className="size-4" />} loading={saveShot.isPending} disabled={!editorDirty || deleteShot.isPending}>保存脚本</Button><Button type="primary" icon={<Play className="size-4" />} loading={selectedShotSubmitting || shotTask?.status === "queued" || shotTask?.status === "running"} disabled={deleteShot.isPending} onClick={() => void generateArtifact()}>{selectedShotSubmitting ? `${stageCopy.action}（正在提交）` : shotTask?.status === "queued" || shotTask?.status === "running" ? `${stageCopy.action}（已运行${shotTaskElapsed}）` : shotTask?.status === "failed" ? `${stageCopy.action}（上次失败，可重试）` : shotTask?.status === "succeeded" && !newestArtifact ? `${stageCopy.action}（已完成，正在同步）` : newestArtifact ? `${stageCopy.action}（已生成）` : stageCopy.action}</Button></div>
                         </footer>

--- a/web/src/pages/settings/channel-video-pricing.tsx
+++ b/web/src/pages/settings/channel-video-pricing.tsx
@@ -219,7 +219,7 @@ export function ChannelModelSettings({ channel, onChange }: { channel: ModelChan
                                         step={0.1}
                                         className="w-full"
                                         placeholder={activeBillingMode === "token" ? "每百万视频 Token 价格" : activeBillingMode === "per_second" ? "每秒价格" : "每次价格"}
-                                        addonAfter={`积分/${activeBillingMode === "token" ? "百万 Token" : activeBillingMode === "per_second" ? "秒" : "次"}`}
+                                        addonAfter={`¥/${activeBillingMode === "token" ? "百万 Token" : activeBillingMode === "per_second" ? "秒" : "次"}`}
                                         value={activeModelCost ? (activeBillingMode === "token" ? (activeModelCost.outputTokenPriceMicrocredits || 0) : activeModelCost.unitPriceMicrocredits) / 1_000_000 : null}
                                         onChange={(value) => updateCost(activeModel, activeBillingMode === "token" ? { outputTokenPriceMicrocredits: Math.round(Number(value || 0) * 1_000_000) } : { unitPriceMicrocredits: Math.round(Number(value || 0) * 1_000_000) })}
                                     />

--- a/web/src/pages/settings/model-default-grid.tsx
+++ b/web/src/pages/settings/model-default-grid.tsx
@@ -97,5 +97,5 @@ function capabilityLabel(capability: ModelCapability) {
 }
 
 function formatPrice(microcredits: number) {
-    return (microcredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 6 });
+    return "¥" + (microcredits / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 6 });
 }

--- a/web/src/pages/tasks/task-shared.tsx
+++ b/web/src/pages/tasks/task-shared.tsx
@@ -26,13 +26,13 @@ export function taskAttentionReason(task: GenerationTask) {
 
 export function providerCancelStatusLabel(task: GenerationTask) {
     if (task.providerCancelStatus === "requested") return "已请求上游取消，正在等待确认";
-    if (task.providerCancelStatus === "confirmed") return "上游已确认取消，积分已退回";
+    if (task.providerCancelStatus === "confirmed") return "上游已确认取消，余额已退回";
     if (task.providerCancelStatus === "uncertain") {
         if (task.billing?.status === "settled") return "上游未能取消，费用已结算";
-        if (task.billing?.status === "refunded") return "上游取消结果未确认，积分已退回";
+        if (task.billing?.status === "refunded") return "上游取消结果未确认，余额已退回";
         return task.providerCancelError || "上游无法确认取消，费用待核对";
     }
-    return task.billing?.status === "refunded" ? "任务在调用上游前取消，积分已退回" : "任务已取消，可按原输入重新提交";
+    return task.billing?.status === "refunded" ? "任务在调用上游前取消，余额已退回" : "任务已取消，可按原输入重新提交";
 }
 
 export function statusDotClassName(status: TaskStatus) {
@@ -67,7 +67,7 @@ export function TaskBilling({ billing }: { billing?: GenerationTask["billing"] }
     const amount = formatCredits(billing.amountMicrocredits);
     const note = billing.status === "settled" ? "已结算" : billing.status === "refunded" ? "已退回" : billing.status === "uncertain" ? "待核对" : "预计";
     return (
-        <div className={`task-record-billing ${billing.status === "uncertain" ? "is-uncertain" : ""}`} title={`积分${note}`}>
+        <div className={`task-record-billing ${billing.status === "uncertain" ? "is-uncertain" : ""}`} title={`余额${note}`}>
             <Coins className="size-4" />
             <span>
                 <strong>{amount}</strong>

--- a/web/src/pages/wallet/index.tsx
+++ b/web/src/pages/wallet/index.tsx
@@ -42,7 +42,7 @@ export default function WalletPage() {
             const nextWallet = await getWallet(targetPage, targetPageSize, filter);
             if (sequence === requestSequence.current) setWallet(nextWallet);
         } catch (error) {
-            if (sequence === requestSequence.current) message.error(error instanceof Error ? error.message : "读取积分记录失败");
+            if (sequence === requestSequence.current) message.error(error instanceof Error ? error.message : "读取余额记录失败");
         } finally {
             if (sequence === requestSequence.current) setLoading(false);
         }
@@ -65,7 +65,7 @@ export default function WalletPage() {
             setPage(1);
             await reload(1, pageSize);
             window.dispatchEvent(new CustomEvent("wallet:updated"));
-            message.success("兑换成功，积分已到账");
+            message.success("兑换成功，余额已到账");
         } catch (error) {
             message.error(error instanceof Error ? error.message : "兑换失败");
         } finally {
@@ -79,7 +79,7 @@ export default function WalletPage() {
             await checkinCredits();
             await reload(page, pageSize);
             window.dispatchEvent(new CustomEvent("wallet:updated"));
-            message.success("签到成功，积分已到账");
+            message.success("签到成功，余额已到账");
         } catch (error) {
             message.error(error instanceof Error ? error.message : "签到失败");
         } finally {
@@ -106,7 +106,7 @@ export default function WalletPage() {
             ),
         },
         {
-            title: "积分变化",
+            title: "余额变化",
             dataIndex: "amountMicrocredits",
             width: 145,
             align: "right",
@@ -122,7 +122,7 @@ export default function WalletPage() {
                     <motion.header initial={reducedMotion ? false : { opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: aceternityMotion.duration.panel, ease: aceternityMotion.easing.enter }} className="app-page-header flex flex-wrap items-start justify-between gap-4">
                         <div className="flex min-w-0 items-center gap-3">
                             <div className="min-w-0">
-                                <h1 className="text-[var(--fs-heading-lg)] font-semibold leading-7">积分中心</h1>
+                                <h1 className="text-[var(--fs-heading-lg)] font-semibold leading-7">余额中心</h1>
                                 <p className="mt-1 text-xs leading-5 text-foreground/58">模型调用、冻结与退款都在同一条可追溯流水中。</p>
                             </div>
                         </div>
@@ -147,16 +147,16 @@ export default function WalletPage() {
                             <div className="wallet-balance-primary">
                                 <div className="wallet-balance-heading">
                                     <span className="library-icon-tile wallet-balance-icon"><Coins /></span>
-                                    <div><strong>可用创作积分</strong><span>最近更新 {formatTime(account?.updatedAt)}</span></div>
+                                    <div><strong>可用创作余额</strong><span>最近更新 {formatTime(account?.updatedAt)}</span></div>
                                 </div>
                                 <div className="wallet-balance-number">
                                     <strong>{formatCredits(account?.availableMicrocredits || 0, 6)}</strong>
-                                    <span>积分</span>
+                                    <span>余额</span>
                                 </div>
                             </div>
                             <div className="wallet-balance-details">
                                 <span className="wallet-account-status"><ShieldCheck />账户正常</span>
-                                <BalanceMetric label="冻结积分" description="调用中或待核对" value={account?.reservedMicrocredits || 0} icon={<TicketCheck className="size-4" />} />
+                                <BalanceMetric label="冻结余额" description="调用中或待核对" value={account?.reservedMicrocredits || 0} icon={<TicketCheck className="size-4" />} />
                                 <BalanceMetric label="账户总额" description="可用与冻结合计" value={totalMicrocredits} icon={<Coins className="size-4" />} />
                             </div>
                         </div>
@@ -168,7 +168,7 @@ export default function WalletPage() {
                                 <TicketCheck className="size-4" />
                             </span>
                             <div>
-                                <h2 className="text-base font-semibold">兑换积分</h2>
+                                <h2 className="text-base font-semibold">兑换充值</h2>
                                 <p className="mt-1 text-xs leading-5 text-foreground/55">输入管理员发放的 32 位兑换码。</p>
                             </div>
                         </div>
@@ -181,7 +181,7 @@ export default function WalletPage() {
                             <span className="tabular-nums">{code.length} / 32</span>
                         </div>
                         <Button className="mt-5" type="primary" size="large" block loading={redeeming} disabled={code.length !== 32} onClick={() => void redeem()}>
-                            兑换积分
+                            兑换充值
                         </Button>
                     </motion.div>
                 </section>
@@ -189,7 +189,7 @@ export default function WalletPage() {
                 <section className="wallet-ledger-panel app-workspace-surface mt-9 rounded-lg p-4 backdrop-blur-xl sm:p-5">
                     <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
                         <div>
-                            <h2 className="text-base font-semibold">积分流水</h2>
+                            <h2 className="text-base font-semibold">余额流水</h2>
                             <p className="mt-1 text-xs text-foreground/55">当前展示最近 {wallet?.entries.length || 0} 条记录。</p>
                         </div>
                         <Segmented
@@ -208,7 +208,7 @@ export default function WalletPage() {
                             <Table className="app-data-table wallet-ledger-table" rowKey="id" size="middle" loading={loading} columns={columns} dataSource={entries} pagination={false} tableLayout="fixed" scroll={{ x: 990 }} />
                         </TableSurface>
                     ) : (
-                        <div className="grid gap-1 overflow-hidden rounded-md bg-transparent">{entries.length ? entries.map((entry) => <LedgerMobileRow key={entry.id} config={config} entry={entry} />) : <WorkspaceState compact icon="wallet" title="没有匹配的积分记录" description="切换流水类型，或完成一次生成后再回来查看。" />}</div>
+                        <div className="grid gap-1 overflow-hidden rounded-md bg-transparent">{entries.length ? entries.map((entry) => <LedgerMobileRow key={entry.id} config={config} entry={entry} />) : <WorkspaceState compact icon="wallet" title="没有匹配的余额记录" description="切换流水类型，或完成一次生成后再回来查看。" />}</div>
                     )}
                     <PaginationBar
                         current={page}
@@ -278,13 +278,13 @@ function ledgerTypeMeta(type: CreditLedgerEntry["type"]) {
         redeem: { label: "兑换充值", tagColor: "default", icon: <ArrowDownLeft className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" },
         admin_grant: { label: "管理员充值", tagColor: "default", icon: <ArrowDownLeft className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" },
         consume: { label: "模型消费", tagColor: "error", icon: <Sparkles className="size-4" />, iconClass: "bg-rose-500/10 text-rose-600 dark:text-rose-300" },
-        reserve: { label: "积分冻结", tagColor: "warning", icon: <ArrowUpRight className="size-4" />, iconClass: "bg-amber-500/10 text-amber-600 dark:text-amber-300" },
+        reserve: { label: "余额冻结", tagColor: "warning", icon: <ArrowUpRight className="size-4" />, iconClass: "bg-amber-500/10 text-amber-600 dark:text-amber-300" },
         refund: { label: "消费退款", tagColor: "warning", icon: <RotateCcw className="size-4" />, iconClass: "bg-amber-500/10 text-amber-600 dark:text-amber-300" },
         admin_adjustment: { label: "管理员调账", tagColor: "default", icon: <SlidersHorizontal className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" },
         signup_bonus: { label: "注册奖励", tagColor: "default", icon: <Sparkles className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" },
         checkin_bonus: { label: "签到奖励", tagColor: "default", icon: <CalendarCheck className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" },
     } as const;
-    return values[type] || { label: "其他积分变动", tagColor: "default", icon: <ArrowUpRight className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" };
+    return values[type] || { label: "其他余额变动", tagColor: "default", icon: <ArrowUpRight className="size-4" />, iconClass: "bg-foreground/8 text-foreground/70" };
 }
 
 function ledgerTitle(entry: CreditLedgerEntry) {
@@ -293,7 +293,7 @@ function ledgerTitle(entry: CreditLedgerEntry) {
     if (entry.type === "consume") return "模型调用";
     if (entry.type === "signup_bonus") return "新用户注册奖励";
     if (entry.type === "checkin_bonus") return "每日签到奖励";
-    return entry.note || "积分调整";
+    return entry.note || "余额调整";
 }
 
 function ledgerModelName(config: AiConfig, entry: CreditLedgerEntry) {

--- a/web/src/services/api/task-center.ts
+++ b/web/src/services/api/task-center.ts
@@ -233,7 +233,7 @@ export function createGenerationTask(input: CreateTaskInput) {
     return request<GenerationTask>(api.post("/tasks", input)).then((task) => {
         recordDiagnosticEvent({ level: "info", category: "task", message: "任务已创建", taskId: task.id, projectId: task.projectId });
         notifyCanvasTaskCreated(task);
-        // 创建任务时积分已被预占，不能等任务结束后才刷新可用余额。
+        // 创建任务时余额已被预占，不能等任务结束后才刷新可用余额。
         window.dispatchEvent(new CustomEvent("wallet:updated"));
         return task;
     });


### PR DESCRIPTION
## 主要改动

### 1. 小数价格支持
- 数据库：价格字段从 bigint 改为 numeric(20,6)，新增 schema 迁移 v4
- 后端：价格字段从 int64 改为 float64，计费逻辑支持小数计算
- 前端：新增 formatDecimalPrice 函数，支持显示所有有效小数位

### 2. 画布 Agent 面板模型选择器优化
- 去掉模型价格显示，只显示模型名称和渠道来源
- 修复滚动条不能使用的问题
- 禁用虚拟列表，支持鼠标滚轮直接滚动

### 3. 创作页面模型选择器优化
- 选中后只显示模型名称，不显示价格
- 文本模型价格显示在模型名称下方

## 验证
- 后端编译通过
- 前端构建通过