### PR TITLE
feat(canvas): 插件节点 - 已启用插件贡献的画布节点进入添加节点菜单

### DIFF
--- a/web/src/lib/canvas/tool-registry/definitions/add-node-menu-tools.tsx
+++ b/web/src/lib/canvas/tool-registry/definitions/add-node-menu-tools.tsx
@@ -1,7 +1,7 @@
-import { Folder, FolderOpen, Layers3, Palette, UploadCloud, UserRound, Workflow } from "lucide-react";
+import { Blocks, Folder, FolderOpen, Layers3, Palette, UploadCloud, UserRound, Workflow } from "lucide-react";
 
-import { getNodeIcon, getNodeLabel } from "@/lib/canvas/node-registry";
-import { registerAddNodeMenuCommands, type AddNodeMenuCommand } from "@/lib/canvas/tool-registry";
+import { getNodeIcon, getNodeLabel, listCreatableNodeDefinitions } from "@/lib/canvas/node-registry";
+import { registerAddNodeMenuCommandProvider, registerAddNodeMenuCommands, type AddNodeMenuCommand } from "@/lib/canvas/tool-registry";
 import { CanvasNodeType } from "@/types/canvas";
 
 /** 真正创建节点的命令，文案与图标统一取自节点注册表。 */
@@ -32,3 +32,18 @@ export const addNodeMenuCommands: AddNodeMenuCommand[] = [
 ];
 
 registerAddNodeMenuCommands(addNodeMenuCommands);
+
+// 插件贡献的画布节点（如肖像排查）随插件启用状态动态进入菜单：
+// 安装/启用发生在运行时，不能进上面的静态表；未提供 enabledPluginIds 的调用方不显示插件节点。
+registerAddNodeMenuCommandProvider((ctx) =>
+    listCreatableNodeDefinitions()
+        .filter((def) => def.plugin && ctx.enabledPluginIds?.has(def.plugin.pluginId))
+        .map((def, index) => ({
+            id: def.type,
+            label: def.label,
+            icon: def.icon ?? <Blocks />,
+            section: "node" as const,
+            defaultOrder: 90 + index,
+            run: (runCtx) => runCtx.handlers.onAddExtensionNode(def.type),
+        })),
+);

--- a/web/src/lib/canvas/tool-registry/index.ts
+++ b/web/src/lib/canvas/tool-registry/index.ts
@@ -1,4 +1,4 @@
 export type { AddNodeMenuCommand, AddNodeMenuContext, ToolbarHandlers, ToolbarId, ToolbarPrefs, ToolCategory, ToolContext, ToolDefinition } from "./tool-definition";
 export { clearToolbarPrefs, persistToolbarPrefs, readToolbarPrefs } from "./tool-persistence";
-export { defaultToolbarPrefs, getAddNodeMenuCommands, getToolbarTools, registerAddNodeMenuCommands, registerToolbarTools, resolveAddNodeMenuCommands, resolveToolbarEntries, resolveToolbarTools } from "./tool-registry";
+export { defaultToolbarPrefs, getAddNodeMenuCommands, getToolbarTools, registerAddNodeMenuCommandProvider, registerAddNodeMenuCommands, registerToolbarTools, resolveAddNodeMenuCommands, resolveToolbarEntries, resolveToolbarTools } from "./tool-registry";
 import "./definitions";

--- a/web/src/lib/canvas/tool-registry/tool-registry.ts
+++ b/web/src/lib/canvas/tool-registry/tool-registry.ts
@@ -15,9 +15,17 @@ export function registerToolbarTools(tools: ToolDefinition[]) {
     }
 }
 
+/** 动态命令提供者——插件贡献的画布节点安装/启用发生在运行时，无法静态注册，解析时按上下文实时生成 */
+const addNodeMenuProviders: Array<(ctx: AddNodeMenuContext) => AddNodeMenuCommand[]> = [];
+
 /** 注册添加节点菜单命令 */
 export function registerAddNodeMenuCommands(commands: AddNodeMenuCommand[]) {
     addNodeMenuRegistry.push(...commands);
+}
+
+/** 注册添加节点菜单动态命令提供者 */
+export function registerAddNodeMenuCommandProvider(provider: (ctx: AddNodeMenuContext) => AddNodeMenuCommand[]) {
+    addNodeMenuProviders.push(provider);
 }
 
 /** 获取某工具栏全部已注册工具（按 defaultOrder 升序） */
@@ -66,9 +74,12 @@ export function resolveToolbarTools(toolbar: ToolbarId, ctx: ToolContext, prefs:
     });
 }
 
-/** 解析添加节点菜单命令——仅 applicable 过滤，不参与排序/显隐 */
+/** 解析添加节点菜单命令——静态命令与动态提供者合并后仅 applicable 过滤，不参与排序/显隐 */
 export function resolveAddNodeMenuCommands(ctx: AddNodeMenuContext): AddNodeMenuCommand[] {
-    return getAddNodeMenuCommands().filter((command) => !command.applicable || command.applicable(ctx));
+    const dynamic = addNodeMenuProviders.flatMap((provider) => provider(ctx));
+    return [...getAddNodeMenuCommands(), ...dynamic]
+        .sort((a, b) => a.defaultOrder - b.defaultOrder)
+        .filter((command) => !command.applicable || command.applicable(ctx));
 }
 
 /**

--- a/web/test/canvas-node-registry.test.ts
+++ b/web/test/canvas-node-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { getNodeDefinition, getNodeGenerationMode, getNodeInputKind, getNodeListLabel, getNodeMinSize, getNodeResourceKind, listCreatableNodeDefinitions, listNodeDefinitions, shouldKeepAspectRatio } from "../src/lib/canvas/node-registry";
+import { getNodeDefinition, getNodeGenerationMode, getNodeInputKind, getNodeListLabel, getNodeMinSize, getNodeResourceKind, listCreatableNodeDefinitions, listNodeDefinitions, registerPluginCanvasNodes, shouldKeepAspectRatio, unregisterNodeDefinitions } from "../src/lib/canvas/node-registry";
+import { resolveAddNodeMenuCommands, type AddNodeMenuContext } from "../src/lib/canvas/tool-registry";
 import { connectionInputSummary } from "../src/lib/canvas/canvas-connection-policy";
 import { CanvasNodeType, type CanvasConnection, type CanvasNodeData, type CanvasNodeMetadata } from "../src/types/canvas";
 
@@ -163,5 +164,56 @@ describe("节点注册表——列表标签", () => {
         expect(getNodeListLabel(CanvasNodeType.Video)).toBe("视频节点");
         expect(getNodeListLabel(CanvasNodeType.Audio)).toBe("音频节点");
         expect(getNodeListLabel(CanvasNodeType.Frame)).toBe("背板");
+    });
+});
+
+describe("插件画布节点进入添加菜单", () => {
+    const pluginId = "test-menu-plugin";
+    const nodeType = "test-menu-node";
+
+    function menuCtx(enabledPluginIds: ReadonlySet<string> | undefined, added: string[]): AddNodeMenuContext {
+        return {
+            workspaceMode: "standard",
+            isProjectLinked: false,
+            enabledPluginIds,
+            handlers: { onAddExtensionNode: (type) => added.push(type) } as AddNodeMenuContext["handlers"],
+        } as AddNodeMenuContext;
+    }
+
+    function registerTestPluginNode() {
+        registerPluginCanvasNodes(pluginId, [{ id: nodeType, label: "测试插件", defaultTitle: "测试插件节点", defaultSize: { width: 320, height: 240 }, schema: {}, renderer: "declarative" }]);
+    }
+
+    test("插件启用时命令出现并创建对应节点", () => {
+        registerTestPluginNode();
+        try {
+            const added: string[] = [];
+            const commands = resolveAddNodeMenuCommands(menuCtx(new Set([pluginId]), added));
+            const command = commands.find((item) => item.id === nodeType);
+            expect(command?.label).toBe("测试插件");
+            expect(command?.section).toBe("node");
+            command?.run(menuCtx(new Set([pluginId]), added));
+            expect(added).toEqual([nodeType]);
+        } finally {
+            unregisterNodeDefinitions(pluginId);
+        }
+    });
+
+    test("插件停用或未提供启用信息时命令不出现", () => {
+        registerTestPluginNode();
+        try {
+            const added: string[] = [];
+            expect(resolveAddNodeMenuCommands(menuCtx(new Set(), added)).some((item) => item.id === nodeType)).toBe(false);
+            expect(resolveAddNodeMenuCommands(menuCtx(undefined, added)).some((item) => item.id === nodeType)).toBe(false);
+            expect(added).toEqual([]);
+        } finally {
+            unregisterNodeDefinitions(pluginId);
+        }
+    });
+
+    test("注销插件后命令随之消失", () => {
+        registerTestPluginNode();
+        unregisterNodeDefinitions(pluginId);
+        expect(resolveAddNodeMenuCommands(menuCtx(new Set([pluginId]), [])).some((item) => item.id === nodeType)).toBe(false);
     });
 });


### PR DESCRIPTION
## 背景

插件系统通过 `contributes.canvasNodes` 注册画布节点定义（如内置的肖像可识别性排查插件），`canvasNodeDefinitionFromPlugin` 也标记了 `showInCreateMenu: true`，但添加节点菜单是一张静态命令表，`listCreatableNodeDefinitions()` 无消费方，`onAddExtensionNode` 也没有任何菜单命令调用——用户在插件中心启用肖像排查后，画布上找不到创建该节点的入口。

## 方案

- `tool-registry` 新增 `registerAddNodeMenuCommandProvider`：动态命令提供者在解析时按上下文实时生成命令。插件的安装/启用发生在运行时，不能进静态注册表。
- `add-node-menu-tools` 注册一个提供者：把 `listCreatableNodeDefinitions()` 中带 `plugin` 归属、且 `ctx.enabledPluginIds` 包含其插件 ID 的节点定义映射为 node 区命令，点击走既有的 `onAddExtensionNode(def.type)`；无图标的插件节点回退 `Blocks` 图标。
- 未提供 `enabledPluginIds` 的调用方不显示插件节点，与现有 gating 语义一致。
- `resolveAddNodeMenuCommands` 合并静态与动态命令后按 `defaultOrder` 排序再做 applicable 过滤。

## 影响

- 启用肖像排查插件后，工具栏「+」菜单与画布右键菜单的节点区出现「肖像排查」，点击即创建节点（`use-canvas-node-operations` 已有该类型的默认 metadata 初始化）。
- 后续任何插件贡献的画布节点自动获得同一入口，无需再改菜单代码。
- 插件停用或卸载（`unregisterNodeDefinitions`）后命令随之消失。

## 验证

- `cd web && bun run typecheck` 通过。
- `bun test test/canvas-node-registry.test.ts` 22 项全部通过，新增 3 项：启用时命令出现并创建对应节点、停用/未提供启用信息时不出现、注销后消失。
- `tool-registry.ts` 与 `canvas-node-registry.test.ts` 在 main 上本就属于 prettier 豁免的存量未格式化文件，本次未额外重排格式，保持 diff 最小。