### PR TITLE
fix(video): 修复声明式视频协议分辨率后缀丢失

### DIFF
--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -2388,6 +2388,12 @@ func queryProtocolAdapterVideoTask(ctx context.Context, input canvasGenerationIn
 }
 
 func protocolRequestFromInput(input canvasGenerationInput) protocol.GenerationRequest {
+	resolution := strings.TrimSpace(input.Config.VQuality)
+	if input.Mode == "video" {
+		if declared := videoResolutionNameRequest(input.VideoCapability, resolution); declared != "" {
+			resolution = declared
+		}
+	}
 	request := protocol.GenerationRequest{
 		Capability:    protocol.Capability(input.Mode),
 		Model:         input.Config.Model,
@@ -2397,7 +2403,7 @@ func protocolRequestFromInput(input canvasGenerationInput) protocol.GenerationRe
 		Videos:        protocolMediaReferences(input.ReferenceVideos, "video"),
 		Audios:        protocolMediaReferences(input.ReferenceAudios, "audio"),
 		AspectRatio:   input.Config.Size,
-		Resolution:    input.Config.VQuality,
+		Resolution:    resolution,
 		Quality:       input.Config.Quality,
 		GenerateAudio: parseBool(input.Config.VideoGenerateAudio, false),
 		Watermark:     parseBool(input.Config.VideoWatermark, false),

--- a/backend/internal/service/provider_test.go
+++ b/backend/internal/service/provider_test.go
@@ -2037,6 +2037,63 @@ func TestProtocolRequestPreservesVideoImageIDsAndRoles(t *testing.T) {
 	}
 }
 
+func TestProtocolRequestRestoresDeclaredVideoResolutionEnum(t *testing.T) {
+	tests := []struct {
+		name        string
+		quality     string
+		resolutions []string
+		want        string
+	}{
+		{name: "lowercase suffix", quality: "480", resolutions: []string{"480p", "720p"}, want: "480p"},
+		{name: "provider casing", quality: "1080", resolutions: []string{"720P", "1080P"}, want: "1080P"},
+		{name: "opaque enum", quality: "768p竖", resolutions: []string{"768p竖", "768p横"}, want: "768p竖"},
+		{name: "unmatched custom value", quality: "native", resolutions: []string{"720p"}, want: "native"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := protocolRequestFromInput(canvasGenerationInput{
+				Mode:            "video",
+				Config:          providerConfig{VQuality: test.quality},
+				VideoCapability: &VideoCapabilityConfig{Resolutions: test.resolutions},
+			})
+			if request.Resolution != test.want || request.Output.Resolution != test.want {
+				t.Fatalf("resolution = %q, output resolution = %q, want %q", request.Resolution, request.Output.Resolution, test.want)
+			}
+		})
+	}
+}
+
+func TestVolcengineArkDeclarativeRequestUsesResolutionSuffix(t *testing.T) {
+	profile := DefaultModelCapabilityConfigForModel("volcengine-ark-video", "doubao-seedance-2-0-fast-260128").Video
+	request := protocolRequestFromInput(canvasGenerationInput{
+		Mode:   "video",
+		Prompt: "make it move",
+		Config: providerConfig{
+			InterfaceType: "volcengine-ark-video",
+			Model:         "doubao-seedance-2-0-fast-260128",
+			Size:          "16:9",
+			VQuality:      "480",
+			VideoSeconds:  "4",
+		},
+		VideoCapability: profile,
+	})
+	adapter, ok := loadOfficialFallbackRegistry().Resolve("volcengine-ark-video")
+	if !ok {
+		t.Fatal("Volcengine Ark declarative adapter is unavailable")
+	}
+	spec, err := adapter.BuildCreate(context.Background(), protocol.RequestContext{Request: request})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, ok := spec.Body.(map[string]any)
+	if !ok {
+		t.Fatalf("body = %#v", spec.Body)
+	}
+	if body["resolution"] != "480p" {
+		t.Fatalf("resolution = %#v, want 480p", body["resolution"])
+	}
+}
+
 func TestNewAPIChannel1VideoBodyRejectsInlineMedia(t *testing.T) {
 	_, err := newAPIChannel1VideoBody(canvasGenerationInput{
 		Prompt:          "make it move",


### PR DESCRIPTION
## 问题说明

统一视频配置会将 `480p` 等数字分辨率规范化为 `480`，而声明式协议请求此前直接透传该内部值。火山方舟 Seedance 的 `resolution` 只接受 `480p`、`720p`、`1080p` 等完整枚举，因此上游收到 `"resolution": "480"` 后返回 `InvalidParameter`。

该问题位于统一任务到声明式协议的公共边界，其他要求完整分辨率枚举的视频协议也存在同类风险。

## 修复内容

- 声明式视频协议发送请求前，根据当前模型能力声明的分辨率列表恢复供应商完整枚举。
- 支持 `480 -> 480p`、`1080 -> 1080P` 等大小写不同的供应商枚举。
- 保留 `768p竖` 等不透明自定义枚举。
- 无法匹配模型能力声明时保留原值，避免对所有供应商无条件追加 `p`。
- 增加火山方舟 Seedance 声明式请求回归测试，确认最终请求发送 `"resolution": "480p"`。

## 验证

- `go test ./internal/service -run 'TestProtocolRequestRestoresDeclaredVideoResolutionEnum|TestVolcengineArkDeclarativeRequestUsesResolutionSuffix|TestProtocolRequestPreservesVideoImageIDsAndRoles|TestDefaultVideoCapabilityUsesProtocolSpecificResolutionTiers' -count=1`
- `go test ./internal/protocol -count=1`
- `go test ./internal/service -run '^$' -count=1`
- `git diff --check`

当前 Windows 环境为 `CGO_ENABLED=0`，且没有 GCC/Clang，因此依赖 go-sqlite3 的完整 `internal/service` 数据库测试无法运行；相关专项测试及包编译均已通过。
