### PR TITLE
fix(storage): 兼容 COS 忽略 Range 时的完整响应

### DIFF
--- a/backend/internal/service/storage_location.go
+++ b/backend/internal/service/storage_location.go
@@ -26,6 +26,8 @@ type OSSConnectionTestResult struct {
 	TestedDigest string    `json:"testedDigest"`
 }
 
+var errOSSConnectionReadMismatch = errors.New("对象存储读取内容不一致")
+
 func (s *Service) TestAdminOSSSetting(actor *model.User, req OSSSettingRequest) (*OSSConnectionTestResult, error) {
 	if err := s.RequireAdmin(actor); err != nil {
 		return nil, err
@@ -110,11 +112,7 @@ func verifyOSSConnection(value ossSettingValue, testKey string) error {
 	if err != nil {
 		rangeErr = err
 	} else {
-		data, readErr := io.ReadAll(io.LimitReader(stream.body, 5))
-		closeErr := stream.body.Close()
-		if readErr != nil || closeErr != nil || string(data) != "ying" {
-			rangeErr = errors.New("对象存储 Range 读取测试失败")
-		}
+		rangeErr = verifyOSSConnectionRead(stream, payload)
 	}
 	if err := deleteOSSObject(testValue, testKey); err != nil {
 		return storageConnectionTestError(testValue.Provider, "删除", err)
@@ -123,6 +121,34 @@ func verifyOSSConnection(value ossSettingValue, testKey string) error {
 		return storageConnectionTestError(testValue.Provider, "Range 读取", rangeErr)
 	}
 	return nil
+}
+
+func verifyOSSConnectionRead(stream *ossObjectStream, payload []byte) error {
+	if stream == nil || stream.body == nil {
+		return fmt.Errorf("%w：响应为空", errOSSConnectionReadMismatch)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(stream.body, int64(len(payload)+1)))
+	closeErr := stream.body.Close()
+	if readErr != nil {
+		return fmt.Errorf("对象存储响应读取失败：%w", readErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("对象存储响应关闭失败：%w", closeErr)
+	}
+
+	// HTTP 允许服务端忽略 Range 并返回 200 + 完整对象。应用的资源代理也会
+	// 原样透传这种响应，因此连接测试应同时接受完整读取与标准的 206 分段读取。
+	switch stream.statusCode {
+	case http.StatusPartialContent:
+		if len(payload) >= 4 && bytes.Equal(data, payload[:4]) {
+			return nil
+		}
+	case http.StatusOK:
+		if bytes.Equal(data, payload) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%w（HTTP %d，读取 %d 字节）", errOSSConnectionReadMismatch, stream.statusCode, len(data))
 }
 
 func storageConnectionTestError(provider string, operation string, cause error) error {
@@ -145,6 +171,9 @@ func storageConnectionTestError(provider string, operation string, cause error) 
 	var networkErr net.Error
 	if errors.As(cause, &networkErr) && networkErr.Timeout() {
 		return WrapAppError(http.StatusGatewayTimeout, fmt.Sprintf("%s %s测试超时，请检查 Endpoint 和服务端网络", providerName, operation), cause)
+	}
+	if operation == "Range 读取" && errors.Is(cause, errOSSConnectionReadMismatch) {
+		return WrapAppError(http.StatusBadGateway, fmt.Sprintf("%s Range 读取返回的数据与刚写入对象不一致，请检查 Endpoint 或出网代理是否忽略、改写了 Range 请求", providerName), cause)
 	}
 
 	if provider == tencentCOSProvider {

--- a/backend/internal/service/storage_location_test.go
+++ b/backend/internal/service/storage_location_test.go
@@ -77,6 +77,39 @@ func TestTencentCOSConnectionTestUsesStorageEndpointInsteadOfCDN(t *testing.T) {
 	}
 }
 
+func TestOSSConnectionReadAcceptsFullObjectWhenRangeIsIgnored(t *testing.T) {
+	payload := []byte("yingce-storage-test")
+	stream := &ossObjectStream{
+		body:          io.NopCloser(strings.NewReader(string(payload))),
+		statusCode:    http.StatusOK,
+		contentLength: int64(len(payload)),
+	}
+	if err := verifyOSSConnectionRead(stream, payload); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOSSConnectionReadRejectsUnexpectedContent(t *testing.T) {
+	payload := []byte("yingce-storage-test")
+	stream := &ossObjectStream{
+		body:          io.NopCloser(strings.NewReader("error page")),
+		statusCode:    http.StatusOK,
+		contentLength: 10,
+	}
+	err := verifyOSSConnectionRead(stream, payload)
+	if err == nil {
+		t.Fatal("verifyOSSConnectionRead() error = nil")
+	}
+	if !errors.Is(err, errOSSConnectionReadMismatch) {
+		t.Fatalf("verifyOSSConnectionRead() error = %v", err)
+	}
+	publicErr := storageConnectionTestError(tencentCOSProvider, "Range 读取", err)
+	var appErr *AppError
+	if !errors.As(publicErr, &appErr) || !strings.Contains(appErr.Message, "忽略、改写了 Range 请求") {
+		t.Fatalf("storageConnectionTestError() = %#v", publicErr)
+	}
+}
+
 func TestTencentCOSConnectionTestReturnsActionableAuthError(t *testing.T) {
 	t.Setenv("CANVAS_ALLOW_PRIVATE_UPSTREAMS", "true")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## 改动摘要

修复 `/admin/settings/storage` 页面中腾讯云 COS 连接测试的误报。

连接测试会写入一个最小测试对象，并用 `Range: bytes=0-3` 验证读取。部分 COS 自定义源站域名或出网代理会忽略 Range，按 HTTP 语义返回 `200` 和完整对象；原逻辑只读取 5 字节并要求内容严格等于 `ying`，因此会把实际可用的读写连接判定为 502。

本次调整：

- 保留对标准 `206 Partial Content` 和前 4 字节内容的校验。
- 当上游返回 `200 OK` 时，仅在完整响应与刚写入的测试对象完全一致时判定通过。
- 空响应、错误页、截断内容和其他异常状态仍判定失败。
- 内容不一致时返回更明确的提示，引导检查 Endpoint 或出网代理是否忽略、改写 Range 请求。
- 增加“Range 被忽略但完整对象正确”和“异常内容必须拒绝”的回归测试。

## 风险与兼容性

- 仅调整对象存储连接测试的成功判定和错误提示，不改变生产资源上传、读取、删除及 CDN 路由逻辑。
- 未放宽对象内容校验；`200` 回退必须与本次随机测试对象逐字节一致。
- 不涉及数据库迁移、配置格式、权限范围或外部 API 变更。

## 验证

- [x] `go test ./internal/service -run "Test(TencentCOSConnectionTest|OSSConnectionRead)" -count=1`
- [x] `git diff --check`
- [ ] `go test ./...`：当前 Windows 环境为 `CGO_ENABLED=0`，仓库既有 SQLite 测试因 `go-sqlite3 requires cgo` 无法运行；另有既有 Windows 文件权限断言 `0666 != 0640`，均与本次改动无关。
- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义
