### PR TITLE
fix(admin): 优化插件拖拽上传与价格开关提示

### DIFF
--- a/web/src/pages/admin/components/channel-model-manager.tsx
+++ b/web/src/pages/admin/components/channel-model-manager.tsx
@@ -746,7 +746,7 @@ function PriceTierFields({
                             <div className="admin-price-tier-toggle">
                                 <div>
                                     <strong>可供用户使用</strong>
-                                    <span>关闭后保留配置，但用户请求不再匹配这档价格</span>
+                                    <span>开启后参与用户请求匹配；关闭后仅保留配置，不参与计费匹配</span>
                                 </div>
                                 <Switch
                                     aria-label="可供用户使用"

--- a/web/src/pages/plugins/plugin-documentation-modals.tsx
+++ b/web/src/pages/plugins/plugin-documentation-modals.tsx
@@ -1,5 +1,6 @@
 import { Modal, Upload } from "antd";
 import { CloudUpload, FileText, ShieldCheck } from "lucide-react";
+import { useRef, useState } from "react";
 
 import type { RegisteredPlugin } from "@/lib/plugins/plugin-types";
 
@@ -15,6 +16,30 @@ type UploadPluginModalProps = {
 };
 
 export function UploadPluginModal({ open, onClose, onUpload }: UploadPluginModalProps) {
+    const [isDraggingPlugin, setIsDraggingPlugin] = useState(false);
+    const dragDepth = useRef(0);
+
+    const handlePluginDragEnter = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        dragDepth.current += 1;
+        setIsDraggingPlugin(true);
+    };
+
+    const handlePluginDragLeave = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        dragDepth.current -= 1;
+        if (dragDepth.current <= 0) {
+            dragDepth.current = 0;
+            setIsDraggingPlugin(false);
+        }
+    };
+
+    const handlePluginDrop = (event: React.DragEvent<HTMLDivElement>) => {
+        event.preventDefault();
+        dragDepth.current = 0;
+        setIsDraggingPlugin(false);
+    };
+
     return (
         <Modal
             className="workspace-modal workspace-modal-wide plugin-upload-modal"
@@ -38,20 +63,28 @@ export function UploadPluginModal({ open, onClose, onUpload }: UploadPluginModal
                             <p>选择统一影策插件包，安装后会立即进入插件中心。</p>
                         </div>
                     </div>
-                    <Upload.Dragger
-                        className="plugin-upload-dropzone"
-                        accept=".yingce-plugin,application/zip"
-                        maxCount={1}
-                        showUploadList={false}
-                        beforeUpload={(file) => {
-                            onUpload(file);
-                            return false;
-                        }}
+                    <div
+                        className={`plugin-upload-dropzone-shell${isDraggingPlugin ? " is-dragging" : ""}`}
+                        onDragEnter={handlePluginDragEnter}
+                        onDragLeave={handlePluginDragLeave}
+                        onDragOver={(event) => event.preventDefault()}
+                        onDrop={handlePluginDrop}
                     >
-                        <CloudUpload className="plugin-upload-dropzone-icon" />
-                        <p className="ant-upload-text">点击选择插件文件</p>
-                        <p className="ant-upload-hint">仅支持 .yingce-plugin 包，大小不超过 16 MiB</p>
-                    </Upload.Dragger>
+                        <Upload.Dragger
+                            className="plugin-upload-dropzone"
+                            accept=".yingce-plugin,application/zip"
+                            maxCount={1}
+                            showUploadList={false}
+                            beforeUpload={(file) => {
+                                onUpload(file);
+                                return false;
+                            }}
+                        >
+                            <CloudUpload className="plugin-upload-dropzone-icon" />
+                            <p className="ant-upload-text">{isDraggingPlugin ? "释放文件以上传插件" : "点击选择插件文件，也可拖拽到此处"}</p>
+                            <p className="ant-upload-hint">支持 .yingce-plugin 包 · 大小不超过 16 MiB</p>
+                        </Upload.Dragger>
+                    </div>
                     <div className="plugin-upload-notice">
                         <ShieldCheck className="size-4" />
                         <span>上传前请确认插件来源可信。Web 入口只能进入声明的隔离运行时，不会获得主页面权限；密钥也不会从清单读取。</span>

--- a/web/src/pages/plugins/plugins.css
+++ b/web/src/pages/plugins/plugins.css
@@ -542,6 +542,12 @@
     border-color: var(--workspace-accent);
 }
 
+.plugin-upload-dropzone-shell.is-dragging .plugin-upload-dropzone.ant-upload-wrapper .ant-upload-drag {
+    border-color: var(--workspace-accent);
+    background: color-mix(in srgb, var(--workspace-accent) 11%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--workspace-accent) 24%, transparent);
+}
+
 .plugin-upload-dropzone-icon {
     width: 30px;
     height: 30px;

--- a/web/src/styles/admin-ui.css
+++ b/web/src/styles/admin-ui.css
@@ -7989,7 +7989,7 @@
 
 .admin-price-tier-controls {
     display: grid !important;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
     gap: 10px !important;
 }
 
@@ -7997,7 +7997,7 @@
     display: flex;
     min-width: 0;
     min-height: 58px;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
     border: 1px solid var(--admin-card-border);
@@ -8008,6 +8008,7 @@
 
 .admin-price-tier-toggle > div {
     display: grid;
+    flex: 1 1 auto;
     min-width: 0;
     gap: 2px;
 }
@@ -8020,12 +8021,11 @@
 }
 
 .admin-price-tier-toggle span {
-    overflow: hidden;
+    overflow-wrap: anywhere;
     color: var(--admin-text-muted);
     font-size: 9px;
     line-height: 1.4;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    white-space: normal;
 }
 
 .admin-model-editor-add-tier.ant-btn {

--- a/web/test/admin-ui-regressions.test.ts
+++ b/web/test/admin-ui-regressions.test.ts
@@ -33,6 +33,25 @@ test("announcement editor preserves image and pinned fields through edit and sav
     expect(safetySource).toContain("pinned?: boolean");
 });
 
+test("plugin upload owns native drops and price availability text remains readable", async () => {
+    const [pluginSource, adminCss] = await Promise.all([
+        Bun.file(new URL("../src/pages/plugins/plugin-documentation-modals.tsx", import.meta.url)).text(),
+        Bun.file(new URL("../src/styles/admin-ui.css", import.meta.url)).text(),
+    ]);
+    const toggleCss = sourceSection(adminCss, ".admin-price-tier-toggle span {", ".admin-model-editor-add-tier.ant-btn {");
+
+    expect(pluginSource).toContain("event.preventDefault()");
+    expect(pluginSource).toContain("onDragOver={(event)");
+    expect(pluginSource).toContain("onDrop={handlePluginDrop}");
+    expect(pluginSource).toContain("点击选择插件文件，也可拖拽到此处");
+    expect(pluginSource).toContain("释放文件以上传插件");
+    expect(pluginSource).toContain("isDraggingPlugin");
+    expect(compactSource(adminCss)).toContain(".admin-price-tier-controls { display: grid !important; grid-template-columns: minmax(0, 1fr);");
+    expect(toggleCss).toContain("overflow-wrap: anywhere;");
+    expect(toggleCss).toContain("white-space: normal;");
+    expect(toggleCss).not.toContain("text-overflow: ellipsis;");
+});
+
 test("analytics keeps fixed range presets distinct and uses enabled channel models for pricing", async () => {
     const source = compactSource(await Bun.file(new URL("../src/pages/admin/components/analytics-panel.tsx", import.meta.url)).text());
 


### PR DESCRIPTION
## 改动摘要

这次主要修复管理员后台两个使用问题：

1. `admin/plugins` 插件上传区域

- 增加“点击选择插件文件，也可拖拽到此处”的提示。
- 拖拽文件进入上传区域时显示“释放文件以上传插件”。
- 拖拽过程中上传区域会高亮，方便确认文件应该放在哪里。
- 阻止浏览器把拖入的插件文件直接下载到本地。
- 保留原来的点击选择文件和插件上传流程。

2. 模型价格配置区域

- 补充“可供用户使用”开关的完整说明。
- 开启时参与用户请求匹配。
- 关闭时保留价格配置，但不参与计费匹配。
- 调整布局，避免说明文字被压缩、省略或显示不完整。

## 风险与兼容性

- 没有修改后端接口、数据库结构和权限逻辑。
- 没有修改插件上传接口和文件校验规则。
- 没有修改支付商品功能。
- 没有修改本地启动脚本、`.local` 文件夹或个人配置。
- 主要是上传交互提示、拖拽事件处理和价格配置区域的显示优化。

## 验证

- TypeScript 类型检查通过。
- `git diff --check` 通过。
- 已增加相关回归检查，覆盖插件拖拽事件、默认提示、释放提示和价格开关文字显示。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义