### PR TITLE
fix(admin): 模型测试 - 视频测试按能力画像回填比例与分辨率

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,12 +5,14 @@ go 1.25.0
 require (
 	github.com/aws/aws-sdk-go v1.40.45
 	github.com/gin-gonic/gin v1.12.0
+	github.com/google/uuid v1.5.0
 	github.com/qiniu/go-sdk/v7 v7.27.0
 	github.com/redis/go-redis/v9 v9.22.0
 	github.com/tencentyun/cos-go-sdk-v5 v0.7.75
 	github.com/volcengine/volc-sdk-golang v1.0.253
 	golang.org/x/crypto v0.54.0
 	golang.org/x/net v0.57.0
+	golang.org/x/sync v0.22.0
 	gorm.io/driver/postgres v1.6.2
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.31.2
@@ -35,7 +37,6 @@ require (
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
-	github.com/google/uuid v1.5.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.10.0 // indirect
@@ -60,7 +61,6 @@ require (
 	go.mongodb.org/mongo-driver/v2 v2.8.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/arch v0.29.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/backend/internal/service/channel_models.go
+++ b/backend/internal/service/channel_models.go
@@ -563,13 +563,25 @@ func (s *Service) TestAdminChannelModel(ctx context.Context, actor *model.User, 
 	}
 	imageSize, imageQuality := "", ""
 	var imageProfile *ImageCapabilityConfig
-	if capability == "image" {
+	videoRatio, videoResolution := videoTestDefaults(nil)
+	var videoProfile *VideoCapabilityConfig
+	switch capability {
+	case "image":
 		profile, normalizeErr := NormalizeModelCapabilityConfigForModel(capability, string(protocol), providerModelKey, req.CapabilityConfig)
 		if normalizeErr != nil {
 			return nil, normalizeErr
 		}
 		imageProfile = profile.Image
 		imageSize, imageQuality = imageTestDefaults(imageProfile)
+	case "video":
+		// 视频测试必须带上模型能力画像：声明式协议只按画像里的枚举回填分辨率名（如 480 -> 480p），
+		// 没有画像时会把裸数字发给上游，火山方舟等供应商会直接拒绝。
+		profile, normalizeErr := NormalizeModelCapabilityConfigForModel(capability, string(protocol), providerModelKey, req.CapabilityConfig)
+		if normalizeErr != nil {
+			return nil, normalizeErr
+		}
+		videoProfile = profile.Video
+		videoRatio, videoResolution = videoTestDefaults(videoProfile)
 	}
 	input := canvasGenerationInput{
 		Mode:   capability,
@@ -585,11 +597,11 @@ func (s *Service) TestAdminChannelModel(ctx context.Context, actor *model.User, 
 			Headers:            headers,
 			Model:              providerModelKey,
 			ChannelModelKey:    modelKey,
-			Size:               map[string]string{"image": imageSize, "video": "16:9"}[capability],
+			Size:               map[string]string{"image": imageSize, "video": videoRatio}[capability],
 			Quality:            imageQuality,
 			Count:              "1",
 			VideoSeconds:       videoSeconds,
-			VQuality:           "720",
+			VQuality:           videoResolution,
 			VideoGenerateAudio: "false",
 			VideoWatermark:     "false",
 			AudioVoice:         "alloy",
@@ -600,6 +612,9 @@ func (s *Service) TestAdminChannelModel(ctx context.Context, actor *model.User, 
 	}
 	if capability == "image" {
 		input.ImageCapability = imageProfile
+	}
+	if capability == "video" {
+		input.VideoCapability = videoProfile
 	}
 
 	// 测试复用真实生成协议、运行时并发和熔断策略，但不创建用户任务或计费订单。
@@ -633,6 +648,28 @@ func (s *Service) TestAdminChannelModel(ctx context.Context, actor *model.User, 
 }
 
 // 模型测试必须使用当前模型声明的默认参数，避免固定分辨率 SKU 被通用 1K 测试值误伤。
+// videoTestDefaults 从模型能力画像取测试用的比例和分辨率；画像缺失时回退到最通用的 16:9 / 720。
+func videoTestDefaults(profile *VideoCapabilityConfig) (string, string) {
+	if profile == nil {
+		return "16:9", "720"
+	}
+	ratio := strings.TrimSpace(profile.DefaultRatio)
+	if ratio == "" && len(profile.Ratios) > 0 {
+		ratio = strings.TrimSpace(profile.Ratios[0])
+	}
+	if ratio == "" {
+		ratio = "16:9"
+	}
+	resolution := strings.TrimSpace(profile.DefaultResolution)
+	if resolution == "" && len(profile.Resolutions) > 0 {
+		resolution = strings.TrimSpace(profile.Resolutions[0])
+	}
+	if resolution == "" {
+		resolution = "720"
+	}
+	return ratio, resolution
+}
+
 func imageTestDefaults(profile *ImageCapabilityConfig) (string, string) {
 	if profile == nil {
 		return "1024x1024", "auto"

--- a/backend/internal/service/channel_models_admin_test_defaults_test.go
+++ b/backend/internal/service/channel_models_admin_test_defaults_test.go
@@ -1,0 +1,36 @@
+package service
+
+import "testing"
+
+func TestVideoTestDefaultsFollowCapabilityProfile(t *testing.T) {
+	tests := []struct {
+		name           string
+		profile        *VideoCapabilityConfig
+		wantRatio      string
+		wantResolution string
+	}{
+		{name: "nil profile falls back", profile: nil, wantRatio: "16:9", wantResolution: "720"},
+		{name: "declared defaults win", profile: &VideoCapabilityConfig{Ratios: []string{"9:16", "16:9"}, DefaultRatio: "16:9", Resolutions: []string{"480p", "720p"}, DefaultResolution: "720p"}, wantRatio: "16:9", wantResolution: "720p"},
+		{name: "first enum when no default", profile: &VideoCapabilityConfig{Ratios: []string{"1:1"}, Resolutions: []string{"768p横"}}, wantRatio: "1:1", wantResolution: "768p横"},
+		{name: "empty profile falls back", profile: &VideoCapabilityConfig{}, wantRatio: "16:9", wantResolution: "720"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ratio, resolution := videoTestDefaults(tt.profile)
+			if ratio != tt.wantRatio || resolution != tt.wantResolution {
+				t.Fatalf("videoTestDefaults() = (%q, %q), want (%q, %q)", ratio, resolution, tt.wantRatio, tt.wantResolution)
+			}
+		})
+	}
+}
+
+func TestVideoTestDefaultsResolveArkSeedanceEnum(t *testing.T) {
+	profile := DefaultModelCapabilityConfigForModel("volcengine-ark-video", "doubao-seedance-2-0-mini-260615").Video
+	_, resolution := videoTestDefaults(profile)
+	if resolution == "" || resolution == "720" {
+		t.Fatalf("Ark Seedance test resolution must come from the declared enum, got %q", resolution)
+	}
+	if got := videoResolutionNameRequest(profile, resolution); got != resolution {
+		t.Fatalf("declared resolution %q must round-trip through the profile, got %q", resolution, got)
+	}
+}


### PR DESCRIPTION
## 改动摘要

管理后台「测试模型」的视频分支把 `VQuality` 硬编码为 `720`，且不给 `canvasGenerationInput` 挂模型能力画像。#381 之后声明式视频协议只按画像里的分辨率枚举回填名称（`480`→`480p`），没有画像时裸数字直接发给上游，火山方舟返回 `the parameter resolution specified in the request is not valid`——画布里的真实任务已经修好，但测试按钮仍然必失败，管理员无法用它确认渠道可用。

本 PR 让视频测试与图片测试对齐：按 `NormalizeModelCapabilityConfigForModel` 归一化能力画像，把画像挂到 `input.VideoCapability`，比例和分辨率取画像的默认值（缺省时取枚举首项，再缺省回退 `16:9`/`720`）。

## 风险与兼容性

- 只影响管理端模型测试；不改画布任务链路。
- 视频测试现在与图片测试一样要求提交能力参数，缺失时返回「请配置视频模型能力参数」而不是发出注定失败的上游请求；前台测试按钮本就随表单提交 `capabilityConfig`。
- 测试仍是真实生成，费用语义不变。

## 验证

- `go test ./internal/protocol/ ./internal/service/`、`go vet`、`gofmt`：通过。新增 `TestVideoTestDefaultsFollowCapabilityProfile`、`TestVideoTestDefaultsResolveArkSeedanceEnum`。
- 生产环境复现（v1.2.4.2）：对 `doubao-seedance-2-0-mini` 点测试，`api_call_logs` 请求体 `"resolution": "720"`，上游 400；同一模型走画布任务（`vquality=480`）请求体为 `480p`，成功。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义
