### PR TITLE
修复 Docker 构建平台参数为空

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,14 +1,9 @@
 # syntax=docker/dockerfile:1.7
 
-ARG BUILDPLATFORM
-ARG TARGETPLATFORM
-
 FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS payment-package-build
 
 ARG TARGETOS
 ARG TARGETARCH
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
 ARG GOPROXY=https://proxy.golang.org,direct
 ENV GOPROXY=$GOPROXY
 
@@ -28,7 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build set -eu; \
       ./plugin-packages/build-packages.sh --payments-only; \
     sh ./plugin-packages/verify-payment-packages.sh "$TARGETOS" "$TARGETARCH"
 
-FROM --platform=$TARGETPLATFORM alpine:3.22 AS payment-package-smoke
+FROM alpine:3.22 AS payment-package-smoke
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
## 改动摘要

修复 #402 合并后，Docker/Compose 构建后端镜像时出现的平台参数解析失败：

    failed to parse platform: "" is an invalid component

- 移除 Dockerfile 顶层对 BUILDPLATFORM、TARGETPLATFORM 的无默认值重复声明，直接使用 BuildKit 自动注入的全局平台参数。
- 保留 payment-package-build 在 BUILDPLATFORM 上执行，继续通过 TARGETOS/TARGETARCH 交叉编译支付插件。
- 移除 payment-package-smoke 上冗余的 --platform=$TARGETPLATFORM；未指定 FROM 平台时，BuildKit 会默认使用构建请求的目标平台。

## 风险与兼容性

- 仅修改 backend/Dockerfile，不涉及应用代码、数据库、API 或配置格式。
- 不改变多平台构建目标：amd64/arm64 仍分别生成并执行对应架构的支付插件。
- 修复分支基于最新 upstream/main，PR 相对主线仅包含 1 个 commit。

## 验证

- [x] #402 的 Payment plugin artifacts CI 已复现同一平台参数为空错误
- [x] 按 Docker 官方自动平台 ARG 作用域调整 Dockerfile
- [x] git diff --check
- [x] 确认 upstream/main..HEAD 仅有 1 个 commit
- [x] PR CI：amd64/arm64 Buildx 构建与支付插件执行冒烟通过（本机无 Docker）

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义
