### PR TITLE
feat(admin): 渠道模型 - 拉取模型支持勾选导入并允许离线启停渠道

### DIFF
--- a/backend/internal/handler/finance.go
+++ b/backend/internal/handler/finance.go
@@ -214,8 +214,30 @@ func RegisterFinanceRoutes(r *gin.RouterGroup, svc *service.Service) {
 		if !enforceRateLimit(c, "admin-channel-models-fetch:"+user.ID+":"+c.Param("id"), 10, time.Minute) {
 			return
 		}
-		// 上游密钥只在 service 内使用，handler 仅返回去重后的模型标识和新增数量。
-		result, err := svc.FetchAdminChannelModels(c.Request.Context(), user, c.Param("id"))
+		// 上游密钥只在 service 内使用；点击拉取时仅返回目录，确认后才写入渠道模型。
+		models, err := svc.PreviewAdminChannelModels(c.Request.Context(), user, c.Param("id"))
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		ok(c, gin.H{"models": models})
+	})
+	r.POST("/admin/channels/:id/models/import", func(c *gin.Context) {
+		user, err := currentUser(c, svc)
+		if err != nil {
+			failService(c, err)
+			return
+		}
+		if !enforceRateLimit(c, "admin-channel-models-import:"+user.ID+":"+c.Param("id"), 10, time.Minute) {
+			return
+		}
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, 64<<10)
+		var req service.AdminChannelModelImportRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			fail(c, http.StatusBadRequest, err)
+			return
+		}
+		result, err := svc.ImportAdminChannelModels(c.Request.Context(), user, c.Param("id"), req.Models)
 		if err != nil {
 			failService(c, err)
 			return

--- a/backend/internal/service/admin.go
+++ b/backend/internal/service/admin.go
@@ -761,8 +761,16 @@ func (s *Service) channelFromRequest(req ChannelRequest, channel model.ModelChan
 	if requestedAllowLocal && !s.DesktopLocalChannelsEnabled() {
 		return channel, BadAuthRequest("当前后端未启用本机渠道")
 	}
-	if _, err := s.validateChannelOutboundURL(baseURL, requestedAllowLocal, false); err != nil {
-		return channel, err
+	// 启用/停用或只修改价格、模型等本地配置时，不应要求上游域名当前可解析。
+	// 只有 Base URL 或本机渠道开关实际变化时才做出站地址校验。
+	connectionChanged := strings.TrimRight(baseURL, "/") != strings.TrimRight(channel.BaseURL, "/")
+	if req.AllowLocalChannel != nil {
+		connectionChanged = connectionChanged || *req.AllowLocalChannel != channel.AllowLocalChannel
+	}
+	if connectionChanged {
+		if _, err := s.validateChannelOutboundURL(baseURL, requestedAllowLocal, false); err != nil {
+			return channel, err
+		}
 	}
 	models := uniqueNonEmpty(req.Models)
 	modelsJSON, _ := json.Marshal(models)

--- a/backend/internal/service/admin_channel_test.go
+++ b/backend/internal/service/admin_channel_test.go
@@ -52,6 +52,31 @@ func TestMergeChannelRequestSupportsEnabledOnlyPatch(t *testing.T) {
 	}
 }
 
+func TestUpdateSystemChannelEnabledOnlySkipsOutboundResolution(t *testing.T) {
+	svc, db := newChannelModelTestService(t)
+	svc.dataDir = t.TempDir()
+	admin := &model.User{ID: "admin", Role: model.UserRoleAdmin}
+	channel := model.ModelChannel{ID: "channel-1", UserID: admin.ID, Scope: model.ChannelScopeSystem, Enabled: true, Name: "Dead", BaseURL: "https://dead.invalid/v1", APIKey: "key", APIFormat: "openai", ModelsJSON: `[]`}
+	if err := db.Create(&channel).Error; err != nil {
+		t.Fatal(err)
+	}
+	disabled := false
+	updated, err := svc.UpdateSystemChannel(admin, channel.ID, ChannelRequest{Enabled: &disabled})
+	if err != nil {
+		t.Fatalf("UpdateSystemChannel() should not resolve the stored URL for an enabled-only patch: %v", err)
+	}
+	if updated.Enabled {
+		t.Fatal("UpdateSystemChannel() did not persist disabled state")
+	}
+	var stored model.ModelChannel
+	if err := db.First(&stored, "id = ?", channel.ID).Error; err != nil {
+		t.Fatal(err)
+	}
+	if stored.Enabled {
+		t.Fatal("stored channel is still enabled after update")
+	}
+}
+
 func TestChannelFromRequestStoresAndClearsHeaders(t *testing.T) {
 	request := ChannelRequest{Name: "Headers", BaseURL: "https://example.com/v1", Headers: []OutboundHeader{{Name: "User-Agent", Value: "Custom Agent"}}}
 	channel, err := channelFromRequest(request, model.ModelChannel{})
@@ -150,6 +175,81 @@ func TestFetchAdminChannelModelsReaddsDeletedModel(t *testing.T) {
 	}
 	if total != 2 {
 		t.Fatalf("model history count = %d, want 2", total)
+	}
+}
+
+func TestImportAdminChannelModelsOnlyImportsSelectedModels(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"model-a"},{"id":"model-b"}]}`))
+	}))
+	defer upstream.Close()
+
+	svc, db := newChannelModelTestService(t)
+	svc.runtimeCapabilities = RuntimeCapabilities{desktopLocalChannels: true}
+	admin := &model.User{ID: "admin", Role: model.UserRoleAdmin}
+	channel := model.ModelChannel{ID: "channel-1", UserID: admin.ID, Scope: model.ChannelScopeSystem, Enabled: true, Name: "Test", BaseURL: upstream.URL + "/v1", APIKey: "key", APIFormat: "openai", ModelsJSON: `[]`, AllowLocalChannel: true}
+	if err := db.Create(&channel).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	preview, err := svc.PreviewAdminChannelModels(context.Background(), admin, channel.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(preview) != 2 {
+		t.Fatalf("preview models = %#v, want two models", preview)
+	}
+	var before int64
+	if err := db.Model(&model.ChannelModel{}).Where("channel_id = ?", channel.ID).Count(&before).Error; err != nil {
+		t.Fatal(err)
+	}
+	if before != 0 {
+		t.Fatalf("preview created %d channel models", before)
+	}
+
+	result, err := svc.ImportAdminChannelModels(context.Background(), admin, channel.ID, []string{"model-b"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Added != 1 || len(result.Models) != 1 || result.Models[0] != "model-b" {
+		t.Fatalf("import result = %#v, want only model-b", result)
+	}
+	var imported []model.ChannelModel
+	if err := db.Where("channel_id = ?", channel.ID).Find(&imported).Error; err != nil {
+		t.Fatal(err)
+	}
+	if len(imported) != 1 || imported[0].ModelKey != "model-b" {
+		t.Fatalf("imported models = %#v, want only model-b", imported)
+	}
+}
+
+func TestImportAdminChannelModelsRejectsUnknownSelection(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"model-a"}]}`))
+	}))
+	defer upstream.Close()
+
+	svc, db := newChannelModelTestService(t)
+	svc.runtimeCapabilities = RuntimeCapabilities{desktopLocalChannels: true}
+	admin := &model.User{ID: "admin", Role: model.UserRoleAdmin}
+	channel := model.ModelChannel{ID: "channel-1", UserID: admin.ID, Scope: model.ChannelScopeSystem, Enabled: true, Name: "Test", BaseURL: upstream.URL + "/v1", APIKey: "key", APIFormat: "openai", ModelsJSON: `[]`, AllowLocalChannel: true}
+	if err := db.Create(&channel).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := svc.ImportAdminChannelModels(context.Background(), admin, channel.ID, []string{"not-in-catalog"})
+	var authErr *AuthError
+	if !errors.As(err, &authErr) || authErr.Message != "所选模型不在上游模型目录中：not-in-catalog" {
+		t.Fatalf("ImportAdminChannelModels() error = %#v", err)
+	}
+	var count int64
+	if err := db.Model(&model.ChannelModel{}).Where("channel_id = ?", channel.ID).Count(&count).Error; err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("unknown selection created %d channel models", count)
 	}
 }
 

--- a/backend/internal/service/channel_models.go
+++ b/backend/internal/service/channel_models.go
@@ -59,6 +59,10 @@ type AdminChannelModelFetchResult struct {
 	Added  int64    `json:"added"`
 }
 
+type AdminChannelModelImportRequest struct {
+	Models []string `json:"models"`
+}
+
 type AdminChannelModelTestResult struct {
 	DurationMs int64 `json:"durationMs"`
 }
@@ -182,6 +186,107 @@ func (s *Service) FetchAdminChannelModels(ctx context.Context, actor *model.User
 		s.invalidateRouteCatalog()
 	}
 	return &AdminChannelModelFetchResult{Models: models, Added: added}, nil
+}
+
+// PreviewAdminChannelModels 只读取上游模型目录，不修改渠道模型配置。
+func (s *Service) PreviewAdminChannelModels(ctx context.Context, actor *model.User, channelID string) ([]string, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	return s.fetchAdminChannelModelCatalog(ctx, actor, channelID)
+}
+
+// ImportAdminChannelModels 只导入管理员明确选择、且仍存在于上游目录中的模型。
+func (s *Service) ImportAdminChannelModels(ctx context.Context, actor *model.User, channelID string, selected []string) (*AdminChannelModelFetchResult, error) {
+	if err := s.RequireAdmin(actor); err != nil {
+		return nil, err
+	}
+	channel, err := s.adminSystemChannel(channelID)
+	if err != nil {
+		return nil, err
+	}
+	models, err := s.fetchAdminChannelModelCatalog(ctx, actor, channelID)
+	if err != nil {
+		return nil, err
+	}
+	if len(selected) == 0 {
+		return nil, BadAuthRequest("请至少选择一个要导入的模型")
+	}
+	if len(selected) > 500 {
+		return nil, BadAuthRequest("单次最多导入 500 个模型")
+	}
+	available := make(map[string]string, len(models))
+	for _, name := range models {
+		available[channelModelCatalogKey(name)] = name
+	}
+	chosen := make([]string, 0, len(selected))
+	seen := make(map[string]struct{}, len(selected))
+	for _, rawName := range selected {
+		name := strings.TrimPrefix(strings.TrimSpace(rawName), "models/")
+		key := channelModelCatalogKey(name)
+		if key == "" {
+			continue
+		}
+		canonical, ok := available[key]
+		if !ok {
+			return nil, BadAuthRequest("所选模型不在上游模型目录中：" + name)
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		chosen = append(chosen, canonical)
+	}
+	if len(chosen) == 0 {
+		return nil, BadAuthRequest("请至少选择一个有效的模型")
+	}
+
+	existing, err := s.repo.ChannelModels(channelID, true)
+	if err != nil {
+		return nil, err
+	}
+	known := make(map[string]struct{}, len(existing))
+	for _, item := range existing {
+		known[channelModelCatalogKey(item.ModelKey)] = struct{}{}
+	}
+	retired := retiredChannelModelKeys(channel.RetiredModelsJSON)
+	missing := make([]model.ChannelModel, 0, len(chosen))
+	for _, name := range chosen {
+		key := channelModelCatalogKey(name)
+		if _, ok := known[key]; ok || retired[key] {
+			continue
+		}
+		modelID, idErr := s.repo.NextPrefixedID("MODEL")
+		if idErr != nil {
+			return nil, idErr
+		}
+		missing = append(missing, model.ChannelModel{ID: modelID, ChannelID: channelID, ModelKey: name, DisplayName: name, BillingMode: "fixed_request", Enabled: false, PriceConfigured: false, PriceVersion: 1})
+		known[key] = struct{}{}
+	}
+	added, err := s.repo.CreateMissingChannelModels(missing)
+	if err != nil {
+		return nil, err
+	}
+	if added > 0 {
+		s.invalidateRouteCatalog()
+	}
+	return &AdminChannelModelFetchResult{Models: chosen, Added: added}, nil
+}
+
+func (s *Service) fetchAdminChannelModelCatalog(ctx context.Context, actor *model.User, channelID string) ([]string, error) {
+	channel, err := s.adminSystemChannel(channelID)
+	if err != nil {
+		return nil, err
+	}
+	headers, err := ParseOutboundHeadersJSON(channel.HeadersJSON)
+	if err != nil {
+		return nil, err
+	}
+	models, err := s.FetchChannelModels(ctx, actor, ChannelModelsRequest{BaseURL: channel.BaseURL, AllowLocalChannel: channel.AllowLocalChannel, APIKey: channel.APIKey, APIFormat: channel.APIFormat, Headers: headers})
+	if err != nil {
+		return nil, err
+	}
+	return uniqueNonEmpty(models), nil
 }
 
 func (s *Service) SaveAdminChannelModel(actor *model.User, channelID string, id string, req ChannelModelRequest) (*model.ChannelModel, error) {

--- a/web/src/pages/admin/components/channel-model-manager.tsx
+++ b/web/src/pages/admin/components/channel-model-manager.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { App, Button, Drawer, Form, Input, InputNumber, Popconfirm, Segmented, Select, Space, Switch, type FormInstance } from "antd";
+import { App, Button, Checkbox, Drawer, Form, Input, InputNumber, Modal, Popconfirm, Segmented, Select, Space, Switch, type FormInstance } from "antd";
 import type { ColumnsType } from "antd/es/table";
 import { FlaskConical, Plus, RefreshCw, Search, Trash2 } from "lucide-react";
 
@@ -11,7 +11,7 @@ import { CapabilityCardPicker, ProtocolCardPicker, type ModelCapabilityChoice } 
 import { defaultModelCapabilityConfig, normalizeModelCapabilityConfig, type ModelCapabilityConfig } from "@/lib/model-capabilities";
 import { modelProtocolCapability, modelProtocolDefinition, modelProtocolLabel, modelProtocolSupportsTokenBilling, type ModelProtocol } from "@/lib/model-protocols";
 import { fetchPluginProviderCatalog } from "@/services/api/plugin-catalog";
-import { createAdminChannelModel, deleteAdminChannelModel, fetchAdminChannelModels, listAdminChannelModels, testAdminChannelModel, updateAdminChannelModel, type ChannelModel, type ChannelModelPriceTier } from "@/services/api/wallet";
+import { createAdminChannelModel, deleteAdminChannelModel, fetchAdminChannelModels, importAdminChannelModels, listAdminChannelModels, testAdminChannelModel, updateAdminChannelModel, type ChannelModel, type ChannelModelPriceTier } from "@/services/api/wallet";
 import type { ModelChannel } from "@/stores/use-config-store";
 import { defaultPriceTier, legacyPriceTierToForm, priceTierResolutionFromForm, priceTierToForm, priceTierVideoSecondsFromForm, skuSelectorFromForm, type PriceTierFormValues } from "./channel-model-price-tier-form";
 import { AdminPageFrame } from "./admin-shell";
@@ -37,6 +37,10 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
     const [editing, setEditing] = useState<ChannelModel | null>(null);
     const [loading, setLoading] = useState(false);
     const [fetching, setFetching] = useState(false);
+    const [fetchPreviewOpen, setFetchPreviewOpen] = useState(false);
+    const [fetchPreviewModels, setFetchPreviewModels] = useState<string[]>([]);
+    const [selectedFetchModels, setSelectedFetchModels] = useState<string[]>([]);
+    const [importing, setImporting] = useState(false);
     const [saving, setSaving] = useState(false);
     const [testing, setTesting] = useState(false);
     const [editorOpen, setEditorOpen] = useState(false);
@@ -75,6 +79,7 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
             .catch(() => setAvailableProtocols([]));
         setEditing(null);
         setEditorOpen(false);
+        resetFetchPreview();
         setKeyword("");
         setCapability("all");
         setStatus("all");
@@ -84,17 +89,51 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
     const fetchModels = async () => {
         setFetching(true);
         try {
-            // 拉取只导入缺失项；新模型仍需管理员定价并手动启用。
             const result = await fetchAdminChannelModels(channel.id);
-            await reload();
-            await onChanged();
-            if (result.models.length === 0) message.warning("上游没有返回可用模型");
-            else if (result.added > 0) message.success(`已拉取 ${result.models.length} 个模型，新增 ${result.added} 个待配置模型`);
-            else message.info(`已拉取 ${result.models.length} 个模型，没有需要新增的模型`);
+            if (result.models.length === 0) {
+                message.warning("上游没有返回可用模型");
+                return;
+            }
+            setFetchPreviewModels(result.models);
+            setSelectedFetchModels(result.models);
+            setFetchPreviewOpen(true);
         } catch (error) {
             message.error(error instanceof Error ? error.message : "拉取模型失败");
         } finally {
             setFetching(false);
+        }
+    };
+
+    const closeFetchPreview = () => {
+        if (importing) return;
+        resetFetchPreview();
+    };
+
+    const resetFetchPreview = () => {
+        setFetchPreviewOpen(false);
+        setFetchPreviewModels([]);
+        setSelectedFetchModels([]);
+    };
+
+    const importSelectedModels = async () => {
+        if (!selectedFetchModels.length) return;
+        if (!selectedNewFetchModels.length) {
+            message.info("当前勾选的模型均已存在，没有需要新增的模型");
+            resetFetchPreview();
+            return;
+        }
+        setImporting(true);
+        try {
+            const result = await importAdminChannelModels(channel.id, selectedFetchModels);
+            await reload();
+            await onChanged();
+            resetFetchPreview();
+            if (result.added > 0) message.success(`已导入 ${result.added} 个模型，新增模型仍需配置价格后启用`);
+            else message.info("所选模型均已存在，没有新增模型");
+        } catch (error) {
+            message.error(error instanceof Error ? error.message : "导入模型失败");
+        } finally {
+            setImporting(false);
         }
     };
 
@@ -293,6 +332,23 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
         return true;
     });
     const pagedItems = filteredItems.slice((page - 1) * pageSize, page * pageSize);
+    const existingFetchModelKeys = new Set(items.map((item) => normalizeFetchModelKey(item.modelKey)));
+    const selectedNewFetchModels = selectedFetchModels.filter((name) => !existingFetchModelKeys.has(normalizeFetchModelKey(name)));
+    const selectedExistingFetchCount = selectedFetchModels.length - selectedNewFetchModels.length;
+    const fetchModelOptions = fetchPreviewModels.map((name) => {
+        const alreadyExists = existingFetchModelKeys.has(normalizeFetchModelKey(name));
+        return {
+            label: alreadyExists ? (
+                <span className="flex min-w-0 items-center gap-2">
+                    <span className="min-w-0 break-all">{name}</span>
+                    <span className="shrink-0 text-xs text-foreground/45">已存在</span>
+                </span>
+            ) : (
+                <span className="break-all">{name}</span>
+            ),
+            value: name,
+        };
+    });
 
     return (
         <AdminPageFrame
@@ -416,6 +472,40 @@ export function ChannelModelManager({ channel, onClose, onChanged }: { channel: 
                     />
                 }
             />
+            <Modal
+                title="选择要导入的模型"
+                open={fetchPreviewOpen}
+                centered
+                width={720}
+                rootClassName="admin-modal-root admin-model-import-modal"
+                onCancel={closeFetchPreview}
+                maskClosable={!importing}
+                closable={!importing}
+                footer={[
+                    <Button key="cancel" disabled={importing} onClick={closeFetchPreview}>
+                        取消
+                    </Button>,
+                    <Button key="confirm" type="primary" loading={importing} disabled={!selectedFetchModels.length} onClick={() => void importSelectedModels()}>
+                        确认导入
+                    </Button>,
+                ]}
+            >
+                <div className="space-y-3">
+                    <p className="m-0 text-sm text-foreground/65">上游共返回 {fetchPreviewModels.length} 个模型。默认已全选，请取消本次不需要拉入的模型；已存在的模型不会重复导入。</p>
+                    <div className="max-h-[min(60vh,520px)] overflow-y-auto rounded-md border border-border/70 p-3">
+                        <Checkbox.Group
+                            className="channel-model-import-picker grid w-full grid-cols-1 gap-2 sm:grid-cols-2"
+                            value={selectedFetchModels}
+                            options={fetchModelOptions}
+                            onChange={(values) => setSelectedFetchModels(values as string[])}
+                        />
+                    </div>
+                    <div className="text-xs text-foreground/50">
+                        {selectedNewFetchModels.length > 0 ? `将导入 ${selectedNewFetchModels.length} 个新模型` : "当前勾选的模型均已存在"}
+                        {selectedExistingFetchCount > 0 ? `，另有 ${selectedExistingFetchCount} 个已存在模型已勾选` : ""}
+                    </div>
+                </div>
+            </Modal>
             <Drawer
                 title={editing ? `编辑模型 / ${editing.displayName || editing.modelKey}` : "新增模型"}
                 open={editorOpen}
@@ -807,4 +897,8 @@ function operationLabel(operation: string) {
 
 function formatCredits(value: number) {
     return (value / 1_000_000).toLocaleString("zh-CN", { maximumFractionDigits: 6 });
+}
+
+function normalizeFetchModelKey(value: string) {
+    return value.trim().replace(/^models\//, "").toLowerCase();
 }

--- a/web/src/services/api/wallet.ts
+++ b/web/src/services/api/wallet.ts
@@ -269,9 +269,13 @@ export function listAdminChannelModels(channelId: string) {
     return request<{ models: ChannelModel[] }>(api.get(`/admin/channels/${encodeURIComponent(channelId)}/models`));
 }
 
-// 管理员从上游拉取模型目录；服务端只导入缺失项，价格和启用仍需人工确认。
+// 管理员从上游读取模型目录；确认导入后才会写入渠道模型，价格和启用仍需人工确认。
 export function fetchAdminChannelModels(channelId: string) {
-    return request<{ models: string[]; added: number }>(api.post(`/admin/channels/${encodeURIComponent(channelId)}/models/fetch`));
+	return request<{ models: string[] }>(api.post(`/admin/channels/${encodeURIComponent(channelId)}/models/fetch`));
+}
+
+export function importAdminChannelModels(channelId: string, models: string[]) {
+	return request<{ models: string[]; added: number }>(api.post(`/admin/channels/${encodeURIComponent(channelId)}/models/import`, { models }));
 }
 
 export function testAdminChannelModel(channelId: string, input: Pick<ChannelModel, "modelKey" | "providerModelKey" | "capability" | "protocol"> & { capabilityConfig?: ChannelModel["capabilityConfig"] }) {

--- a/web/src/styles/admin-ui.css
+++ b/web/src/styles/admin-ui.css
@@ -8889,6 +8889,47 @@
 }
 
 /* 系统渠道模型编辑器：恢复已确认的信息层级、协议参数与价格档布局。 */
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox-wrapper {
+    display: flex;
+    min-width: 0;
+    min-height: 38px;
+    align-items: center;
+    margin-inline-end: 0;
+    border: 1px solid var(--admin-divider);
+    border-radius: 7px;
+    background: var(--admin-layer-2);
+    padding: 7px 10px;
+    color: var(--admin-text-primary);
+    transition: background-color 150ms ease, border-color 150ms ease;
+}
+
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox-wrapper:hover {
+    border-color: color-mix(in srgb, var(--foreground) 22%, var(--admin-card-border));
+    background: color-mix(in srgb, var(--foreground) 5%, var(--admin-layer-1));
+}
+
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox-wrapper.ant-checkbox-wrapper-checked {
+    border-color: color-mix(in srgb, var(--foreground) 26%, var(--admin-card-border));
+    background: color-mix(in srgb, var(--foreground) 7%, var(--admin-layer-1));
+}
+
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox {
+    align-self: center;
+    width: 18px;
+    height: 18px;
+    flex: none;
+    border-radius: 5px;
+}
+
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox-checked {
+    background: var(--control-check-bg) !important;
+    border-color: var(--control-check-bg) !important;
+}
+
+.admin-model-import-modal .channel-model-import-picker .ant-checkbox-checked::after {
+    border-color: var(--control-check-fg) !important;
+}
+
 .admin-model-editor-drawer .ant-drawer-header {
     min-height: 52px;
     padding-inline: 24px;

--- a/web/test/admin-ui-regressions.test.ts
+++ b/web/test/admin-ui-regressions.test.ts
@@ -52,6 +52,28 @@ test("plugin upload owns native drops and price availability text remains readab
     expect(toggleCss).not.toContain("text-overflow: ellipsis;");
 });
 
+test("channel model fetch requires explicit selection before import", async () => {
+    const [componentSource, apiSource, adminCssSource] = await Promise.all([
+        Bun.file(new URL("../src/pages/admin/components/channel-model-manager.tsx", import.meta.url)).text(),
+        Bun.file(new URL("../src/services/api/wallet.ts", import.meta.url)).text(),
+        Bun.file(new URL("../src/styles/admin-ui.css", import.meta.url)).text(),
+    ]);
+    const component = compactSource(componentSource);
+
+    expect(apiSource).toContain('api.post(`/admin/channels/${encodeURIComponent(channelId)}/models/fetch`)');
+    expect(apiSource).toContain('api.post(`/admin/channels/${encodeURIComponent(channelId)}/models/import`, { models })');
+    expect(component).toContain('title="选择要导入的模型"');
+    expect(component).toContain("默认已全选");
+    expect(component).toContain("setFetchPreviewOpen(true)");
+    expect(component).toContain("setSelectedFetchModels(result.models)");
+    expect(component).toContain("importAdminChannelModels(channel.id, selectedFetchModels)");
+    expect(component).toContain("disabled={!selectedFetchModels.length}");
+    expect(component).not.toContain("disabled: alreadyExists");
+    expect(component).not.toContain("const result = await fetchAdminChannelModels(channel.id); await reload();");
+    expect(adminCssSource).toContain(".admin-model-import-modal .channel-model-import-picker .ant-checkbox-checked");
+    expect(adminCssSource).toContain("border-color: var(--control-check-fg) !important");
+});
+
 test("analytics keeps fixed range presets distinct and uses enabled channel models for pricing", async () => {
     const source = compactSource(await Bun.file(new URL("../src/pages/admin/components/analytics-panel.tsx", import.meta.url)).text());
 


### PR DESCRIPTION
## 改动摘要

- “拉取模型”改为先读取上游模型目录并弹出预选框，不再点击后立即导入全部模型。
- 预选框默认全选，可取消不需要的模型；确认后只导入仍勾选的模型，已存在模型不会重复导入。
- 后端拆分为“只读目录”和“确认导入”两个接口；确认导入时会重新校验所选模型仍在上游目录中。
- 系统渠道启用/停用改为本地配置操作：Base URL 和本机渠道开关未变化时不再解析外部域名，失效渠道也能正常停用。
- 调整导入弹窗勾选样式，暗色主题下勾选状态清晰可见。

## 风险与兼容性

- `/admin/channels/:id/models/fetch` 的语义由“拉取并自动导入缺失模型”调整为“仅返回上游模型目录”，不再写入数据库。
- 新增管理员导入接口 `/admin/channels/:id/models/import`，仍受管理员权限与频控保护。
- 无数据库迁移、无密钥或权限变化；导入的新模型仍保持未启用、未配置价格状态。
- 拉取模型和测试模型仍需要真实访问上游，离线渠道只保证启用/停用与本地配置修改可用。

## 验证

- 后端：渠道/模型相关 service 测试通过，handler 包编译通过。
- 前端：`tsc --noEmit` 通过。
- 前端：`bun test test/admin-ui-regressions.test.ts` 12 pass、0 fail。
- 已检查未提交密钥、数据库、日志、本地配置或 `.local` 内容。

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义