### PR TITLE
fix(canvas): 剥离工具执行结果中的画布快照，防止工程数据超4MB导致同步死锁

### DIFF
--- a/web/src/components/canvas/canvas-assistant-panel.tsx
+++ b/web/src/components/canvas/canvas-assistant-panel.tsx
@@ -829,7 +829,8 @@ export function CanvasAssistantPanel({
             }
             const ops = onlineToolToOps(name, args, current, effectiveConfig);
             const result = await executeOps(ops, { source: "online", conversationId: sessionId, messageId: messageId || sessionId });
-            return { ok: result.ok, message: result.changed ? canvasAgentPostconditionMessage(result) : result.noopReason, data: result };
+            const { snapshot: _snapshot, before: _before, after: _after, ...cleanData } = result;
+            return { ok: result.ok, message: result.changed ? canvasAgentPostconditionMessage(result) : result.noopReason, data: cleanData };
         } catch (error) {
             if (isAgentSessionPollingAbort(error)) throw error;
             return { ok: false, message: error instanceof Error ? error.message : "工具执行失败" };

--- a/web/src/services/user-data-sync.ts
+++ b/web/src/services/user-data-sync.ts
@@ -369,7 +369,7 @@ async function saveRemoteUserDataBatch(uploaded: Map<string, string>) {
                     message: "正在保存画布结构",
                 });
             }
-            await upsertRemoteCanvasProject(remotePayload);
+            await upsertRemoteCanvasProject(sanitizeCanvasProjectForRemoteSync(remotePayload));
             acknowledgedProjects.set(source.id, source);
             if (total > 0) useSyncProgressStore.getState().setProjectProgress(source.id, null);
         } catch (error) {
@@ -512,4 +512,43 @@ function isLocalStorageKey(value: string) {
 function numberValue(value: unknown) {
     const number = Number(value);
     return Number.isFinite(number) && number > 0 ? number : undefined;
+}
+
+function sanitizeCanvasProjectForRemoteSync<T>(project: T): T {
+    if (!project || typeof project !== "object") return project;
+    const clone = { ...(project as Record<string, unknown>) };
+    if (Array.isArray(clone.chatSessions)) {
+        clone.chatSessions = clone.chatSessions.map((session) => {
+            if (!session || typeof session !== "object") return session;
+            const s = { ...(session as Record<string, unknown>) };
+            if (Array.isArray(s.messages)) {
+                s.messages = s.messages.map((message) => {
+                    if (!message || typeof message !== "object" || !message.detail) return message;
+                    const m = { ...(message as Record<string, unknown>) };
+                    if (m.detail && typeof m.detail === "object") {
+                        const d = { ...(m.detail as Record<string, unknown>) };
+                        if (Array.isArray(d.results)) {
+                            d.results = d.results.map((r) => {
+                                if (!r || typeof r !== "object") return r;
+                                const res = { ...(r as Record<string, unknown>) };
+                                if (res.result && typeof res.result === "object") {
+                                    const inner = { ...(res.result as Record<string, unknown>) };
+                                    if (inner.data && typeof inner.data === "object") {
+                                        const { snapshot: _s, before: _b, after: _a, ...restData } = inner.data as Record<string, unknown>;
+                                        inner.data = restData;
+                                    }
+                                    res.result = inner;
+                                }
+                                return res;
+                            });
+                        }
+                        m.detail = d;
+                    }
+                    return m;
+                });
+            }
+            return s;
+        });
+    }
+    return clone as T;
 }


### PR DESCRIPTION
## 问题背景与根因 (Background & Root Cause)

在影策工作台中，当用户在大画布（如包含数十个分镜节点）中与 Agent 进行多轮协作时，会触发严重的同步死锁与数据溢出问题：

1. **快照冗余存储导致会话急剧膨胀**：
   `CanvasAssistantPanel.tsx` 在 `executeOnlineTool` 执行操作返回结果时，将整张画布的 AST、`before` 和 `after` 全量快照对象封装在 `data` 中返回，最终被写入消息的 `detail.results` 并在持久化与会话轮次间传递。多轮交互后，单个会话体积便能膨胀至 5MB+。
2. **服务端 4MB 安全拦截**：
   后端 `validateSyncedPayload` 对同步的画布 JSON 设有 4MB 安全上限，一旦超标便直接抛出 HTTP 400（文案提示“数据超过4MB，请先把媒体文件保存到资源存储”）。
3. **前端事务保护机制导致回滚死锁**：
   前端 `unconfirmedGeneration` 容灾逻辑在后端返回 400 时，误判为生成中断，强制从持久层回滚复活已被删除的坏会话和任务，导致用户在前端无法删除会话也无法继续保存。

## 修复方案 (Changes)

1. **`web/src/components/canvas/canvas-assistant-panel.tsx`**：
   在 `executeOnlineTool` 返回结果前，解构并剔除冗余的 `snapshot`、`before`、`after`，仅保留轻量操作摘要（`changed`, `createdNodeIds`, `affectedNodeIds`, `verification` 等）。从源头上消除单条工具执行结果对全量快照的重复持有。
2. **`web/src/services/user-data-sync.ts`**：
   在 `saveRemoteUserDataBatch` 调用 `upsertRemoteCanvasProject` 同步前，增加 `sanitizeCanvasProjectForRemoteSync` 辅助函数，防御性清洗消息历史详情中可能存在的历史快照遗留，确保发往后端的画布 Payload 始终保持在几十至上百 KB 范围内。

## 验证情况 (Verification)

- [x] 在数十轮工具调用后，画布工程体积稳定在 100KB 以内，杜绝 4MB 拦截。
- [x] 已通过本地生产 Docker 镜像构建（`open-ai-canvas-web:local`）验证，无类型错误，功能与交互完全正常。