### PR TITLE
修复皮肤主题下提示浮层文字对比度

### DIFF
--- a/backend/internal/service/appearance_test.go
+++ b/backend/internal/service/appearance_test.go
@@ -3,12 +3,14 @@ package service
 import (
 	"bytes"
 	"encoding/json"
+	"math"
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"net/textproto"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -46,6 +48,52 @@ func TestAppearanceDefaultsPreserveBuiltInBrand(t *testing.T) {
 	if len(adminAppearance.SkinThemes) != 4 || !adminAppearance.SkinThemes[0].Locked {
 		t.Fatalf("AdminAppearance() skin library = %#v", adminAppearance.SkinThemes)
 	}
+}
+
+func TestBuiltInAppearanceSkinTooltipPairsMeetContrast(t *testing.T) {
+	for _, skin := range defaultAppearanceSkinThemes() {
+		modes := []struct {
+			name   string
+			tokens AppearanceSkinModeTokens
+		}{
+			{name: "light", tokens: skin.Tokens.Light},
+			{name: "dark", tokens: skin.Tokens.Dark},
+		}
+		for _, mode := range modes {
+			ratio := appearanceColorContrastRatio(t, mode.tokens.Overlay, mode.tokens.Text)
+			if ratio < 4.5 {
+				t.Errorf("skin %s %s tooltip contrast = %.2f, want at least 4.5", skin.ID, mode.name, ratio)
+			}
+		}
+	}
+}
+
+func appearanceColorContrastRatio(t *testing.T, foreground, background string) float64 {
+	t.Helper()
+	contrastLuminance := func(color string) float64 {
+		if len(color) != 7 || color[0] != '#' {
+			t.Fatalf("unsupported test color %q", color)
+		}
+		channels := make([]float64, 3)
+		for index := range channels {
+			value, err := strconv.ParseUint(color[1+index*2:3+index*2], 16, 8)
+			if err != nil {
+				t.Fatalf("parse test color %q: %v", color, err)
+			}
+			srgb := float64(value) / 255
+			if srgb <= 0.04045 {
+				channels[index] = srgb / 12.92
+			} else {
+				channels[index] = math.Pow((srgb+0.055)/1.055, 2.4)
+			}
+		}
+		return 0.2126*channels[0] + 0.7152*channels[1] + 0.0722*channels[2]
+	}
+	foregroundLuminance := contrastLuminance(foreground)
+	backgroundLuminance := contrastLuminance(background)
+	lighter := math.Max(foregroundLuminance, backgroundLuminance)
+	darker := math.Min(foregroundLuminance, backgroundLuminance)
+	return (lighter + 0.05) / (darker + 0.05)
 }
 
 func TestAppearanceBackfillsVersionSixFieldsForExistingSetting(t *testing.T) {

--- a/web/src/styles/globals.css
+++ b/web/src/styles/globals.css
@@ -13015,6 +13015,18 @@ html:not(.dark) .creation-history-drawer-root {
     backdrop-filter: none !important;
 }
 
+/* Tooltip 必须使用同一套浮层背景/前景语义色。Ant Design 会让它继承
+   colorTextLightSolid（实心按钮文字色），深色主题下会形成深底深字。 */
+:where(.ant-tooltip) {
+    --ant-tooltip-arrow-background-color: var(--popover) !important;
+    --ant-tooltip-overlay-color: var(--popover-foreground) !important;
+}
+
+:where(.ant-tooltip-container, .ant-tooltip-inner) {
+    background: var(--popover) !important;
+    color: var(--popover-foreground) !important;
+}
+
 :where(.ant-select-item-option, .ant-dropdown-menu-item, .ant-dropdown-menu-submenu-title, .ant-cascader-menu-item, .ant-mentions-dropdown-menu-item) {
     min-height: 36px;
     margin-block: 2px;

--- a/web/test/site-appearance-and-skins.test.ts
+++ b/web/test/site-appearance-and-skins.test.ts
@@ -155,6 +155,10 @@ describe("site appearance and editable skin library", () => {
         expect(editorSource).toContain("后台菜单");
         expect(globalStyles).toContain("--control-switch-checked-bg: #16a34a");
         expect(globalStyles).toContain("--plugin-switch-checked-bg: var(--control-switch-checked-bg)");
+        expect(globalStyles).toContain("--ant-tooltip-arrow-background-color: var(--popover) !important");
+        expect(globalStyles).toContain("--ant-tooltip-overlay-color: var(--popover-foreground) !important");
+        expect(globalStyles).toContain(":where(.ant-tooltip-container, .ant-tooltip-inner)");
+        expect(globalStyles).toContain("color: var(--popover-foreground) !important");
         expect(adminStyles).toContain("--admin-status-warning: var(--palette-status-warning)");
         expect(adminStyles).toContain("border-radius: var(--menu-radius);");
     });


### PR DESCRIPTION
## 改动摘要

- 修复深色模式下提示浮层出现深底深字、文字难以辨认的问题
- 让 Ant Design Tooltip 的背景与文字统一使用皮肤语义变量 `--popover` 和 `--popover-foreground`
- 让提示浮层箭头与浮层背景保持同色
- 同时兼容 Ant Design 6 的 `.ant-tooltip-container` 与旧版 `.ant-tooltip-inner`
- 为默认、创作室、暖调、紫色四套预置皮肤的明暗模式增加对比度回归测试

## 原因

Tooltip 默认文字色来自 `colorTextLightSolid`。本项目将该变量用于实心主按钮前景色，在部分深色主题中会得到深色文字，而 Tooltip 背景同样为深色，导致文字几乎不可见。

## 风险与兼容性

- 不修改数据库、接口或业务数据
- 不改变已有皮肤字段，只复用现有语义色
- 同时覆盖新版和旧版 Tooltip 内部结构

## 验证

- `bun test test/site-appearance-and-skins.test.ts`：8 项通过、57 个断言、0 失败
- TypeScript `tsc --noEmit` 通过
- Vite 生产构建通过
- `go test ./internal/service -run TestBuiltInAppearanceSkinTooltipPairsMeetContrast -count=1` 通过
- 浏览器检查 4 套预置皮肤 × 明暗模式，共 8 种组合；文字、背景和箭头均随主题正确切换
- 每组提示文字与背景的对比度均达到 WCAG AA 4.5:1 下限

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义