### PR TITLE
fix: 修复请求明细轮询、开关动画与声明式任务幂等

### DIFF
--- a/backend/internal/repository/analytics.go
+++ b/backend/internal/repository/analytics.go
@@ -190,8 +190,8 @@ func (r *Repository) HasAPICallLogForTask(taskID string) (bool, error) {
 }
 
 func visibleAPICallLogQuery(query *gorm.DB) *gorm.DB {
-	// 视频轮询属于一次生成调用的内部阶段，管理端只展示聚合后的创建主记录。
-	return query.Where("NOT (api_call_logs.capability = ? AND api_call_logs.request_kind IN ?)", "video", []string{"poll", "download"})
+	// 轮询属于一次生成调用的内部状态查询，管理端不单独展示。
+	return query.Where("api_call_logs.request_kind <> ?", "poll")
 }
 
 func (r *Repository) VideoAPICallRoot(log model.ApiCallLog) (*model.ApiCallLog, error) {

--- a/backend/internal/repository/analytics_test.go
+++ b/backend/internal/repository/analytics_test.go
@@ -151,3 +151,39 @@ func TestQueryAPICallLogsSearchesFailureFields(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryAPICallLogsHidesInternalPollStages(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:api-log-visible-stages?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.ApiCallLog{}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	logs := []model.ApiCallLog{
+		{ID: "image-create", UserID: "user-1", Capability: "image", RequestKind: "create", CreatedAt: now},
+		{ID: "image-poll", UserID: "user-1", Capability: "image", RequestKind: "poll", CreatedAt: now.Add(time.Second)},
+		{ID: "image-download", UserID: "user-1", Capability: "image", RequestKind: "download", CreatedAt: now.Add(2 * time.Second)},
+		{ID: "video-create", UserID: "user-1", Capability: "video", RequestKind: "create", CreatedAt: now.Add(3 * time.Second)},
+		{ID: "video-poll", UserID: "user-1", Capability: "video", RequestKind: "poll", CreatedAt: now.Add(4 * time.Second)},
+	}
+	if err := db.Create(&logs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := New(db).QueryAPICallLogs(APICallLogFilter{
+		AnalyticsFilter: AnalyticsFilter{From: now.Add(-time.Hour), To: now.Add(time.Hour)},
+		Page:            1,
+		Limit:           20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(items) != 3 {
+		t.Fatalf("visible logs = total:%d items:%#v, want create and download logs without polls", total, items)
+	}
+	if items[0].ID != "video-create" || items[1].ID != "image-download" || items[2].ID != "image-create" {
+		t.Fatalf("visible logs = %#v, want video-create, image-download, image-create", items)
+	}
+}

--- a/backend/internal/service/protocol_runtime_test.go
+++ b/backend/internal/service/protocol_runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -341,6 +342,68 @@ func TestDeclarativeProtocolRuntimeExecutesCreatePollAndDownload(t *testing.T) {
 	}
 	if result["mode"] != "video" {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestDeclarativeProtocolRuntimeGeneratesPerCreateIdempotencyKey(t *testing.T) {
+	manifest := []byte(`{
+		"apiVersion":"yingce.plugin/v1",
+		"id":"test-idempotency-key-runtime","version":"1.0.0","name":"Test Idempotency Key","author":"Test","documentation":"# Test Idempotency Key",
+		"contributes":{"providers":[{"id":"test-idempotency-key-runtime","label":"Test Idempotency Key","capabilities":["video"],"scopes":["canvas"],"create":{"method":"POST","path":"/tasks","headers":{"Idempotency-Key":{"$ref":"request.extra.idempotencyKey"}},"body":{"model":{"$ref":"request.model"},"prompt":{"$ref":"request.prompt"}}},"poll":{"method":"GET","path":"/tasks/{{taskId}}"},"response":{"taskIdPaths":["id"],"statusPaths":["status"],"resultPaths":["video_url"],"resultKind":"video"}}]}
+	}`)
+	center, err := newPluginRuntime(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := center.install(testPluginPackage(t, manifest), "test-idempotency-key-runtime.yingce-plugin"); err != nil {
+		t.Fatal(err)
+	}
+
+	var keys []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/tasks":
+			key := r.Header.Get("Idempotency-Key")
+			if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(key) {
+				t.Errorf("Idempotency-Key = %q, want UUID", key)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			if _, ok := body["idempotencyKey"]; ok {
+				t.Error("host idempotency key leaked into provider JSON body")
+			}
+			keys = append(keys, key)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"task-1","status":"pending"}`))
+		case "/v1/tasks/task-1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"task-1","status":"succeeded","video_url":"` + server.URL + `/media.mp4"}`))
+		case "/media.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	config := providerConfig{BaseURL: server.URL + "/v1", APIKey: "key", Model: "test-model", APIFormat: "openai", InterfaceType: "test-idempotency-key-runtime", AllowLocalChannel: true}
+	ctx := withProviderOutboundPolicy(context.Background(), config)
+	ctx = withProtocolRegistry(ctx, center.registrySnapshot())
+	for i := 0; i < 2; i++ {
+		result, err := runDeclarativeProtocolTask(ctx, canvasGenerationInput{Mode: "video", Prompt: "a clip", Config: config})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result["mode"] != "video" {
+			t.Fatalf("result = %#v", result)
+		}
+	}
+	if len(keys) != 2 || keys[0] == keys[1] {
+		t.Fatalf("create idempotency keys = %#v, want two different UUIDs", keys)
 	}
 }
 

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -29,6 +29,7 @@ import (
 	"infinite-canvas/backend/internal/model"
 	"infinite-canvas/backend/internal/protocol"
 
+	"github.com/google/uuid"
 	"github.com/volcengine/volc-sdk-golang/base"
 	"gorm.io/gorm"
 )
@@ -2445,6 +2446,10 @@ func runProtocolAdapterTaskWithTiming(ctx context.Context, input canvasGeneratio
 	createdProviderTask := false
 	syncWindowStartedAt := time.Now()
 	if taskID == "" {
+		// The upstream create request may require an idempotency key. Keep it in
+		// the host-only request metadata so declarative plugins can map it to a
+		// header without exposing it in the provider JSON body.
+		request.Extra["idempotencyKey"] = uuid.NewString()
 		spec, err := adapter.BuildCreate(ctx, protocol.RequestContext{BaseURL: input.Config.BaseURL, Request: request})
 		if err != nil {
 			return nil, err

--- a/web/src/components/ui/base/switch/switch.tsx
+++ b/web/src/components/ui/base/switch/switch.tsx
@@ -115,7 +115,8 @@ export function Switch({ size = "md", checked: checkedProp, defaultChecked = fal
             ) : (
                 <span
                     aria-hidden="true"
-                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-[transform] duration-200 ease-out motion-reduce:transition-none", thumbClass)}
+                    data-state={checked ? "on" : "off"}
+                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-transform duration-200 ease-out motion-reduce:transition-none", thumbClass)}
                 />
             )}
         </button>

--- a/web/src/components/ui/base/switch/switch.tsx
+++ b/web/src/components/ui/base/switch/switch.tsx
@@ -115,7 +115,7 @@ export function Switch({ size = "md", checked: checkedProp, defaultChecked = fal
             ) : (
                 <span
                     aria-hidden="true"
-                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full bg-surface-strong border border-border/80 transition-transform duration-200 ease-out motion-reduce:transition-none", thumbClass)}
+                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-[transform] duration-200 ease-out motion-reduce:transition-none", thumbClass)}
                 />
             )}
         </button>

--- a/web/src/pages/admin/logs/logs-page.tsx
+++ b/web/src/pages/admin/logs/logs-page.tsx
@@ -127,7 +127,7 @@ export default function LogsPage() {
     return (
         <AdminPageFrame
             title="请求明细"
-            description="模型生成、状态查询与结果下载；仅计费调用扣除积分"
+            description="模型生成与结果下载记录；仅计费调用扣除积分"
             actions={
                 <AdminExportButton
                     exportFile={() => exportAdminApiLogs({ recordType, keyword: debouncedKeyword || undefined, status: status === "all" ? undefined : status })}


### PR DESCRIPTION
## 改动摘要

本次包含三个问题修复。

### 1. 隐藏请求明细中的轮询状态查询

请求明细不再展示任务轮询产生的状态查询记录，避免日志列表被内部轮询请求重复占用。

保留以下内容：

- 实际模型生成请求
- 模型返回结果
- 任务失败信息
- 其他用户真正发起的请求

只隐藏轮询状态查询的展示，不影响任务轮询、状态更新、失败处理和实际生成流程。

### 2. 修复图片生成节点透明背景开关没有滑动动画

修复图片生成节点中“透明背景”开关只能变色、滑块不移动的问题。

原因是：

- 位移样式使用了 `data-[state=on]:translate-x-*`
- 但 `data-state` 之前只设置在外层按钮上
- 滑块自身无法匹配开启状态，因此不会移动

本次修改：

- 将 `data-state="on|off"` 同步到滑块元素
- 使用 `transition-transform` 恢复左右滑动动画
- 保留原有透明背景配置和生成参数逻辑

### 3. 声明式协议任务创建时增加幂等 UUID

仅修改声明式协议任务的建单路径 `runProtocolAdapterTaskWithTiming`。

具体行为：

- 只有在没有恢复已有上游任务、确实需要新建任务时生成 UUID
- 轮询、下载和已有任务恢复路径不会重新生成 UUID
- UUID 只放在 `request.Extra`
- 只有插件 Manifest 明确引用 `request.extra.idempotencyKey` 时，才会映射为 HTTP Header
- 普通插件如果不读取该字段，请求行为保持不变
- UUID 不会进入提示词、JSON 请求体、API Key 或素材 URL
- 不执行插件代码，不访问本地文件，也不扩大插件权限
- 使用项目已有的 `github.com/google/uuid`

已有插件如果自己使用同名 `extra.idempotencyKey`，新建任务时会由宿主生成的 UUID 覆盖，以保证每次新任务的幂等键唯一。

## 风险与兼容性

- 请求明细只是过滤轮询日志展示，不改变实际轮询和任务状态处理。
- 开关只调整通用 Switch 组件的状态属性和视觉过渡，不改变业务配置。
- 幂等 UUID 只影响声明式协议的新建任务请求。
- 普通声明式插件不引用 `request.extra.idempotencyKey` 时，请求行为保持兼容。
- 不涉及数据库迁移、权限扩大、脚本执行、文件系统访问或 API Key 处理。
- 不涉及 OSS、COS、七牛云或 S3 配置。
- 不会把 UUID 作为凭据使用，也不能通过 UUID 反推出 API Key。

## 验证

- [x] 请求明细隐藏轮询状态查询。
- [x] 图片生成节点透明背景开关恢复左右滑动动画。
- [x] 声明式协议新建任务生成唯一 UUID。
- [x] 已有任务恢复、轮询和下载路径不会重新生成 UUID。
- [x] 只有 Manifest 明确引用 `request.extra.idempotencyKey` 时才发送 Header。
- [x] UUID 不进入 Provider JSON 请求体。
- [x] 插件包解析相关测试通过。
- [x] 未调用真实 Laogou 接口。
- [x] 未提交密钥、数据库、日志或本机配置。
- [x] 保留上游署名和许可证通知。
- [x] 已检查权限、资源归属和失败语义。