### PR TITLE
fix: 修复请求日志丢失、轮询日志显示和开关动画问题

### DIFF
--- a/backend/internal/repository/analytics.go
+++ b/backend/internal/repository/analytics.go
@@ -190,8 +190,8 @@ func (r *Repository) HasAPICallLogForTask(taskID string) (bool, error) {
 }
 
 func visibleAPICallLogQuery(query *gorm.DB) *gorm.DB {
-	// 视频轮询属于一次生成调用的内部阶段，管理端只展示聚合后的创建主记录。
-	return query.Where("NOT (api_call_logs.capability = ? AND api_call_logs.request_kind IN ?)", "video", []string{"poll", "download"})
+	// 轮询属于一次生成调用的内部状态查询，管理端不单独展示。
+	return query.Where("api_call_logs.request_kind <> ?", "poll")
 }
 
 func (r *Repository) VideoAPICallRoot(log model.ApiCallLog) (*model.ApiCallLog, error) {

--- a/backend/internal/repository/analytics_test.go
+++ b/backend/internal/repository/analytics_test.go
@@ -151,3 +151,39 @@ func TestQueryAPICallLogsSearchesFailureFields(t *testing.T) {
 		}
 	}
 }
+
+func TestQueryAPICallLogsHidesInternalPollStages(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:api-log-visible-stages?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.ApiCallLog{}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	logs := []model.ApiCallLog{
+		{ID: "image-create", UserID: "user-1", Capability: "image", RequestKind: "create", CreatedAt: now},
+		{ID: "image-poll", UserID: "user-1", Capability: "image", RequestKind: "poll", CreatedAt: now.Add(time.Second)},
+		{ID: "image-download", UserID: "user-1", Capability: "image", RequestKind: "download", CreatedAt: now.Add(2 * time.Second)},
+		{ID: "video-create", UserID: "user-1", Capability: "video", RequestKind: "create", CreatedAt: now.Add(3 * time.Second)},
+		{ID: "video-poll", UserID: "user-1", Capability: "video", RequestKind: "poll", CreatedAt: now.Add(4 * time.Second)},
+	}
+	if err := db.Create(&logs).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	items, total, err := New(db).QueryAPICallLogs(APICallLogFilter{
+		AnalyticsFilter: AnalyticsFilter{From: now.Add(-time.Hour), To: now.Add(time.Hour)},
+		Page:            1,
+		Limit:           20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 || len(items) != 3 {
+		t.Fatalf("visible logs = total:%d items:%#v, want create and download logs without polls", total, items)
+	}
+	if items[0].ID != "video-create" || items[1].ID != "image-download" || items[2].ID != "image-create" {
+		t.Fatalf("visible logs = %#v, want video-create, image-download, image-create", items)
+	}
+}

--- a/backend/internal/service/admin.go
+++ b/backend/internal/service/admin.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	stdlog "log"
 	"strings"
 	"time"
 
@@ -652,7 +653,9 @@ func (s *Service) LogAPICall(log model.ApiCallLog) error {
 	s.estimateCallCost(&log)
 	if log.BillingOrderID != "" && log.ProviderRequestID != "" {
 		if err := s.repo.UpdateBillingProviderRequestID(log.BillingOrderID, log.ProviderRequestID); err != nil {
-			return err
+			// 账单关联是请求日志的辅助状态，不能因为关联更新失败而丢失
+			// 已经发生的上游调用记录。后续由任务/账单对账流程补偿关联。
+			stdlog.Printf("provider billing request id update failed: billing_order_id=%s provider_request_id=%s error=%v", log.BillingOrderID, log.ProviderRequestID, err)
 		}
 	}
 	if log.TaskID != "" {
@@ -667,7 +670,9 @@ func (s *Service) LogAPICall(log model.ApiCallLog) error {
 			nextPollAt = &next
 		}
 		if err := s.repo.UpdateTaskProviderState(log.TaskID, log.ProviderRequestID, stage, nextPollAt); err != nil {
-			return err
+			// 请求日志本身仍需保留；任务状态可由后续任务收尾或恢复流程
+			// 重建，不能让一次状态写失败掩盖真实的上游调用。
+			stdlog.Printf("provider task state update failed: task_id=%s provider_request_id=%s error=%v", log.TaskID, log.ProviderRequestID, err)
 		}
 	}
 	if merged, err := s.mergeVideoAPICallLog(log); err != nil {

--- a/backend/internal/service/protocol_runtime_test.go
+++ b/backend/internal/service/protocol_runtime_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -341,6 +342,68 @@ func TestDeclarativeProtocolRuntimeExecutesCreatePollAndDownload(t *testing.T) {
 	}
 	if result["mode"] != "video" {
 		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestDeclarativeProtocolRuntimeGeneratesPerCreateIdempotencyKey(t *testing.T) {
+	manifest := []byte(`{
+		"apiVersion":"yingce.plugin/v1",
+		"id":"test-idempotency-key-runtime","version":"1.0.0","name":"Test Idempotency Key","author":"Test","documentation":"# Test Idempotency Key",
+		"contributes":{"providers":[{"id":"test-idempotency-key-runtime","label":"Test Idempotency Key","capabilities":["video"],"scopes":["canvas"],"create":{"method":"POST","path":"/tasks","headers":{"Idempotency-Key":{"$ref":"request.extra.idempotencyKey"}},"body":{"model":{"$ref":"request.model"},"prompt":{"$ref":"request.prompt"}}},"poll":{"method":"GET","path":"/tasks/{{taskId}}"},"response":{"taskIdPaths":["id"],"statusPaths":["status"],"resultPaths":["video_url"],"resultKind":"video"}}]}
+	}`)
+	center, err := newPluginRuntime(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := center.install(testPluginPackage(t, manifest), "test-idempotency-key-runtime.yingce-plugin"); err != nil {
+		t.Fatal(err)
+	}
+
+	var keys []string
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/tasks":
+			key := r.Header.Get("Idempotency-Key")
+			if !regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`).MatchString(key) {
+				t.Errorf("Idempotency-Key = %q, want UUID", key)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			if _, ok := body["idempotencyKey"]; ok {
+				t.Error("host idempotency key leaked into provider JSON body")
+			}
+			keys = append(keys, key)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"task-1","status":"pending"}`))
+		case "/v1/tasks/task-1":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"id":"task-1","status":"succeeded","video_url":"` + server.URL + `/media.mp4"}`))
+		case "/media.mp4":
+			w.Header().Set("Content-Type", "video/mp4")
+			_, _ = w.Write([]byte("video"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	config := providerConfig{BaseURL: server.URL + "/v1", APIKey: "key", Model: "test-model", APIFormat: "openai", InterfaceType: "test-idempotency-key-runtime", AllowLocalChannel: true}
+	ctx := withProviderOutboundPolicy(context.Background(), config)
+	ctx = withProtocolRegistry(ctx, center.registrySnapshot())
+	for i := 0; i < 2; i++ {
+		result, err := runDeclarativeProtocolTask(ctx, canvasGenerationInput{Mode: "video", Prompt: "a clip", Config: config})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result["mode"] != "video" {
+			t.Fatalf("result = %#v", result)
+		}
+	}
+	if len(keys) != 2 || keys[0] == keys[1] {
+		t.Fatalf("create idempotency keys = %#v, want two different UUIDs", keys)
 	}
 }
 

--- a/backend/internal/service/provider.go
+++ b/backend/internal/service/provider.go
@@ -29,6 +29,7 @@ import (
 	"infinite-canvas/backend/internal/model"
 	"infinite-canvas/backend/internal/protocol"
 
+	"github.com/google/uuid"
 	"github.com/volcengine/volc-sdk-golang/base"
 	"gorm.io/gorm"
 )
@@ -2445,6 +2446,10 @@ func runProtocolAdapterTaskWithTiming(ctx context.Context, input canvasGeneratio
 	createdProviderTask := false
 	syncWindowStartedAt := time.Now()
 	if taskID == "" {
+		// The upstream create request may require an idempotency key. Keep it in
+		// the host-only request metadata so declarative plugins can map it to a
+		// header without exposing it in the provider JSON body.
+		request.Extra["idempotencyKey"] = uuid.NewString()
 		spec, err := adapter.BuildCreate(ctx, protocol.RequestContext{BaseURL: input.Config.BaseURL, Request: request})
 		if err != nil {
 			return nil, err

--- a/web/src/components/ui/base/switch/switch.tsx
+++ b/web/src/components/ui/base/switch/switch.tsx
@@ -115,7 +115,8 @@ export function Switch({ size = "md", checked: checkedProp, defaultChecked = fal
             ) : (
                 <span
                     aria-hidden="true"
-                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-[transform] duration-200 ease-out motion-reduce:transition-none", thumbClass)}
+                    data-state={checked ? "on" : "off"}
+                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-transform duration-200 ease-out motion-reduce:transition-none", thumbClass)}
                 />
             )}
         </button>

--- a/web/src/components/ui/base/switch/switch.tsx
+++ b/web/src/components/ui/base/switch/switch.tsx
@@ -115,7 +115,7 @@ export function Switch({ size = "md", checked: checkedProp, defaultChecked = fal
             ) : (
                 <span
                     aria-hidden="true"
-                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full bg-surface-strong border border-border/80 transition-transform duration-200 ease-out motion-reduce:transition-none", thumbClass)}
+                    className={cn("sc-switch-thumb absolute left-0.5 top-1/2 -translate-y-1/2 rounded-full border border-border/80 bg-surface-strong transition-[transform] duration-200 ease-out motion-reduce:transition-none", thumbClass)}
                 />
             )}
         </button>

--- a/web/src/pages/admin/logs/logs-page.tsx
+++ b/web/src/pages/admin/logs/logs-page.tsx
@@ -127,7 +127,7 @@ export default function LogsPage() {
     return (
         <AdminPageFrame
             title="请求明细"
-            description="模型生成、状态查询与结果下载；仅计费调用扣除积分"
+            description="模型生成与结果下载记录；仅计费调用扣除积分"
             actions={
                 <AdminExportButton
                     exportFile={() => exportAdminApiLogs({ recordType, keyword: debouncedKeyword || undefined, status: status === "all" ? undefined : status })}


### PR DESCRIPTION
## 改动摘要

本次 PR 主要包含以下问题修复：

### 1. 隐藏请求明细中的轮询状态查询

任务执行过程中会产生多次状态轮询请求，之前这些内部请求也会显示在请求明细中，导致日志内容重复，不方便查看真正的生成请求。

本次调整后：

- 隐藏内部轮询产生的状态查询日志。
- 保留真实的模型生成请求。
- 保留任务结果和失败信息。
- 不影响任务轮询、状态更新和生成流程。

### 2. 修复透明背景开关没有左右滑动动画

图片生成节点中的“透明背景”开关之前只能改变颜色，滑块不会正常左右移动。

问题原因是滑块自身没有正确获取 `data-state` 状态，导致位移样式无法匹配。

本次修复：

- 将 `data-state="on|off"` 同步到开关滑块。
- 恢复滑块的 `translate-x` 状态切换。
- 使用 `transition-transform` 恢复左右滑动动画。
- 保留原有透明背景配置和生成参数逻辑。

### 3. 声明式协议任务创建时增加幂等 UUID

在声明式协议任务确实需要新建上游任务时，宿主会生成唯一 UUID，用于支持上游接口的幂等请求。

具体行为：

- 只有新建任务时才生成 UUID。
- 恢复已有上游任务时不会重新生成。
- 轮询和下载路径不会重新生成。
- UUID 只放在 `request.Extra` 中。
- 只有插件 Manifest 明确引用 `request.extra.idempotencyKey` 时，才会映射成 HTTP Header。
- 普通插件不读取该字段时，请求行为保持原样。
- UUID 不会进入提示词、JSON 请求体、API Key 或素材 URL。
- 不会执行插件代码、访问本地文件或扩大插件权限。
- 使用项目已有的 `github.com/google/uuid` 生成随机请求标识。

### 4. 修复请求日志因辅助状态更新失败而丢失

请求虽然已经成功发送到上游，但在保存请求日志前，如果账单关联或任务状态更新失败，之前会直接返回错误，导致 `ApiCallLog` 没有落库。

本次修复后：

- 账单关联更新失败时，不再丢弃请求日志。
- 上游任务状态更新失败时，不再丢弃请求日志。
- 辅助状态更新失败只写入服务端进程日志。
- 请求本身仍会继续保存到 `ApiCallLog`。
- 不改变上游请求、计费、轮询或视频下载行为。
- 错误日志不记录 API Key、完整敏感凭据或幂等 UUID。

## 风险与兼容性

- 请求明细只是隐藏内部轮询日志，不影响实际轮询和任务状态处理。
- 开关修复只涉及通用 `Switch` 组件的状态属性和视觉动画，不改变业务逻辑。
- 幂等 UUID 只应用于声明式协议的新建任务。
- 普通插件不引用 `request.extra.idempotencyKey` 时，请求行为保持兼容。
- 不新增脚本执行、命令执行、文件系统访问、数据库访问或插件权限。
- 不涉及数据库迁移。
- 不涉及 OSS、COS、七牛云或 S3 配置。
- 辅助状态更新失败时，相关任务状态可能需要后续对账或恢复流程补偿，但原始请求日志不会再丢失。
- 未改变上游请求格式、计费规则、轮询机制和结果下载流程。

## 验证

- [x] 请求明细不再显示任务轮询状态查询。
- [x] 实际生成请求和任务结果仍正常保留。
- [x] 图片生成节点“透明背景”开关可以正常切换。
- [x] 透明背景开关滑块恢复左右滑动动画。
- [x] 声明式协议新建任务会生成唯一 UUID。
- [x] 已有任务恢复、轮询和下载路径不会重新生成 UUID。
- [x] 只有插件 Manifest 明确引用时，UUID 才会发送为 HTTP Header。
- [x] UUID 不会进入 Provider JSON 请求体。
- [x] 账单关联更新失败时仍会保存请求日志。
- [x] 任务状态更新失败时仍会保存请求日志。
- [x] `git diff --check` 通过。
- [x] 未提交密钥、数据库、日志或本机配置。
- [x] 保留上游署名和许可证通知。
- [x] 已检查权限、资源归属和失败语义。