### PR TITLE
相机控制（虚拟摄影机）

### DIFF
--- a/web/src/components/canvas/canvas-image-settings-popover.tsx
+++ b/web/src/components/canvas/canvas-image-settings-popover.tsx
@@ -1,14 +1,11 @@
 import { useEffect, useRef, useState, type RefObject } from "react";
 import { createPortal } from "react-dom";
-import { Camera, Settings2 } from "lucide-react";
+import { Settings2 } from "lucide-react";
 import { Button } from "antd";
 
 import { ImageSettingsPanel, imageQualityLabel, imageSizeLabel } from "@/components/image-settings-panel";
-import { CanvasNodeCameraPanel } from "@/components/canvas/canvas-node-camera-dialog";
-import { AppModal } from "@/components/ui/product/app-modal/app-modal";
 import { canvasThemes } from "@/lib/canvas-theme";
 import { modelCapabilityConfigFor, normalizeImageValue } from "@/lib/model-capabilities";
-import type { CameraControlOptions } from "@/lib/canvas/camera-prompt-library";
 import { useThemeStore } from "@/stores/use-theme-store";
 import type { AiConfig } from "@/stores/use-config-store";
 
@@ -22,17 +19,14 @@ type CanvasImageSettingsPopoverProps = {
     placement?: "topLeft" | "top" | "topRight" | "bottomLeft" | "bottom" | "bottomRight";
     autoAdjustOverflow?: boolean;
     showCount?: boolean;
-    cameraControl?: CameraControlOptions;
-    onCameraControlChange?: (options: CameraControlOptions) => void;
 };
 
-export function CanvasImageSettingsPopover({ config, onConfigChange, onOpenChange, buttonClassName, placement = "topLeft", showCount = true, cameraControl, onCameraControlChange }: CanvasImageSettingsPopoverProps) {
+export function CanvasImageSettingsPopover({ config, onConfigChange, onOpenChange, buttonClassName, placement = "topLeft", showCount = true }: CanvasImageSettingsPopoverProps) {
     const theme = canvasThemes[useThemeStore((state) => state.theme)];
     const buttonRef = useRef<HTMLSpanElement>(null);
     const panelRef = useRef<HTMLDivElement>(null);
     const [open, setOpen] = useState(false);
     const [buttonRect, setButtonRect] = useState<DOMRect | null>(null);
-    const [cameraOpen, setCameraOpen] = useState(false);
     const profile = modelCapabilityConfigFor(config, config.model || config.imageModel).image!;
     const normalized = normalizeImageValue(profile, config);
     const summaryParts = [
@@ -73,48 +67,16 @@ export function CanvasImageSettingsPopover({ config, onConfigChange, onOpenChang
 
     const panel = open && buttonRect ? <ImageSettingsPortal buttonRect={buttonRect} panelRef={panelRef} placement={placement} theme={theme} config={config} showCount={showCount} onConfigChange={onConfigChange} /> : null;
 
-    if (!hasSettings && !onCameraControlChange) return null;
-
-    const cameraEnabled = cameraControl?.enabled === true;
+    if (!hasSettings) return null;
 
     return (
         <>
-            {onCameraControlChange && (
-                <Button
-                    size="small"
-                    type="text"
-                    className="canvas-camera-control-trigger !h-8 !rounded-full !px-2.5"
-                    style={{
-                        background: cameraEnabled ? theme.node.activeStroke : theme.node.fill,
-                        color: cameraEnabled ? theme.node.panel : theme.node.text,
-                    }}
-                    icon={<Camera className="size-3.5" />}
-                    aria-pressed={cameraEnabled}
-                    aria-label="摄像机控制"
-                    title={`摄像机控制${cameraEnabled ? " · 已启用" : ""}`}
-                    onClick={() => setCameraOpen(true)}
-                />
-            )}
-            {hasSettings && (
-                <span ref={buttonRef} className="inline-flex min-w-0">
-                    <Button size="small" type="text" className={`canvas-generation-settings-trigger ${buttonClassName || "!h-8 !max-w-[180px] !justify-start !rounded-full !px-2.5"}`} style={{ background: theme.node.fill, color: theme.node.text }} icon={<Settings2 className="size-3.5" />} aria-expanded={open} aria-label={`图像设置：${summary}`} title={`图像设置 · ${summary}`} onClick={() => updateOpen(!open)}>
-                        <span className="truncate">{summary}</span>
-                    </Button>
-                </span>
-            )}
+            <span ref={buttonRef} className="inline-flex min-w-0">
+                <Button size="small" type="text" className={`canvas-generation-settings-trigger ${buttonClassName || "!h-8 !max-w-[180px] !justify-start !rounded-full !px-2.5"}`} style={{ background: theme.node.fill, color: theme.node.text }} icon={<Settings2 className="size-3.5" />} aria-expanded={open} aria-label={`图像设置：${summary}`} title={`图像设置 · ${summary}`} onClick={() => updateOpen(!open)}>
+                    <span className="truncate">{summary}</span>
+                </Button>
+            </span>
             {panel}
-            {cameraOpen && onCameraControlChange && (
-                <AppModal title="摄像机控制" open centered footer={null} width={780} flush onCancel={() => setCameraOpen(false)}>
-                    <CanvasNodeCameraPanel
-                        cameraControl={cameraControl}
-                        onClose={() => setCameraOpen(false)}
-                        onConfirm={(options, _prompt) => {
-                            onCameraControlChange(options);
-                            setCameraOpen(false);
-                        }}
-                    />
-                </AppModal>
-            )}
         </>
     );
 }

--- a/web/src/components/canvas/canvas-image-toolbar-tools.tsx
+++ b/web/src/components/canvas/canvas-image-toolbar-tools.tsx
@@ -159,7 +159,7 @@ const imageToolDefinitions: ImageToolDefinition[] = [
         section: "视角",
         description: "调整光线方向、亮度与光效，生成新图片",
         icon: () => <Sun className="size-3.5" />,
-        group: "viewpoint",
+        group: "lighting",
         order: 30,
         run: (node, handlers) => handlers.onLighting(node),
     },

--- a/web/src/components/canvas/canvas-node-prompt-panel.tsx
+++ b/web/src/components/canvas/canvas-node-prompt-panel.tsx
@@ -1,7 +1,7 @@
 import { Button, Image as AntImage, InputNumber, Modal, Popover } from "antd";
 import { Tooltip } from "@/components/ui/base/tooltip";
 import { useEffect, useMemo, useRef, useState, type CSSProperties, type KeyboardEvent as ReactKeyboardEvent, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
-import { ArrowUp, AtSign, Boxes, ChevronDown, FileText, ImageIcon, ImagePlus, Link2, LoaderCircle, Maximize2, Music2, Pencil, SlidersHorizontal, UserRound, Video, WandSparkles, X } from "lucide-react";
+import { ArrowUp, AtSign, Boxes, Camera, ChevronDown, FileText, ImageIcon, ImagePlus, Link2, LoaderCircle, Maximize2, Music2, Pencil, SlidersHorizontal, UserRound, Video, WandSparkles, X } from "lucide-react";
 
 import { ModelPicker } from "@/components/model-picker";
 import { defaultConfig, modelOptionName, resolveModelChannel, useEffectiveConfig, type AiConfig } from "@/stores/use-config-store";
@@ -14,7 +14,10 @@ import { modelRequestOptions, resolveCompatibleModel, resolveModelGenerationDefa
 import { navigateToSettings } from "@/lib/settings-navigation";
 import { useThemeStore } from "@/stores/use-theme-store";
 import { useUserStore } from "@/stores/use-user-store";
+import { AppModal } from "@/components/ui/product/app-modal/app-modal";
+import type { CameraControlOptions } from "@/lib/canvas/camera-prompt-library";
 import { CanvasImageSettingsPopover } from "./canvas-image-settings-popover";
+import { CanvasNodeCameraPanel } from "./canvas-node-camera-dialog";
 import { CanvasAudioSettingsPopover, type CanvasAudioSettingKey } from "./canvas-audio-settings-popover";
 import { CanvasResourceMentionTextarea } from "./canvas-resource-mention-textarea";
 import { CanvasVideoSettingsPopover } from "./canvas-video-settings-popover";
@@ -392,16 +395,23 @@ export function CanvasNodePromptPanel({ node, isRunning, onPromptChange, onConfi
                             />
                         </Tooltip>
                     ) : mode === "image" ? (
-                        <CanvasImageSettingsPopover
-                            config={config}
-                            placement={expanded ? "topRight" : "topLeft"}
-                            buttonClassName="canvas-node-composer-settings-trigger [&>span]:min-w-0 [&_.lucide]:!size-3"
-                            onConfigChange={(key, value) => onConfigChange(node.id, key === "count" ? { count: Number(value) || 1 } : { [key]: value })}
-                            onMissingConfig={() => navigateToSettings({ continueCreation: true })}
-                            onOpenChange={expanded ? undefined : onImageSettingsOpenChange}
-                            cameraControl={node.metadata?.cameraControl}
-                            onCameraControlChange={(options) => onConfigChange(node.id, { cameraControl: options })}
-                        />
+                        // 图片模式下，显示相机配置与镜头配置
+                        <>
+                            <CameraToolsPopover
+                                cameraControl={node.metadata?.cameraControl}
+                                onCameraControlChange={(options) => onConfigChange(node.id, { cameraControl: options })}
+                                theme={theme}
+                                compact={!expanded}
+                            />
+                            <CanvasImageSettingsPopover
+                                config={config}
+                                placement={expanded ? "topRight" : "topLeft"}
+                                buttonClassName="canvas-node-composer-settings-trigger [&>span]:min-w-0 [&_.lucide]:!size-3"
+                                onConfigChange={(key, value) => onConfigChange(node.id, key === "count" ? { count: Number(value) || 1 } : { [key]: value })}
+                                onMissingConfig={() => navigateToSettings({ continueCreation: true })}
+                                onOpenChange={expanded ? undefined : onImageSettingsOpenChange}
+                            />
+                        </>
                     ) : mode === "video" ? (
                         <CanvasVideoSettingsPopover
                             config={config}
@@ -537,6 +547,42 @@ export function CanvasNodePromptPanel({ node, isRunning, onPromptChange, onConfi
     );
 }
 
+function CameraToolsPopover({ cameraControl, onCameraControlChange, theme, compact }: { cameraControl?: CameraControlOptions; onCameraControlChange: (options: CameraControlOptions) => void; theme: CanvasTheme; compact: boolean }) {
+    const [open, setOpen] = useState(false);
+    const cameraEnabled = cameraControl?.enabled === true;
+    return (
+        <>
+            <button
+                type="button"
+                className={`canvas-node-composer-camera-tools-trigger inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 text-[var(--fs-tiny)] transition-colors ${compact ? "is-compact h-7" : "h-8"}`}
+                style={{
+                    background: cameraEnabled ? `${theme.node.activeStroke}66` : theme.node.fill,
+                    color: cameraEnabled ? theme.node.panel : theme.node.text,
+                }}
+                aria-pressed={cameraEnabled}
+                aria-label="摄像机控制"
+                title={`摄像机控制${cameraEnabled ? " · 已启用" : ""}`}
+                onClick={() => setOpen(true)}
+            >
+                <Camera className="size-4.5" />
+                {!compact ? <span>摄像机</span> : null}
+            </button>
+            {open ? (
+                <AppModal title="摄像机控制" open centered footer={null} width={780} flush onCancel={() => setOpen(false)}>
+                    <CanvasNodeCameraPanel
+                        cameraControl={cameraControl}
+                        onClose={() => setOpen(false)}
+                        onConfirm={(options) => {
+                            onCameraControlChange(options);
+                            setOpen(false);
+                        }}
+                    />
+                </AppModal>
+            ) : null}
+        </>
+    );
+}
+
 function ReferenceToolsPopover({ canAutoMention, autoLinkEnabled, onAutoMention, onAutoLinkEnabledChange, accent, compact }: { canAutoMention: boolean; autoLinkEnabled: boolean; onAutoMention: () => void; onAutoLinkEnabledChange: (enabled: boolean) => void; accent: string; compact: boolean }) {
     return (
         <Popover
@@ -583,7 +629,7 @@ function ReferenceToolsPopover({ canAutoMention, autoLinkEnabled, onAutoMention,
                 aria-label="打开智能引用"
                 title="智能引用"
             >
-                <SlidersHorizontal className="size-3" />
+                <SlidersHorizontal className="size-4.5" />
                 {!compact ? <span>引用</span> : null}
             </button>
         </Popover>

--- a/web/src/components/canvas/canvas-node-toolbar.tsx
+++ b/web/src/components/canvas/canvas-node-toolbar.tsx
@@ -280,7 +280,8 @@ export function CanvasNodeToolbar({
     const primaryTools = narrow ? primary.slice(0, 1) : primary;
     const portraitTools = compact ? [] : inGroup("portrait");
     const viewpointTools = compact ? [] : inGroup("viewpoint");
-    const processTools = compact ? [...inGroup("portrait"), ...inGroup("viewpoint"), ...inGroup("process")] : inGroup("process");
+    const lightingTools = compact ? [] : inGroup("lighting");
+    const processTools = compact ? [...inGroup("portrait"), ...inGroup("viewpoint"), ...inGroup("lighting"), ...inGroup("process")] : inGroup("process");
     const workspaceTools = narrow ? [] : inGroup("workspace");
     const utilityTools = inGroup("utility");
     const moreTools = [...(narrow ? [...primary.slice(1), ...inGroup("workspace")] : []), ...inGroup("more")];
@@ -315,6 +316,7 @@ export function CanvasNodeToolbar({
                 {primaryTools.map((tool) => <NodeDockToolButton key={tool.id} tool={tool} />)}
                 {portraitTools.length ? <NodeDockMenuButton menuId="portrait" label="人像调整" icon={<UserRound className="size-3.5" />} tools={portraitTools} openMenuId={openMenuId} onOpenChange={handleMenuOpenChange} /> : null}
                 {viewpointTools.map((tool) => <NodeDockToolButton key={tool.id} tool={tool} />)}
+                {lightingTools.map((tool) => <NodeDockToolButton key={tool.id} tool={tool} />)}
                 {processTools.length ? <NodeDockMenuButton menuId="process" label={processMenuLabel} icon={isVideo ? <Images className="size-3.5" /> : <SlidersHorizontal className="size-3.5" />} tools={processTools} openMenuId={openMenuId} onOpenChange={handleMenuOpenChange} /> : null}
                 {workspaceTools.length ? <span aria-hidden className="aceternity-dock-separator mx-1 h-5 w-px shrink-0" /> : null}
                 {workspaceTools.map((tool) => <NodeDockToolButton key={tool.id} tool={tool} />)}

--- a/web/src/lib/canvas/tool-registry/tool-definition.ts
+++ b/web/src/lib/canvas/tool-registry/tool-definition.ts
@@ -7,7 +7,7 @@ import type { CanvasNodeData, CanvasNodeMetadata, CanvasNodeTypeId, CanvasToolMo
 
 /** 工具栏标识——每个工具栏有独立的注册表与偏好 */
 export type ToolbarId = "main" | "selection" | "node-hover" | "add-node-menu";
-export type NodeToolbarGroup = "primary" | "portrait" | "viewpoint" | "process" | "workspace" | "utility" | "more";
+export type NodeToolbarGroup = "primary" | "portrait" | "viewpoint" | "lighting" | "process" | "workspace" | "utility" | "more";
 
 /** 工具分类——用于分组渲染、危险隔离与 separator 自动插入 */
 export type ToolCategory =


### PR DESCRIPTION
改动摘要
为画布图片生成引入两项摄影级控制能力，均移植自 open-storyboard-canvas 并适配本项目主题 token 与生成链路：

相机控制（虚拟摄影机）

图片节点提示词面板新增「摄像机」胶囊按钮，点击打开摄像机控制面板
面板提供 8 种电影机机身（ARRI、RED、Sony、Panavision 等）、8 种镜头（含变形宽银幕、微距、老镜）、11 档焦距、10 档光圈的组合选择，每列卡片带 SVG 设备预览与悬停说明（设备特性 + 使用场景）
启用后生成时自动将「机身 + 镜头 + 焦距透视 + 光圈景深」提示词片段追加到用户提示词，并明确约束模型将其作为摄影指导而非画面内实体设备
配置持久化到 node.metadata.cameraControl，随节点保存；按钮启用态高亮反馈
打光优化

图片节点工具栏「视角」分组后新增独立「打光」工具（lighting 分组）
打光面板支持：可拖拽 3D 光球调整光源方位/俯仰（透视/正视两种视图，中心预览源图）、亮度滑杆、光色拾色器、轮廓光开关、6 个主光源快捷位置、智能模式自然语描述、8 种风格预设（过曝胶片、伦勃朗光、赛博朋克、黄金时刻等）
确认后以参考图编辑模式生成新图片节点（edit: "lighting" 元数据），沿用源节点模型配置与风格执行，提示词内建一致性约束防止改光时改变主体内容
附带重构

相机控制从图像设置弹窗中拆分为独立组件 CameraToolsPopover，位于提示词面板工具区
NodeToolbarGroup 类型新增 lighting 分组，打光工具从视角分组独立渲染
风险与兼容性
数据结构：CanvasNodeMetadata 新增可选字段 cameraControl，旧节点无此字段时相机控制默认关闭，不影响存量数据；无后端接口、无数据库迁移
生成成本：相机控制与打光均为提示词增强，不改变请求数量、尺寸或计费逻辑；打光生成走既有参考图编辑链路，费用与普通图片生成一致
静态资源：新增 web/public/lighting-presets/ 8 张预设参考图约 18MB，随 Vite 打包进 dist，镜像体积相应增加；无网络加载、无外部依赖
生成链路：use-canvas-generation-executor.ts 仅在 cameraControl.enabled 时追加提示词，打光走 use-canvas-media-tools.ts 既有 runBackendCanvasGenerationTask 流程，失败语义与错误态处理与现有一致
权限：只读分享页（shared.tsx）打光入口返回 unauthorized，与多角度工具同策略；相机控制在提示词面板内，只读态本身不可触达
提示词长度：相机提示词片段约 200 词元，极端长提示词场景可能触及模型长度上限，由既有 modelPromptLengthError 校验兜底
验证
 npx tsc --noEmit 通过（含新增 camera-prompt-library.ts、两个 dialog 组件、类型扩展、executor 与 media-tools 改动）
 新增 web/test/camera-prompt-library.test.ts 单测覆盖 buildCameraPrompt 输出
 两个面板均按 canvasThemes token 适配明暗主题，遵循 prefers-reduced-motion、aria-pressed/aria-label 无障碍约定
 未提交密钥、数据库、日志或本机配置（预设图为纯静态素材）
 保留上游署名和许可证通知（提示词库与面板结构移植自 open-storyboard-canvas，该仓库同为 MIT 且已在 .gitignore 中隔离，无代码直接复制引用其内部路径）
 已检查权限、资源归属和失败语义（只读分享拦截、生成失败走既有 errorDetails 展示）
 浏览器手工验证：面板交互（光球拖拽、卡片切换、预设选择）、生成结果一致性、明暗主题切换、窄屏 compact 模式分组折叠——待按 pending-test.mdx 清单执行
