### PR TITLE
fix(canvas): 画布同步水位与双向分歧冲突页 - 跨会话未同步修改不再被静默覆盖

### DIFF
--- a/web/src/components/canvas/canvas-sync-conflict-gate.tsx
+++ b/web/src/components/canvas/canvas-sync-conflict-gate.tsx
@@ -1,0 +1,62 @@
+import { Button, Popconfirm } from "antd";
+import { Link } from "react-router";
+import type { CanvasSyncConflictError } from "@/services/user-data-sync";
+import { useCanvasStore } from "@/stores/canvas/use-canvas-store";
+
+type CanvasSyncConflictGateProps = {
+    /** 加载失败的完整提示（冲突错误自带退路说明，普通错误原样展示）。 */
+    message: string;
+    /** 结构化冲突对象；为 null 表示普通加载失败（仅重试，无冲突分支）。 */
+    conflict: CanvasSyncConflictError | null;
+    /** 普通加载失败的重试。 */
+    onRetry: () => void;
+    /** 冲突态"加载云端版本"：调用方先放弃本地该画布再重跑加载。 */
+    onLoadRemote: () => void;
+    projectId: string;
+};
+
+/**
+ * 画布加载失败/同步冲突阻断页。
+ * 冲突态给用户两条真实退路：导出本地备份（完整 JSON 落盘）与确认后放弃本地加载云端；
+ * 不提供双向分歧下的"覆盖云端"——单用户多设备场景下一键覆盖必然丢另一端的修改。
+ */
+export function CanvasSyncConflictGate({ message, conflict, onRetry, onLoadRemote, projectId }: CanvasSyncConflictGateProps) {
+    const exportLocalCanvas = () => {
+        const local = useCanvasStore.getState().projects.find((candidate) => candidate.id === projectId);
+        if (!local) return;
+        const blob = new Blob([JSON.stringify(local, null, 2)], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const anchor = document.createElement("a");
+        anchor.href = url;
+        anchor.download = `canvas-conflict-${projectId}-${Date.now()}.json`;
+        anchor.click();
+        URL.revokeObjectURL(url);
+    };
+    return (
+        <main className="flex h-full flex-col items-center justify-center gap-4 px-6 text-center">
+            <p role="alert" className="max-w-[420px]">{message}</p>
+            {conflict ? (
+                <>
+                    <div className="flex items-center gap-3">
+                        <Button onClick={exportLocalCanvas}>导出本地备份</Button>
+                        <Popconfirm
+                            title="加载云端版本？"
+                            description="本地这份画布（含未同步的修改）将被放弃，云端版本会覆盖本地。可先导出备份。"
+                            okText="加载云端版本"
+                            cancelText="取消"
+                            onConfirm={onLoadRemote}
+                        >
+                            <Button danger>加载云端版本</Button>
+                        </Popconfirm>
+                    </div>
+                    <Link to="/canvas">返回画布库</Link>
+                </>
+            ) : (
+                <>
+                    <Button onClick={onRetry}>重新加载</Button>
+                    <Link to="/canvas">返回画布库</Link>
+                </>
+            )}
+        </main>
+    );
+}

--- a/web/src/pages/canvas/project.tsx
+++ b/web/src/pages/canvas/project.tsx
@@ -124,6 +124,7 @@ import { useCanvasKeyboard } from "./use-canvas-keyboard";
 import { useCanvasMediaTools } from "./use-canvas-media-tools";
 import { useCanvasNodeEditor } from "./use-canvas-node-editor";
 import { useCanvasNodeOperations } from "./use-canvas-node-operations";
+import { CanvasSyncConflictGate } from "@/components/canvas/canvas-sync-conflict-gate";
 import { useCanvasProjectLifecycle } from "./use-canvas-project-lifecycle";
 import { useCanvasRenderModel } from "./use-canvas-render-model";
 import { useCanvasSelectionController } from "./use-canvas-selection-controller";
@@ -425,7 +426,7 @@ function InfiniteCanvasPage() {
         [cleanupAssetImages, getHistoryCleanupContext],
     );
 
-    const { loadError, retryLoad, addedSkills, clearCanvasFiles, createAndOpenProject, currentProject, deleteCurrentProject, renameCurrentProject, saveCanvasProject, updateProject } = useCanvasProjectLifecycle({
+    const { loadError, loadConflict, loadRemoteAfterDiscard, retryLoad, addedSkills, clearCanvasFiles, createAndOpenProject, currentProject, deleteCurrentProject, renameCurrentProject, saveCanvasProject, updateProject } = useCanvasProjectLifecycle({
         projectId,
         projectLoaded,
         nodes,
@@ -2264,7 +2265,17 @@ function InfiniteCanvasPage() {
             onAddScript={() => createNode(CanvasNodeType.Script)}
         />
     ) : null;
-    if (!projectLoaded && loadError) return <main className="flex h-full flex-col items-center justify-center gap-4"><p role="alert">{loadError}</p><Button onClick={retryLoad}>重新加载</Button><Link to="/canvas">返回画布库</Link></main>;
+    if (!projectLoaded && loadError) {
+        return (
+            <CanvasSyncConflictGate
+                message={loadError}
+                conflict={loadConflict}
+                onRetry={retryLoad}
+                onLoadRemote={() => void loadRemoteAfterDiscard()}
+                projectId={projectId}
+            />
+        );
+    }
     if (!projectLoaded) return <CanvasRefreshShell />;
 
     return (

--- a/web/src/pages/canvas/use-canvas-project-lifecycle.ts
+++ b/web/src/pages/canvas/use-canvas-project-lifecycle.ts
@@ -8,7 +8,7 @@ import { removeCanvasDrawing } from "@/lib/canvas/canvas-drawing-storage";
 import { normalizeCanvasNodeTimestamps } from "@/lib/canvas/canvas-node-timestamps";
 import { hydrateAssistantImages, resetInterruptedGeneration } from "@/lib/canvas/canvas-project-generation";
 import { listAddedSkills, type Skill } from "@/services/api/skills";
-import { createCanvasProjectWithRemoteSync, deleteCanvasProjectsWithRemoteSync, loadCanvasProjectForEditing, localSavedRemotePendingMessage, saveRemoteUserDataNow } from "@/services/user-data-sync";
+import { CanvasSyncConflictError, createCanvasProjectWithRemoteSync, deleteCanvasProjectsWithRemoteSync, loadCanvasProjectForEditing, localSavedRemotePendingMessage, saveRemoteUserDataNow, discardLocalCanvasProject } from "@/services/user-data-sync";
 import { flushCanvasStorePersistence, useCanvasStore, type CanvasProject } from "@/stores/canvas/use-canvas-store";
 import { useThemeStore } from "@/stores/use-theme-store";
 import { useUserStore } from "@/stores/use-user-store";
@@ -82,6 +82,7 @@ export function useCanvasProjectLifecycle({
     const currentProject = useCanvasStore((state) => state.projects.find((project) => project.id === projectId));
     const [addedSkills, setAddedSkills] = useState<Skill[]>([]);
     const [loadError, setLoadError] = useState("");
+    const [loadConflict, setLoadConflict] = useState<CanvasSyncConflictError | null>(null);
     const [loadAttempt, setLoadAttempt] = useState(0);
     const viewportSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -90,6 +91,7 @@ export function useCanvasProjectLifecycle({
         let cancelled = false;
         setProjectLoaded(false);
         setLoadError("");
+        setLoadConflict(null);
         const applyRestoredProject = (targetProject: CanvasProject) => {
             if (cancelled) return;
             const fallbackTheme = useThemeStore.getState().theme;
@@ -150,7 +152,13 @@ export function useCanvasProjectLifecycle({
                 });
         };
         void load().catch((error) => {
-            if (!cancelled) setLoadError(error instanceof Error ? error.message : "读取画布失败，请重试");
+            if (!cancelled) return;
+            if (error instanceof CanvasSyncConflictError) {
+                setLoadConflict(error);
+                setLoadError(error.message);
+                return;
+            }
+            setLoadError(error instanceof Error ? error.message : "读取画布失败，请重试");
         });
         return () => {
             cancelled = true;
@@ -256,6 +264,13 @@ export function useCanvasProjectLifecycle({
 
     return {
         loadError,
+        loadConflict,
+        loadRemoteAfterDiscard: async () => {
+            // 冲突页"加载云端版本": 先放弃本地该画布(基线/水位一并清), 再重跑加载 — 纯远端采纳, 不会再次冲突。
+            await discardLocalCanvasProject(projectId);
+            setLoadConflict(null);
+            setLoadAttempt((attempt) => attempt + 1);
+        },
         retryLoad: () => setLoadAttempt((attempt) => attempt + 1),
         addedSkills,
         clearCanvasFiles,

--- a/web/src/services/user-data-sync.ts
+++ b/web/src/services/user-data-sync.ts
@@ -14,6 +14,59 @@ import { useCanvasHistoryStore } from "@/stores/canvas/use-canvas-history-store"
 import { repairMissingCanvasAssets } from "@/services/canvas-asset-repair";
 import { canvasNodeToAsset } from "@/lib/canvas/canvas-node-asset";
 
+// 同步水位: "最后一次确认与远端一致"的 updatedAt(按用户持久化到 localStorage)。
+// 会话内基线(acknowledged*)随进程消失, 重启后会把上一会话未同步成功的本地修改误认作"已同步基线"。
+// 水位跨会话存活, 是唯一可靠的"本地是否落后于上次确认同步点"判据。
+// 服务端 upsert 原样存储客户端 updatedAt(backend/internal/service/user_data.go parseClientTime),
+// 因此"同步成功"必然使两侧 updatedAt 相同, 水位对比无时钟歧义。
+let watermarkProjects = new Map<string, string>();
+let watermarkAssets = new Map<string, string>();
+
+function watermarkStorageKey(userId: string) {
+    return `canvas-user-data-sync-watermark:${userId}`;
+}
+
+function loadWatermarks(userId: string) {
+    watermarkProjects = new Map();
+    watermarkAssets = new Map();
+    try {
+        const raw = localStorage.getItem(watermarkStorageKey(userId));
+        if (!raw) return;
+        const parsed = JSON.parse(raw) as { p?: Record<string, string>; a?: Record<string, string> };
+        watermarkProjects = new Map(Object.entries(parsed.p ?? {}));
+        watermarkAssets = new Map(Object.entries(parsed.a ?? {}));
+    } catch {
+        // 水位缺失时退回旧行为: 无法识别跨会话未同步修改(不再比旧实现更差), 下次同步成功即重建水位。
+    }
+}
+
+function persistWatermarks() {
+    if (!activeRemoteUserId) return;
+    try {
+        localStorage.setItem(watermarkStorageKey(activeRemoteUserId), JSON.stringify({
+            p: Object.fromEntries(watermarkProjects),
+            a: Object.fromEntries(watermarkAssets),
+        }));
+    } catch {
+        // localStorage 配额满等场景忽略: 水位落后只导致保守冲突(fail-closed), 不会静默覆盖。
+    }
+}
+
+export type CanvasSyncConflictKind = "diverged";
+
+/** 画布本地与远端双向分歧(两版都有对方没有的修改)。阻断打开, 由用户选择导出备份或放弃本地。 */
+export class CanvasSyncConflictError extends Error {
+    readonly kind: CanvasSyncConflictKind;
+    readonly projectId: string;
+
+    constructor(projectId: string, kind: CanvasSyncConflictKind) {
+        super("画布在本地和云端都有修改。可先导出本地备份，再选择加载云端版本（将放弃本地版本）。");
+        this.name = "CanvasSyncConflictError";
+        this.kind = kind;
+        this.projectId = projectId;
+    }
+}
+
 let activeRemoteUserId = "";
 type RemoteUserDataPhase = "inactive" | "hydrating" | "ready" | "failed";
 
@@ -36,6 +89,7 @@ export async function initializeRemoteUserDataSession(userId: string) {
         resetRemoteUserDataSync();
         activeRemoteUserId = userId;
         incrementalSession = true;
+        loadWatermarks(userId);
         acknowledgedProjects = new Map(useCanvasStore.getState().projects.map((project) => [project.id, project]));
         acknowledgedAssets = new Map(useAssetStore.getState().assets.map((asset) => [asset.id, asset]));
         remoteUserDataPhase = "ready";
@@ -53,16 +107,27 @@ export async function loadCanvasProjectForEditing(id: string) {
         const { project } = await getRemoteCanvasProject(id);
         await loadReferencedAssets(collectAssetIds(project));
         const current = useCanvasStore.getState().projects.find((candidate) => candidate.id === id);
-        if (current && !sameEntitySnapshot(acknowledgedProjects.get(id), current)) {
-            // 当前页面已经开始编辑本地缓存时，远端详情只建立新的冲突基线；
-            // 保留当前画布内容，后续保存由当前打开的画布显式覆盖远端版本，
-            // 避免旧缓存被永久卡在“自动重试但永远冲突”的状态。
+        // 本地未同步内容 = 会话内编辑(store≠基线) 或 上一会话未同步完(store 领先于水位)。
+        const watermark = watermarkProjects.get(id);
+        const locallyDirty = current !== undefined && (!sameEntitySnapshot(acknowledgedProjects.get(id), current)
+            || (watermark !== undefined && Date.parse(current.updatedAt) !== Date.parse(watermark)));
+        if (current && locallyDirty) {
+            if (watermark !== undefined && Date.parse(project.updatedAt) !== Date.parse(watermark)) {
+                // 远端同样领先于上次确认同步点: 双向分歧, 保留本地继续保存会覆盖另一端的修改,
+                // 升级为结构化冲突交由用户选择(冲突页: 导出备份 / 放弃本地加载云端)。
+                throw new CanvasSyncConflictError(id, "diverged");
+            }
+            // 纯本地领先(远端仍停在水位): 保留当前画布内容，远端详情只建立新的冲突基线；
+            // 基线与 store 的差异由防抖同步补推，避免旧缓存被永久卡在“自动重试但永远冲突”的状态。
             acknowledgedProjects.set(id, project);
             verifiedProjects.add(id);
             return current;
         }
         acknowledgedProjects.set(id, project);
         verifiedProjects.add(id);
+        // 采纳远端后本地与远端一致, 水位推进到该同步点。
+        watermarkProjects.set(id, project.updatedAt);
+        persistWatermarks();
         useCanvasStore.setState((state) => ({ projects: [...state.projects.filter((candidate) => candidate.id !== id), project] }));
         return project;
     });
@@ -72,6 +137,18 @@ export async function loadCanvasProjectForEditing(id: string) {
     };
     void request.then(clearPending, clearPending);
     return request;
+}
+
+/** 冲突页"加载云端版本": 放弃本地该画布(从 store 移除), 下一次 load 即走纯远端采纳。不触碰其它画布与持久媒体。 */
+export async function discardLocalCanvasProject(id: string) {
+    await withRemoteUserDataSyncExclusive(async () => {
+        acknowledgedProjects.delete(id);
+        watermarkProjects.delete(id);
+        verifiedProjects.delete(id);
+        useCanvasStore.setState((state) => ({ projects: state.projects.filter((candidate) => candidate.id !== id) }));
+        await flushCanvasStorePersistence();
+        persistWatermarks();
+    });
 }
 
 async function waitForRemoteProjectLoads() {
@@ -488,6 +565,9 @@ async function saveRemoteUserDataBatch(uploaded: Map<string, string>) {
             }
             await upsertRemoteCanvasProject(sanitizeCanvasProjectForRemoteSync(remotePayload));
             acknowledgedProjects.set(source.id, source);
+            // 同步成功: 服务端原样存储客户端 updatedAt, 水位即推进到本次提交点。
+            watermarkProjects.set(source.id, source.updatedAt);
+            persistWatermarks();
             verifiedProjects.add(source.id);
             if (total > 0) useSyncProgressStore.getState().setProjectProgress(source.id, null);
         } catch (error) {

--- a/web/test/canvas-sync-conflict.test.ts
+++ b/web/test/canvas-sync-conflict.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { CanvasSyncConflictError } from "@/services/user-data-sync";
+
+describe("画布同步冲突错误", () => {
+    test("携带冲突方向与画布 id, 消息说明退路", () => {
+        const error = new CanvasSyncConflictError("proj-1", "diverged");
+        expect(error.name).toBe("CanvasSyncConflictError");
+        expect(error.kind).toBe("diverged");
+        expect(error.projectId).toBe("proj-1");
+        expect(error.message).toContain("导出本地备份");
+        expect(error.message).toContain("加载云端版本");
+    });
+
+    test("instanceof 判定成立, 普通错误不误判", () => {
+        expect(new CanvasSyncConflictError("p", "diverged") instanceof CanvasSyncConflictError).toBe(true);
+        expect(new Error("画布已在其他端修改") instanceof CanvasSyncConflictError).toBe(false);
+    });
+});


### PR DESCRIPTION
## 问题

`loadCanvasProjectForEditing` 的冲突基线是会话内的 `acknowledgedProjects`（进程内存），重启后消失。上一会话未同步成功的本地修改在重启后会被误认作已同步基线，打开画布时被远端版本静默覆盖。

ab588925 已解决了旧缓存永久卡在冲突循环的问题（保留本地 + 重建基线，👍），但在**双向分歧**（本地有上会话未同步修改、远端也被另一端改过）场景下，后续保存会以远端为新基线静默提交本地快照——另一台设备的修改无提示丢失，且用户无从得知发生过覆盖。

## 方案

引入**同步水位**：按用户持久化到 localStorage 的 `{projectId: updatedAt}`，记录最后一次确认与远端一致的同步点。服务端 `parseClientTime` 原样存储客户端 `updatedAt`，因此同步成功必然使两侧 `updatedAt` 相同，水位对比无时钟歧义。

水位只做**最小介入**，完整保留 ab588925 的结构（防重入 promise、waitForRemoteProjectLoads、基线重建）与行为：

| 场景 | 行为 |
|---|---|
| 本地领先、远端仍停在水位（单向） | 沿用上游：保留本地 + 重建基线 + 防抖补推 |
| 本地、远端都领先于水位（**双向分歧**） | 抛结构化 `CanvasSyncConflictError` → 冲突页 |
| 本地无未同步内容 | 采纳远端 + 水位推进（新增 2 行记录） |

冲突页给两条真实退路：**导出本地备份**（完整 JSON 落盘）与**确认后加载云端版本**（放弃本地，`discardLocalCanvasProject` 精确清理该画布的基线/水位）。不提供覆盖云端——单用户多设备下一键覆盖必然丢另一端，副本合并留待后续。

保存成功后的 ack 循环同步推进水位（2 行）。保存路径的显式覆盖策略不动。

## 测试

- `web/test/canvas-sync-conflict.test.ts`：冲突错误携带 kind/projectId 与退路文案、instanceof 判别
- `bun run build` 通过（tsc 0 错误）
- 真机验证：制造双向分歧 → 冲突页渲染 → 导出/加载云端均可用，加载后画布正常打开无循环