### PR TITLE
fix(auth): 修复刷新误退出及远程同步会话未初始化

### DIFF
--- a/backend/internal/app/model_catalog.go
+++ b/backend/internal/app/model_catalog.go
@@ -22,9 +22,9 @@ const (
 // ModelCatalogResponse 是创作端模型选择的统一读模型。
 // Source=frontend 时读取 Models；Source=system 时读取 Channels。
 type ModelCatalogResponse struct {
-	Source   ModelCatalogSource     `json:"source"`
-	Models   []PublicLogicalModel   `json:"models,omitempty"`
-	Channels []PublicChannelCatalog `json:"channels,omitempty"`
+	Source   ModelCatalogSource      `json:"source"`
+	Models   *[]PublicLogicalModel   `json:"models,omitempty"`
+	Channels *[]PublicChannelCatalog `json:"channels,omitempty"`
 }
 
 // PublicChannelCatalog 公开的渠道目录信息（脱敏）
@@ -81,7 +81,7 @@ func (s *Service) ModelCatalog(intent *ModelRequestIntent) (*ModelCatalogRespons
 		}
 		return &ModelCatalogResponse{
 			Source: ModelCatalogSourceFrontend,
-			Models: models,
+			Models: &models,
 		}, nil
 	}
 
@@ -91,7 +91,7 @@ func (s *Service) ModelCatalog(intent *ModelRequestIntent) (*ModelCatalogRespons
 	}
 	return &ModelCatalogResponse{
 		Source:   ModelCatalogSourceSystem,
-		Channels: channels,
+		Channels: &channels,
 	}, nil
 }
 

--- a/backend/internal/app/model_catalog_response_test.go
+++ b/backend/internal/app/model_catalog_response_test.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestModelCatalogResponseKeepsActiveEmptyCollection(t *testing.T) {
+	channels := []PublicChannelCatalog{}
+	payload, err := json.Marshal(ModelCatalogResponse{Source: ModelCatalogSourceSystem, Channels: &channels})
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+	body := string(payload)
+	if !strings.Contains(body, `"channels":[]`) {
+		t.Fatalf("active empty channel collection was omitted: %s", body)
+	}
+	if strings.Contains(body, `"models"`) {
+		t.Fatalf("inactive model collection must stay omitted: %s", body)
+	}
+}

--- a/web/src/components/auth/auth-session-hydrator.tsx
+++ b/web/src/components/auth/auth-session-hydrator.tsx
@@ -11,8 +11,17 @@ export function AuthSessionHydrator({ children }: { children: ReactNode }) {
 
     useEffect(() => {
         let cancelled = false;
-        getAuthSession()
-            .then(async (payload) => {
+        const hydrate = async () => {
+            let payload: AuthSessionPayload;
+            try {
+                payload = await getAuthSession();
+            } catch (error) {
+                // 只有认证接口本身没有返回有效身份时才进入匿名态；工作区初始化失败不能冒充“登录失效”。
+                console.warn("恢复登录会话失败", error);
+                if (!cancelled) applyAnonymousSession({ user: null, logicalModels: [] });
+                return;
+            }
+            try {
                 if (cancelled) return;
                 if (!payload.user) {
                     applyAnonymousSession(payload);
@@ -23,10 +32,20 @@ export function AuthSessionHydrator({ children }: { children: ReactNode }) {
                 if (cancelled) return;
                 await applyUserSession(payload);
                 preloadWorkspaceRoute(window.location.pathname);
-            })
-            .catch(() => {
-                if (!cancelled) applyAnonymousSession({ user: null, logicalModels: [] });
-            });
+            } catch (error) {
+                if (cancelled) return;
+                // /auth/session 已确认身份时，后续本地缓存或工作区初始化错误不得清空用户。
+                // applyUserSession 会在 finally 中结束 loading；这里保留身份并留下可诊断日志。
+                const store = useUserStore.getState();
+                store.setUser(payload.user);
+                store.setRuntimeLimits(payload.runtimeLimits);
+                store.setDrawingEngine(payload.drawingEngine);
+                store.setFeatures(payload.features);
+                store.setHydrated(true);
+                console.error("登录身份已恢复，但工作区初始化失败", error);
+            }
+        };
+        void hydrate();
         return () => {
             cancelled = true;
         };

--- a/web/src/lib/user-session.ts
+++ b/web/src/lib/user-session.ts
@@ -32,21 +32,33 @@ export async function applyUserSession(payload: AuthSessionPayload) {
     try {
         // Query key 不携带用户 ID；身份变化时必须取消并清空旧账号请求，避免跨账号复用内存数据。
         if (previousUserId !== nextUserId) appQueryClient.clear();
-        await switchUserStorageScope(payload.user?.id);
-        const [persistedCanvas, persistedCanvasHistory, persistedAssets, persistedPlugins] = await Promise.all([
+        try {
+            await switchUserStorageScope(payload.user?.id);
+        } catch (error) {
+            if (previousUserId || !nextUserId) throw error;
+            // 冷启动时 IndexedDB 本身可能不可用，此时旧 scope 没有运行中的用户写入可等待。
+            // 仍需切断旧远端会话并激活服务端已确认的用户 scope，避免把缓存故障伪装成退出登录。
+            console.warn("保存启动阶段的本地缓存失败，已直接切换到当前登录账号", error);
+            await activateInitialUserStorageScope(nextUserId);
+        }
+        const persistedStoreResults = await Promise.allSettled([
             localForageStorage.getItem(CANVAS_STORE_KEY),
             localForageStorage.getItem(CANVAS_HISTORY_STORE_KEY),
             localForageStorage.getItem(ASSET_STORE_KEY),
             localForageStorage.getItem(PLUGIN_STORE_KEY),
         ]);
-        const persistedConfig = scopedLocalStorage.getItem(CONFIG_STORE_KEY);
-        const persistedCreationPreferences = scopedLocalStorage.getItem(CREATION_PREFERENCES_STORE_KEY);
+        const [persistedCanvas, persistedCanvasHistory, persistedAssets, persistedPlugins] = persistedStoreResults.map((result) => (result.status === "fulfilled" ? result.value : null));
+        persistedStoreResults.forEach((result, index) => {
+            if (result.status === "rejected") console.warn(`读取用户本地缓存失败，已忽略：${[CANVAS_STORE_KEY, CANVAS_HISTORY_STORE_KEY, ASSET_STORE_KEY, PLUGIN_STORE_KEY][index]}`, result.reason);
+        });
+        const persistedConfig = readScopedLocalStorageSafely(CONFIG_STORE_KEY);
+        const persistedCreationPreferences = readScopedLocalStorageSafely(CREATION_PREFERENCES_STORE_KEY);
         usePluginStore.setState({ hydrated: false, runtimeStatuses: {}, pluginStates: {} });
         useUserStore.getState().setUser(payload.user);
         useUserStore.getState().setRuntimeLimits(payload.runtimeLimits);
         useUserStore.getState().setDrawingEngine(payload.drawingEngine);
         useUserStore.getState().setFeatures(payload.features);
-        await Promise.all([
+        const rehydrateResults = await Promise.allSettled([
             useCanvasStore.persist.rehydrate(),
             useCanvasHistoryStore.persist.rehydrate(),
             useAssetStore.persist.rehydrate(),
@@ -54,34 +66,61 @@ export async function applyUserSession(payload: AuthSessionPayload) {
             usePluginStore.persist.rehydrate(),
             useCreationPreferencesStore.persist.rehydrate(),
         ]);
+        rehydrateResults.forEach((result, index) => {
+            if (result.status === "rejected")
+                console.warn(`恢复用户本地缓存失败，已使用安全默认值：${[CANVAS_STORE_KEY, CANVAS_HISTORY_STORE_KEY, ASSET_STORE_KEY, CONFIG_STORE_KEY, PLUGIN_STORE_KEY, CREATION_PREFERENCES_STORE_KEY][index]}`, result.reason);
+        });
         // Zustand 在目标 scope 没有快照时会保留旧内存，必须显式恢复该 scope 的空状态。
-        if (!persistedCanvas) useCanvasStore.setState({ projects: [] });
-        if (!persistedCanvasHistory) useCanvasHistoryStore.setState({ deletedProjects: [] });
-        if (!persistedAssets) useAssetStore.setState({ assets: [] });
-        if (!persistedPlugins) usePluginStore.setState({ installations: [], runtimeStatuses: {}, pluginStates: {} });
-        if (!persistedCreationPreferences) useCreationPreferencesStore.setState({ preferences: {} });
-        if (!persistedConfig) {
+        if (!persistedCanvas || rehydrateResults[0].status === "rejected") useCanvasStore.setState({ projects: [] });
+        if (!persistedCanvasHistory || rehydrateResults[1].status === "rejected") useCanvasHistoryStore.setState({ deletedProjects: [] });
+        if (!persistedAssets || rehydrateResults[2].status === "rejected") useAssetStore.setState({ assets: [] });
+        if (!persistedPlugins || rehydrateResults[4].status === "rejected") usePluginStore.setState({ installations: [], runtimeStatuses: {}, pluginStates: {} });
+        if (!persistedCreationPreferences || rehydrateResults[5].status === "rejected") useCreationPreferencesStore.setState({ preferences: {} });
+
+        // 用户身份和远端同步会话必须先于模型目录等可降级初始化就绪。
+        // 否则后续任一浏览器缓存或目录错误都会让页面看似已登录，却留下空 userId 的半初始化状态。
+        installRemoteUserDataAutoSync();
+        if (payload.user?.id) await initializeRemoteUserDataSession(payload.user.id);
+        else resetRemoteUserDataSync();
+
+        if (!persistedConfig || rehydrateResults[3].status === "rejected") {
             // 只有首次配置缺失时才生成能力推荐；已有配置中的空数组代表用户明确清空。
-            const catalog = await getModelCatalog();
             const initialSystemConfig = {
                 ...defaultConfig,
-                channels: modelCatalogChannels(catalog),
                 imageModels: undefined,
                 videoModels: undefined,
                 textModels: undefined,
                 audioModels: undefined,
             };
             useConfigStore.getState().replaceConfig(normalizeConfigSnapshot({ config: initialSystemConfig }).config);
-        } else {
+        }
+        try {
             const catalog = await getModelCatalog();
             useConfigStore.getState().mergeSystemChannels(modelCatalogChannels(catalog));
+        } catch (error) {
+            // 模型目录失败只影响当前目录刷新，不能撤销已经由 /auth/session 确认的登录身份和同步会话。
+            console.warn("模型目录初始化失败，已保留当前用户配置", error);
         }
-        installRemoteUserDataAutoSync();
-        if (payload.user?.id) {
-            await initializeRemoteUserDataSession(payload.user.id);
-        } else resetRemoteUserDataSync();
     } finally {
         useUserStore.getState().setHydrated(true);
+    }
+}
+
+async function activateInitialUserStorageScope(userId: string) {
+    await withGenerationConsumersPaused(async () => {
+        await withRemoteUserDataSyncExclusive(async () => {
+            resetRemoteUserDataSync();
+            setActiveUserScope(userId);
+        });
+    });
+}
+
+function readScopedLocalStorageSafely(key: string) {
+    try {
+        return scopedLocalStorage.getItem(key);
+    } catch (error) {
+        console.warn(`读取用户本地缓存失败，已忽略：${key}`, error);
+        return null;
     }
 }
 

--- a/web/test/user-scoped-generation-persistence.test.ts
+++ b/web/test/user-scoped-generation-persistence.test.ts
@@ -14,7 +14,19 @@ import { ASSET_STORE_KEY, flushAssetStorePersistence, useAssetStore, type Asset,
 import { withGenerationAssetStorageLock } from "../src/services/generation-asset-repository";
 import { CANVAS_STORE_KEY, flushCanvasStorePersistence, useCanvasStore, withCanvasStorePersistenceLock, withCanvasStorePersistenceSuppressed, type CanvasProject } from "../src/stores/canvas/use-canvas-store";
 import { CanvasNodeType, type CanvasAssistantSession, type CanvasConnection, type CanvasNodeData } from "../src/types/canvas";
-import { deleteAssetWithRemoteSync, deleteCanvasProjectsWithRemoteSync, initializeRemoteUserDataSession, loadCanvasProjectForEditing, loadAssetLibraryPage, installRemoteUserDataAutoSync, resetRemoteUserDataSync, saveRemoteUserDataNow, syncRemoteUserData, withRemoteUserDataSyncExclusive } from "../src/services/user-data-sync";
+import {
+    deleteAssetWithRemoteSync,
+    deleteCanvasProjectsWithRemoteSync,
+    hasRemoteUserDataSyncSession,
+    initializeRemoteUserDataSession,
+    loadCanvasProjectForEditing,
+    loadAssetLibraryPage,
+    installRemoteUserDataAutoSync,
+    resetRemoteUserDataSync,
+    saveRemoteUserDataNow,
+    syncRemoteUserData,
+    withRemoteUserDataSyncExclusive,
+} from "../src/services/user-data-sync";
 import { apiClient } from "../src/services/api/request";
 import { useUserStore } from "../src/stores/use-user-store";
 import { CANVAS_HISTORY_STORE_KEY, useCanvasHistoryStore } from "../src/stores/canvas/use-canvas-history-store";
@@ -4654,6 +4666,68 @@ test("user session initializes without downloading the full remote snapshot", as
         expect(snapshotRequests).toBe(0);
     } finally {
         await applying?.catch(() => undefined);
+        resetRemoteUserDataSync();
+        useUserStore.setState(previousUserState);
+        localforage.getItem = originalGetItem;
+        localforage.setItem = originalSetItem;
+        apiClient.defaults.adapter = previousAdapter;
+        if (originalWindow === undefined) delete (globalThis as { window?: unknown }).window;
+        else Object.defineProperty(globalThis, "window", { configurable: true, value: originalWindow });
+    }
+});
+
+test("authenticated session survives unavailable local cache and model catalog", async () => {
+    const originalWindow = (globalThis as { window?: unknown }).window;
+    const originalGetItem = localforage.getItem.bind(localforage);
+    const originalSetItem = localforage.setItem.bind(localforage);
+    const previousAdapter = apiClient.defaults.adapter;
+    const previousUserState = useUserStore.getState();
+    const previousWarn = console.warn;
+    const localStorageValues = new Map<string, string>();
+    Object.defineProperty(globalThis, "window", {
+        configurable: true,
+        value: {
+            setTimeout: () => 1,
+            clearTimeout: () => undefined,
+            localStorage: {
+                getItem: (key: string) => localStorageValues.get(key) ?? null,
+                setItem: (key: string, value: string) => localStorageValues.set(key, value),
+                removeItem: (key: string) => localStorageValues.delete(key),
+            },
+        },
+    });
+    localforage.getItem = (async () => {
+        throw new Error("indexeddb unavailable");
+    }) as typeof localforage.getItem;
+    localforage.setItem = (async (_key: string, value: string) => value) as typeof localforage.setItem;
+    apiClient.defaults.adapter = async (config) => {
+        if (String(config.url || "") === "/model-catalog") throw new Error("model catalog unavailable");
+        throw new Error(`unexpected request: ${String(config.method || "get")} ${String(config.url || "")}`);
+    };
+    console.warn = () => undefined;
+
+    let applying: Promise<void> | undefined;
+    try {
+        resetRemoteUserDataSync();
+        useUserStore.setState({ user: null, hydrated: true });
+        applying = applyUserSession({
+            user: {
+                id: "account-recovery",
+                username: "recovery",
+                displayName: "Recovery",
+                role: "user",
+                status: "active",
+                createdAt: "2026-09-12T00:00:00.000Z",
+                updatedAt: "2026-09-12T00:00:00.000Z",
+            },
+        });
+        await applying;
+        expect(useUserStore.getState().user?.id).toBe("account-recovery");
+        expect(useUserStore.getState().hydrated).toBe(true);
+        expect(hasRemoteUserDataSyncSession()).toBe(true);
+    } finally {
+        await applying?.catch(() => undefined);
+        console.warn = previousWarn;
         resetRemoteUserDataSync();
         useUserStore.setState(previousUserState);
         localforage.getItem = originalGetItem;


### PR DESCRIPTION
## 起因
本地部署后，在还没配置“系统渠道”时：
1. 用户登录后创建画布提示“画布已在本地创建，云端同步失败：尚未建立云端同步会话”
2. 用户登录了，但一旦刷新网页，就立即退出到登录页面。

## 改动摘要

修复已登录用户刷新页面后被错误跳转至登录页，以及创建画布时可能提示“尚未建立云端同步会话”的问题。

根因是用户会话恢复与工作区初始化共用同一失败处理路径：当本地缓存或模型目录初始化失败时，前端会将有效的认证会话错误地降级为匿名状态。同时，模型目录在当前渠道列表为空时会省略对应字段，导致前端协议校验失败，并中断后续初始化流程。

本次改动：

- 将认证会话获取与工作区初始化的失败语义分离，只有认证接口失败才切换为匿名状态。
- 在加载模型目录前建立远程用户数据同步会话，避免非关键初始化错误影响资源归属。
- 使用 `Promise.allSettled` 隔离本地用户缓存的读取与恢复失败，并提供安全默认值。
- 将模型目录初始化失败降级为保留当前用户配置的非致命错误。
- 保证模型目录当前生效的 `models` 或 `channels` 字段即使为空也返回 `[]`，未生效字段继续省略。
- 增加认证会话、远程同步会话和空模型目录响应的回归测试。

外部行为变化：

- 已登录用户刷新页面时，不再因工作区初始化失败而被错误退出。
- 本地缓存或模型目录暂时不可用时，用户仍保持登录状态。
- 远程用户数据同步会话会在认证成功后优先建立。
- 模型目录的当前生效集合始终具有稳定的数组类型。

## 风险与兼容性

- 不涉及数据库 Schema、用户数据迁移或权限模型变更。
- 不修改 Cookie、Session 或登录接口协议。
- 模型目录响应仅补充此前被 `omitempty` 省略的空数组，不影响已有非空响应。
- 本地缓存和模型目录故障现在不会清除有效认证状态，但仍会记录告警以便排查。
- 远程同步仍以认证接口返回的用户 ID 作为资源归属依据，不接受客户端自行指定用户 ID。
- 不增加第三方依赖、外部请求或运行费用。

## 验证

- `bun run typecheck`
- `bun run build`
- `bun test test/user-scoped-generation-persistence.test.ts`
  - 54 项测试通过
  - 覆盖 IndexedDB 和模型目录不可用时，认证状态及远程同步会话仍然有效
- `GOCACHE=/tmp/open-ai-canvas-go-cache go test ./internal/app ./internal/handler`
- `git diff --check`
- 手动验证关键路径：
  1. 用户登录后进入工作区
  4. 刷新页面
  5. 页面保持在工作区且用户身份不丢失
  6. 不再出现新的模型目录初始化错误

<!-- 请在此处附上刷新后仍保持登录状态的关键路径截图。 -->

- [x] 未提交密钥、数据库、日志或本机配置
- [x] 保留上游署名和许可证通知
- [x] 已检查权限、资源归属和失败语义