### PR TITLE
fix(plugins): 插件管理 - 修正官方应用插件的分类与状态显示

### DIFF
--- a/backend/internal/app/plugin_management.go
+++ b/backend/internal/app/plugin_management.go
@@ -14,6 +14,7 @@ const (
 	PluginPortraitClearance   = "portrait-clearance"
 	PluginAIArtCritique       = "ai-art-critique"
 	PluginMediaConversion     = "media-conversion"
+	PluginEditorShell         = "editor-shell"
 
 	PluginOriginOfficial = "official"
 	PluginOriginSystem   = "system"
@@ -82,6 +83,10 @@ var officialApplicationPolicies = map[string]PluginManagementView{
 		ActivationScope: PluginScopeUser, ConfigurationScope: PluginConfigurationNone,
 	},
 	PluginMediaConversion: {
+		Origin: PluginOriginOfficial, Kind: PluginKindApplication,
+		ActivationScope: PluginScopeUser, ConfigurationScope: PluginConfigurationNone,
+	},
+	PluginEditorShell: {
 		Origin: PluginOriginOfficial, Kind: PluginKindApplication,
 		ActivationScope: PluginScopeUser, ConfigurationScope: PluginConfigurationNone,
 	},

--- a/backend/internal/app/plugin_management_test.go
+++ b/backend/internal/app/plugin_management_test.go
@@ -76,3 +76,44 @@ func TestArtCritiqueIsUserToggleableApplication(t *testing.T) {
 		t.Fatalf("AI art critique policy = %#v", policy)
 	}
 }
+
+// Regression: editor-shell was missing from officialApplicationPolicies, so the
+// backend classified it as a system protocol and reported it to the admin page
+// as "管理员已停用该插件" even though nothing disabled it.
+func TestEditorShellIsUserToggleableApplication(t *testing.T) {
+	policy := pluginManagement(PluginEditorShell, "bundled")
+	if policy.Origin != PluginOriginOfficial || policy.Kind != PluginKindApplication || policy.ActivationScope != PluginScopeUser || policy.ConfigurationScope != PluginConfigurationNone {
+		t.Fatalf("editor shell policy = %#v", policy)
+	}
+}
+
+func TestEditorShellReportsPlatformAvailableWithoutPlatformState(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file:"+newID()+"?mode=memory&cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db.AutoMigrate(&model.PluginPlatformState{}, &model.UserPluginState{}, &model.AdminAuditEvent{}); err != nil {
+		t.Fatal(err)
+	}
+	center, err := newPluginRuntime(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	svc := &Service{repo: repository.New(db), pluginRuntime: center}
+	user := &model.User{ID: "user-1", Role: model.UserRoleUser}
+
+	states, err := svc.PluginStatesForUser(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, ok := states[PluginEditorShell]
+	if !ok {
+		t.Fatalf("editor shell missing from plugin states: %#v", states)
+	}
+	if !state.PlatformAvailable || !state.CanToggle {
+		t.Fatalf("editor shell should be a user-toggleable application, got %#v", state)
+	}
+	if state.BlockedReason == "管理员已停用该插件" {
+		t.Fatalf("editor shell reported as admin-disabled: %#v", state)
+	}
+}

--- a/web/src/lib/plugins/builtin/editor/editor-shell.tsx
+++ b/web/src/lib/plugins/builtin/editor/editor-shell.tsx
@@ -10,9 +10,11 @@ import { EditorTranscription } from "./editor-transcription";
 import { EditorExport } from "./editor-export";
 import { EditorAiAssistant } from "./editor-ai-assistant";
 
+export const EDITOR_SHELL_PLUGIN_ID = "editor-shell";
+
 const manifest: PluginManifestV2 = {
     apiVersion: "yingce.plugin/v2",
-    id: "editor-shell",
+    id: EDITOR_SHELL_PLUGIN_ID,
     name: "剪辑工作台",
     version: "0.1.0",
     description: "注册时间线、预览、检查器、素材、字幕、转写、导出和 AI 编辑八个工作台插槽。",

--- a/web/src/lib/plugins/official-applications.ts
+++ b/web/src/lib/plugins/official-applications.ts
@@ -1,0 +1,32 @@
+import { ART_CRITIQUE_PLUGIN_ID } from "@/lib/art-critique/contracts";
+import { MEDIA_CONVERSION_PLUGIN_ID } from "@/lib/plugins/builtin/media-conversion";
+import { EAGLE_PLUGIN_ID } from "@/lib/plugins/builtin/eagle";
+import { PROMPT_OPTIMIZER_PLUGIN_ID } from "@/lib/plugins/builtin/prompt-optimizer";
+import { COMFYUI_PLUGIN_ID, RUNNINGHUB_PLUGIN_ID } from "@/lib/plugins/builtin/workflows";
+import { PORTRAIT_CLEARANCE_PLUGIN_ID } from "@/lib/portrait-clearance/contracts";
+
+import { EDITOR_SHELL_PLUGIN_ID } from "./builtin/editor/editor-shell";
+
+/**
+ * 官方“应用型”插件清单：这些插件在管理页按用户自主启停处理，而不是系统协议。
+ *
+ * 之前管理页、用户插件页和后端各自维护一份清单，管理页漏掉 AI 审美分析和剪辑
+ * 工作台，导致二者被误判为系统协议并在管理页显示“已停用”。这里收敛为唯一来源。
+ */
+export const OFFICIAL_APPLICATION_PLUGIN_IDS = [
+    RUNNINGHUB_PLUGIN_ID,
+    COMFYUI_PLUGIN_ID,
+    EAGLE_PLUGIN_ID,
+    PROMPT_OPTIMIZER_PLUGIN_ID,
+    PORTRAIT_CLEARANCE_PLUGIN_ID,
+    ART_CRITIQUE_PLUGIN_ID,
+    MEDIA_CONVERSION_PLUGIN_ID,
+    EDITOR_SHELL_PLUGIN_ID,
+] as const;
+
+const officialApplicationIdSet = new Set<string>(OFFICIAL_APPLICATION_PLUGIN_IDS);
+
+/** 判断插件是否为官方应用型插件（用户可在插件页自主启停）。 */
+export function isOfficialApplicationPluginId(pluginId: string) {
+    return officialApplicationIdSet.has(pluginId);
+}

--- a/web/src/pages/admin/plugins/plugins-page.tsx
+++ b/web/src/pages/admin/plugins/plugins-page.tsx
@@ -8,9 +8,8 @@ import { useEffect, useMemo, useState } from "react";
 import { PaginationBar } from "@/components/layout/workspace-page";
 import "@/lib/plugins/builtin";
 import { EAGLE_PLUGIN_ID } from "@/lib/plugins/builtin/eagle";
-import { PROMPT_OPTIMIZER_PLUGIN_ID } from "@/lib/plugins/builtin/prompt-optimizer";
 import { COMFYUI_PLUGIN_ID, RUNNINGHUB_PLUGIN_ID } from "@/lib/plugins/builtin/workflows";
-import { MEDIA_CONVERSION_PLUGIN_ID } from "@/lib/plugins/builtin/media-conversion";
+import { isOfficialApplicationPluginId } from "@/lib/plugins/official-applications";
 import { listRegisteredPlugins } from "@/lib/plugins/plugin-registry";
 import type { PluginManifest, PluginManifestV2 } from "@/lib/plugins/plugin-types";
 import { fetchAdminPlugins, setPluginPlatformAvailability, uninstallPlugin, uploadPlugin, type AdminPluginState, type BackendPlugin, type PluginManagement } from "@/services/api/plugins";
@@ -26,8 +25,6 @@ type AdminPluginItem = {
     status?: string;
     error?: string;
 };
-
-const officialApplicationIds = new Set([RUNNINGHUB_PLUGIN_ID, COMFYUI_PLUGIN_ID, EAGLE_PLUGIN_ID, PROMPT_OPTIMIZER_PLUGIN_ID, "portrait-clearance", MEDIA_CONVERSION_PLUGIN_ID]);
 
 export default function AdminPluginsPage() {
     const { message, modal } = App.useApp();
@@ -363,7 +360,7 @@ function PluginBrandIcon({ pluginId }: { pluginId: string }) {
 function mergePlugins(remote: BackendPlugin[]): AdminPluginItem[] {
     const byId = new Map<string, AdminPluginItem>();
     for (const plugin of listRegisteredPlugins()) {
-        const application = officialApplicationIds.has(plugin.manifest.id);
+        const application = isOfficialApplicationPluginId(plugin.manifest.id);
         byId.set(plugin.manifest.id, {
             manifest: plugin.manifest,
             source: plugin.source || "bundled",

--- a/web/src/pages/plugins/index.tsx
+++ b/web/src/pages/plugins/index.tsx
@@ -10,8 +10,7 @@ import "@/lib/plugins/builtin";
 import { EAGLE_PLUGIN_ID } from "@/lib/plugins/builtin/eagle";
 import { PROMPT_OPTIMIZER_PLUGIN_ID } from "@/lib/plugins/builtin/prompt-optimizer";
 import { COMFYUI_PLUGIN_ID, RUNNINGHUB_PLUGIN_ID } from "@/lib/plugins/builtin/workflows";
-import { MEDIA_CONVERSION_PLUGIN_ID } from "@/lib/plugins/builtin/media-conversion";
-import { ART_CRITIQUE_PLUGIN_ID } from "@/lib/art-critique/contracts";
+import { isOfficialApplicationPluginId } from "@/lib/plugins/official-applications";
 import type { PluginManifest, PluginManifestV2, RegisteredPlugin } from "@/lib/plugins/plugin-types";
 import { getEagleLibrary, type EagleFolder } from "@/services/api/eagle";
 import { fetchPlugins, setUserPluginEnabled, type BackendPlugin, type PluginState } from "@/services/api/plugins";
@@ -142,7 +141,7 @@ export default function PluginsPage() {
         const normalizedSearch = search.trim().toLocaleLowerCase();
         return registeredPlugins.filter((plugin) => {
             const state = pluginStates[plugin.manifest.id];
-            const isApplicationPlugin = backendPluginById.get(plugin.manifest.id)?.management.kind === "application" || isOfficialApplicationPlugin(plugin.manifest.id);
+            const isApplicationPlugin = backendPluginById.get(plugin.manifest.id)?.management.kind === "application" || isOfficialApplicationPluginId(plugin.manifest.id);
             if (user?.role !== "admin" && !features.systemPluginsVisibleToUsers && !isApplicationPlugin) return false;
             const installation = installations.find((item) => item.manifest.id === plugin.manifest.id);
             const enabled = state?.effectiveEnabled ?? Boolean(installation?.enabled);
@@ -186,7 +185,7 @@ export default function PluginsPage() {
     }, [pluginSections, scrollTarget]);
 
     const categoryCounts = useMemo(() => {
-        const visiblePlugins = registeredPlugins.filter((plugin) => user?.role === "admin" || features.systemPluginsVisibleToUsers || isOfficialApplicationPlugin(plugin.manifest.id));
+        const visiblePlugins = registeredPlugins.filter((plugin) => user?.role === "admin" || features.systemPluginsVisibleToUsers || isOfficialApplicationPluginId(plugin.manifest.id));
         const counts: Record<string, number> = { all: visiblePlugins.length, text: 0, image: 0, video: 0, audio: 0, payment: 0, other: 0 };
         for (const plugin of visiblePlugins) {
             for (const section of protocolSectionMeta) {
@@ -627,14 +626,10 @@ function toRegisteredPlugin(plugin: BackendPlugin): RegisteredPlugin {
     return { manifest: plugin.manifest, source: plugin.source };
 }
 
-function isOfficialApplicationPlugin(pluginId: string) {
-    return [RUNNINGHUB_PLUGIN_ID, COMFYUI_PLUGIN_ID, EAGLE_PLUGIN_ID, PROMPT_OPTIMIZER_PLUGIN_ID, "portrait-clearance", ART_CRITIQUE_PLUGIN_ID, MEDIA_CONVERSION_PLUGIN_ID].includes(pluginId);
-}
-
 function pluginSourceLabel(plugin: RegisteredPlugin, state?: PluginState) {
     if (plugin.source === "uploaded") return "自定义插件";
     if (plugin.source === "system") return "系统插件";
-    if (state?.canToggle || isOfficialApplicationPlugin(plugin.manifest.id)) return "官方插件";
+    if (state?.canToggle || isOfficialApplicationPluginId(plugin.manifest.id)) return "官方插件";
     return "系统插件";
 }
 

--- a/web/test/official-application-plugins.test.ts
+++ b/web/test/official-application-plugins.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+    OFFICIAL_APPLICATION_PLUGIN_IDS,
+    isOfficialApplicationPluginId,
+} from "../src/lib/plugins/official-applications";
+
+describe("official application plugin classification", () => {
+    test("covers every built-in application plugin, including editor and art critique", () => {
+        // Regression: the admin plugin page kept its own list and missed these
+        // two, so both rendered as disabled system protocols.
+        expect(isOfficialApplicationPluginId("editor-shell")).toBe(true);
+        expect(isOfficialApplicationPluginId("ai-art-critique")).toBe(true);
+        expect(isOfficialApplicationPluginId("portrait-clearance")).toBe(true);
+        expect(isOfficialApplicationPluginId("media-conversion")).toBe(true);
+        expect(isOfficialApplicationPluginId("prompt-optimizer")).toBe(true);
+        expect(isOfficialApplicationPluginId("eagle-asset-connector")).toBe(true);
+        expect(isOfficialApplicationPluginId("runninghub-workflow-provider")).toBe(true);
+        expect(isOfficialApplicationPluginId("comfyui-workflow-provider")).toBe(true);
+    });
+
+    test("does not treat uploaded or unknown plugins as official applications", () => {
+        expect(isOfficialApplicationPluginId("some-uploaded-plugin")).toBe(false);
+        expect(isOfficialApplicationPluginId("")).toBe(false);
+    });
+
+    test("exposes a single de-duplicated id list", () => {
+        const ids = [...OFFICIAL_APPLICATION_PLUGIN_IDS];
+        expect(new Set(ids).size).toBe(ids.length);
+        expect(ids.length).toBe(8);
+    });
+
+    test("both plugin pages consume the shared list instead of a local copy", () => {
+        const adminPage = readFileSync(
+            resolve(import.meta.dir, "../src/pages/admin/plugins/plugins-page.tsx"),
+            "utf8",
+        );
+        const userPage = readFileSync(
+            resolve(import.meta.dir, "../src/pages/plugins/index.tsx"),
+            "utf8",
+        );
+
+        expect(adminPage).toContain("isOfficialApplicationPluginId");
+        expect(userPage).toContain("isOfficialApplicationPluginId");
+
+        // No page may reintroduce a hand-maintained id array.
+        expect(adminPage).not.toContain("const officialApplicationIds = new Set([");
+        expect(userPage).not.toContain("function isOfficialApplicationPlugin(pluginId: string) {");
+    });
+});


### PR DESCRIPTION
## 问题

插件管理页里「剪辑工作台 `editor-shell`」和「AI 审美分析 `ai-art-critique`」显示为**已停用**，但没有任何人停用过它们，插件功能本身也正常。

## 根因

官方应用型插件清单在仓库中存在 **三份互不同步的实现**：

| 位置 | `ai-art-critique` | `editor-shell` |
| --- | --- | --- |
| 后端 `officialApplicationPolicies` | ✅ | ❌ 缺失 |
| 用户插件页 `isOfficialApplicationPlugin` | ✅ | ❌ 缺失 |
| 管理页 `officialApplicationIds` | ❌ 缺失 | ❌ 缺失 |

后端是权威判定来源（`backend/internal/app/plugin_management.go`）：

```go
platformAvailable := policy.Kind == PluginKindApplication
```

`editor-shell` 不在 `officialApplicationPolicies` 中，因此 `pluginManagement()` 走默认分支，把它归类为 `protocol`（系统协议）。于是 `platformAvailable` 回退为 `false`，`pluginStateForUser()` 返回：

```go
state.BlockedReason = "管理员已停用该插件"
```

管理页据此把开关渲染为关闭状态。所以这是**分类缺失导致的状态误报**，不是插件被禁用。

## 修复

1. **后端（权威修复）**：补上 `PluginEditorShell` 常量与 `officialApplicationPolicies` 条目，让 `editor-shell` 以 `application` / `user` 作用域参与平台可用性判定。
2. **前端（消除重复）**：新增 `web/src/lib/plugins/official-applications.ts` 作为唯一清单与 `isOfficialApplicationPluginId()` 判定，管理页和用户插件页改为共用，删除两份手写数组。
3. **回归测试**：新增前端测试与两个后端测试，锁定这 8 个官方应用插件的分类，避免再次漏项。

## 影响范围

- 修复后管理页中「剪辑工作台」「AI 审美分析」正确显示为官方应用插件（用户自主启用 / 全局生效），可在插件管理中正常开关。
- 行为对已有用户数据无破坏性影响：此前两个插件因 `platformAvailable=false` 无法被用户启用，修复后恢复为用户自主控制。

## 验证

- 前端 `tsc --noEmit` 通过
- 前端测试 `17 pass / 0 fail`（含新增 `web/test/official-application-plugins.test.ts`）
- 后端 `go test ./internal/app/`：`TestEditorShellIsUserToggleableApplication`、`TestEditorShellReportsPlatformAvailableWithoutPlatformState` 及既有插件测试全部通过
- `docker build` 前后端镜像均构建成功

## 备注

如果维护者希望缩小改动范围，核心修复只需后端 `plugin_management.go` 的两处改动（常量 + 策略条目）；前端抽取共享清单属于顺带的重复代码收敛，可以拆分为独立 PR。
